### PR TITLE
Fix login template session access bug

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -324,7 +324,7 @@ const loginTemplate = (req, flash) => htmlTemplate(`
           placeholder="your@email.com" 
           required 
           autocomplete="email"
-          value="${req.session.attemptedEmail || ''}"
+          value="${(req.session && req.session.attemptedEmail) || ''}"
         />
         <p class="text-xs text-gray-500 mt-1 hidden" id="emailError">Please enter a valid email address</p>
       </div>


### PR DESCRIPTION
## Summary
- avoid crash on `/login` when session middleware hasn't set `req.session`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ac97320c832faf44de7c49834e49