### PR TITLE
Use COPY --chown in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,16 @@ FROM node:24-alpine
 WORKDIR /app
 
 # Install only production dependencies
-COPY package*.json ./
+COPY --chown=node:node package*.json ./
 RUN npm ci --omit=dev
 
 # Copy application files and built assets from the builder stage
-COPY --from=builder /app ./
+COPY --chown=node:node --from=builder /app ./
 
 # Runtime configuration
 ENV NODE_ENV=production
 RUN mkdir -p /app/data && \
-    chown -R node:node /app/data && \
-    chown -R node:node /app
+    chown node:node /app/data
 
 # Node.js optimizations
 ENV NODE_OPTIONS="--max-old-space-size=512"


### PR DESCRIPTION
## Summary
- use `COPY --chown=node:node` when copying app files
- remove recursive `chown` step and ensure `/app/data` is writable

## Testing
- `npm ci`

------
https://chatgpt.com/codex/tasks/task_e_68418bdd8f8c832faaa82c4987af2bcd