### PR TITLE
Fix tailwind compiler in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,15 +17,15 @@
         "nodemailer": "^7.0.3",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
-        "session-file-store": "^1.5.0"
+        "session-file-store": "^1.5.0",
+        "tailwindcss": "^3.4.17"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",
         "concurrently": "^9.1.2",
         "nodemon": "^3.1.10",
         "postcss": "^8.5.3",
-        "postcss-cli": "^11.0.1",
-        "tailwindcss": "^3.4.17"
+        "postcss-cli": "^11.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-    "session-file-store": "^1.5.0"
+    "session-file-store": "^1.5.0",
+    "tailwindcss": "^3.4.17"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.2",
     "nodemon": "^3.1.10",
     "postcss": "^8.5.3",
-    "postcss-cli": "^11.0.1",
-    "tailwindcss": "^3.4.17"
+    "postcss-cli": "^11.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- move `tailwindcss` from devDependencies to dependencies so it is installed in production

## Testing
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_6841b78a6900832fab82a42f0ae6b438