### PR TITLE
Improve responsive behavior

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -1420,6 +1420,11 @@ const spotifyTemplate = (req) => `
       const menu = document.getElementById('mobileMenu');
       menu.classList.toggle('hidden');
     }
+
+    // Backwards compatibility for old toggle handler
+    function toggleMobileLists() {
+      toggleMobileMenu();
+    }
     
     // Initialize the app
     document.addEventListener('DOMContentLoaded', () => {
@@ -1565,6 +1570,19 @@ const spotifyTemplate = (req) => `
             }, 0);
           }
         });
+      }
+    });
+
+    // Re-render layout when viewport crosses the mobile breakpoint
+    let lastIsMobile = window.innerWidth < 1024;
+    window.addEventListener('resize', () => {
+      const isMobile = window.innerWidth < 1024;
+      if (isMobile !== lastIsMobile) {
+        lastIsMobile = isMobile;
+        if (typeof updateListNav === 'function') updateListNav();
+        if (window.currentList && window.lists && window.lists[window.currentList]) {
+          displayAlbums(window.lists[window.currentList]);
+        }
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- make the mobile list toggle available again
- rerender album layout when crossing the mobile breakpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68419440fe1c832fa17a9693dcdff5cc