### PR TITLE
Fix modal init timing

### DIFF
--- a/public/js/musicbrainz.js
+++ b/public/js/musicbrainz.js
@@ -1929,5 +1929,5 @@ function formatArtistDisplayName(artist) {
 
 // Initialize when the page loads
 document.addEventListener('DOMContentLoaded', () => {
-  setTimeout(initializeAddAlbumFeature, 100);
+  initializeAddAlbumFeature();
 });


### PR DESCRIPTION
## Summary
- initialize add-album modal immediately on DOM ready instead of delaying

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841c7fd4a38832fa54302b93cff4658