### PR TITLE
Fix mobile album list height

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -232,7 +232,7 @@ body {
 
 /* Ensure the table takes full height */
 .album-rows-container {
-  min-height: calc(100vh - 280px);
+  min-height: 100%;
 }
 
 


### PR DESCRIPTION
## Summary
- ensure album rows container fills available space so scrolling reaches the bottom

## Testing
- `npm install`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_684285e3c234832fbb0abf5cdc702bad