### PR TITLE
Add Redis service and configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
 - `SENDGRID_API_KEY` – optional API key for sending password reset emails. If omitted, reset links are logged to the console.
 - `BASE_URL` – base URL used in password reset emails (`http://localhost:3000` by default).
 - `PORT` – server port (defaults to `3000`).
+- `REDIS_URL` – Redis connection string (`redis://localhost:6379` by default).
 
 ## Running with Docker
 A `Dockerfile` and `docker-compose.yml` are included. You can build and start the app with:
 ```bash
 docker compose up --build
 ```
+
+The compose setup now includes a `redis` service which the app uses for
+persistent storage.
 
 The admin access code is displayed in the server logs and rotates every five minutes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,19 @@ services:
       - BASE_URL=${BASE_URL}
       - PORT=3000
       - DATA_DIR=/app/data
+      - REDIS_URL=redis://redis:6379
     volumes:
       - sushe-data:/app/data
     restart: unless-stopped
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
 
 volumes:
   sushe-data:
+  redis-data:

--- a/redis-db.js
+++ b/redis-db.js
@@ -2,7 +2,8 @@ const { createClient } = require('redis');
 const crypto = require('crypto');
 
 async function initRedis() {
-  const client = createClient();
+  const redisUrl = process.env.REDIS_URL;
+  const client = redisUrl ? createClient({ url: redisUrl }) : createClient();
   await client.connect();
   return client;
 }


### PR DESCRIPTION
## Summary
- add env var `REDIS_URL` to specify the Redis server
- update `docker-compose.yml` to launch a Redis container and set `REDIS_URL`
- document the new configuration in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68469f7453f4832f99ca25225d6caf1c