### PR TITLE
Fix mobile album list scroll area

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -126,6 +126,7 @@ body {
 /* Enhanced album row styles */
 #albumContainer {
   min-height: 100vh;
+  min-height: 100dvh;
   position: relative;
 }
 

--- a/templates.js
+++ b/templates.js
@@ -1150,6 +1150,7 @@ const spotifyTemplate = (req) => `
       display: grid;
       grid-template-rows: auto 1fr;
       height: 100vh;
+      height: 100dvh;
     }
     
     .main-content {


### PR DESCRIPTION
## Summary
- ensure the app layout uses dynamic viewport height
- let albumContainer stretch to 100dvh

## Testing
- `npm run build:css --silent` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a3d0e770832f9229a52ee11ec23f