### PR TITLE
Escape JS template in template string

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -126,7 +126,7 @@ body {
 /* Enhanced album row styles */
 #albumContainer {
   min-height: 100vh;
-  min-height: 100dvh;
+  min-height: calc(var(--vh, 1vh) * 100);
   position: relative;
 }
 

--- a/templates.js
+++ b/templates.js
@@ -1150,7 +1150,7 @@ const spotifyTemplate = (req) => `
       display: grid;
       grid-template-rows: auto 1fr;
       height: 100vh;
-      height: 100dvh;
+      height: calc(var(--vh, 1vh) * 100);
     }
     
     .main-content {
@@ -1415,6 +1415,15 @@ const spotifyTemplate = (req) => `
     // Global state
     window.currentUser = ${JSON.stringify(req.user)};
     window.lastSelectedList = ${JSON.stringify(req.user.lastSelectedList || null)};
+
+    function updateViewportHeight() {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty('--vh', \`\${vh}px\`);
+    }
+
+    updateViewportHeight();
+    window.addEventListener('resize', updateViewportHeight);
+    window.addEventListener('orientationchange', updateViewportHeight);
     
     // Mobile menu toggle
     function toggleMobileMenu() {


### PR DESCRIPTION
## Summary
- escape backtick and `${}` characters when setting viewport height in templates.js

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:css` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842aae56c40832f98dd18e088e009c7