### PR TITLE
Fix mobile sidebar list interaction

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -1450,9 +1450,9 @@ const spotifyTemplate = (req) => `
                 >
                   \${listName}
                 </button>
-                <button 
+                <button
                   onclick="event.stopPropagation(); showListMenu('\${listName}');"
-                  class="p-3 text-gray-400 hover:text-white opacity-0 group-hover:opacity-100 lg:opacity-100 transition-opacity"
+                  class="p-3 text-gray-400 hover:text-white opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity"
                 >
                   <i class="fas fa-ellipsis-v"></i>
                 </button>


### PR DESCRIPTION
## Summary
- show mobile list menu button all the time

## Testing
- `npm run build:css`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841c29c7bdc832fbb276d2428de2175