### PR TITLE
Fix redis memory overcommit warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,14 @@ docker compose up --build
 The compose setup now includes a `redis` service which the app uses for
 persistent storage.
 
+Redis may print a warning about `vm.overcommit_memory` when it starts. If you
+see this, enable memory overcommit on the host by running:
+
+```bash
+sudo sysctl -w vm.overcommit_memory=1
+```
+
+You can also persist the setting by adding `vm.overcommit_memory=1` to
+`/etc/sysctl.conf` or by using the `sysctls` option in `docker-compose.yml`.
+
 The admin access code is displayed in the server logs and rotates every five minutes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     restart: unless-stopped
     volumes:
       - redis-data:/data
+    sysctls:
+      vm.overcommit_memory: '1'
 
 volumes:
   sushe-data:


### PR DESCRIPTION
## Summary
- set `vm.overcommit_memory` for Redis in docker-compose
- document how to enable memory overcommit when running Redis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846b40a02f0832f924f5df2921be1f0