### PR TITLE
Fix stats assignment error in settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -597,7 +597,7 @@ app.get('/settings', ensureAuth, async (req, res) => {
                 console.error('Error counting sessions:', e);
               }
 
-      const stats = {
+      stats = {
         totalUsers: allUsers.length,
         totalLists: allLists.length,
         totalAlbums,
@@ -685,7 +685,6 @@ app.get('/settings', ensureAuth, async (req, res) => {
         stats,
         recentActivity: recentActivity.slice(0, 4)
       };
-      stats = adminData.stats;
     }
 
     res.send(settingsTemplate(req, {


### PR DESCRIPTION
## Summary
- fix reassignment of const `stats` in settings route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68419a5a5e10832fac99ff3b9ad9e02c