### PR TITLE
Fix template string termination in settings template

### DIFF
--- a/settings-template.js
+++ b/settings-template.js
@@ -922,7 +922,7 @@ const settingsTemplate = (req, options) => {
         const res = await fetch('/admin/themes/list', { credentials: 'same-origin' });
         const data = await res.json();
         const select = document.getElementById('themeSelect');
-        select.innerHTML = data.themes.map(t => `<option value="${t._id}" ${t.active ? 'selected' : ''}>${t.name}</option>`).join('');
+        select.innerHTML = data.themes.map(t => '<option value="' + t._id + '" ' + (t.active ? 'selected' : '') + '>' + t.name + '</option>').join('');
       }
 
       document.getElementById('themeUploadForm').addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- fix theme option rendering to avoid invalid backtick usage

## Testing
- `node --check settings-template.js`

------
https://chatgpt.com/codex/tasks/task_e_6841adbabf88832f8598de62de78d76d