### PR TITLE
Improve responsive layout on settings page

### DIFF
--- a/settings-template.js
+++ b/settings-template.js
@@ -240,7 +240,7 @@ const settingsTemplate = (req, options) => {
         </p>
         
         <!-- Custom Color Picker -->
-        <div class="flex items-center gap-3">
+        <div class="flex flex-col sm:flex-row items-start sm:items-center gap-3">
             <label class="text-sm text-gray-400">Color:</label>
             <input 
             type="color" 
@@ -321,7 +321,7 @@ const settingsTemplate = (req, options) => {
               <!-- System Stats -->
               <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                 <h3 class="text-lg font-semibold text-white mb-4">System Statistics</h3>
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
                   <div>
                     <p class="text-gray-400 text-sm">Total Users</p>
                     <p class="text-2xl font-bold text-white">${stats.totalUsers}</p>
@@ -377,7 +377,7 @@ const settingsTemplate = (req, options) => {
               <!-- Admin Actions -->
               <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                 <h3 class="text-lg font-semibold text-white mb-4">Admin Actions</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
                   <button 
                     onclick="if(confirm('Export all users as CSV?')) window.location.href='/admin/export-users'"
                     class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded transition duration-200 text-sm"


### PR DESCRIPTION
## Summary
- tweak accent color picker alignment on settings page
- expand system stats and action button grids for larger displays

## Testing
- `npm run build:css` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419e78cde0832f924a5f974fa57c14