### PR TITLE
Fix Docker build by clearing npm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # Copy package files and install all dependencies (dev included)
 COPY package*.json ./
 RUN --mount=type=cache,target=/root/.npm \
+    npm cache clean --force || true && \
     npm ci --prefer-offline --no-audit
 
 # Copy the rest of the source and build assets


### PR DESCRIPTION
## Summary
- clean npm cache before running `npm ci` in the builder stage to avoid ENOENT errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845e6bcecf8832f891273a4b65450fe