### PR TITLE
Optimize Docker build with multi-stage setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,31 @@
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files and install all dependencies (dev included)
+COPY package*.json ./
+RUN npm ci
+
+# Copy the rest of the source and build assets
+COPY . .
+RUN npm run build:css
+
+# Remove node_modules so they are not copied to the final image
+RUN rm -rf node_modules
+
 FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy package files
+# Install only production dependencies
 COPY package*.json ./
+RUN npm ci --omit=dev
 
-# Install ALL dependencies (including dev) for the build
-# Don't set NODE_ENV yet so we get devDependencies
-RUN npm ci
+# Copy application files and built assets from the builder stage
+COPY --from=builder /app ./
 
-# Copy source files
-COPY . .
-
-# Build CSS (needs devDependencies)
-RUN npm run build:css
-
-# NOW set production environment and remove dev dependencies
+# Runtime configuration
 ENV NODE_ENV=production
-RUN npm prune --production
-
-# Create data directory and set permissions
 RUN mkdir -p /app/data && \
     chown -R node:node /app/data && \
     chown -R node:node /app


### PR DESCRIPTION
## Summary
- add a `builder` stage to install dev deps and build CSS
- copy built assets and source from builder into final image
- install production dependencies with `npm ci --omit=dev`
- ensure node_modules from build stage aren't copied

## Testing
- `npm ci`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_68418b0a2590832fb4d83a7da6b18e4c