### PR TITLE
Refactor database calls with async helpers

### DIFF
--- a/db-utils.js
+++ b/db-utils.js
@@ -1,0 +1,14 @@
+const util = require('util');
+
+function promisifyDatastore(db) {
+  return {
+    findOne: util.promisify(db.findOne.bind(db)),
+    find: util.promisify(db.find.bind(db)),
+    count: util.promisify(db.count.bind(db)),
+    insert: util.promisify(db.insert.bind(db)),
+    update: util.promisify(db.update.bind(db)),
+    remove: util.promisify(db.remove.bind(db)),
+  };
+}
+
+module.exports = promisifyDatastore;


### PR DESCRIPTION
## Summary
- add helper `db-utils.js` to promisify NeDB methods
- use async/await in admin backup and restore
- simplify stats logic in settings route

## Testing
- `npm test` *(fails: missing script)*
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_68418411c9ac832f9d7954a17c21beef