### PR TITLE
Improve login/logout feedback

### DIFF
--- a/index.js
+++ b/index.js
@@ -460,6 +460,7 @@ app.post('/login', (req, res, next) => {
           console.error('Session save error:', err);
           // Continue anyway - session might still work
         }
+        req.flash('success', 'Logged in successfully');
         return res.redirect('/');
       });
     });
@@ -468,12 +469,15 @@ app.post('/login', (req, res, next) => {
 
 // Logout
 app.get('/logout', (req, res) => {
-  req.logout(() => res.redirect('/login'));
+  req.logout(() => {
+    req.flash('info', 'You have been logged out');
+    res.redirect('/login');
+  });
 });
 
 // Home (protected) - Spotify-like interface
 app.get('/', ensureAuth, (req, res) => {
-  res.send(spotifyTemplate(req));
+  res.send(spotifyTemplate(req, res.locals.flash));
 });
 
 // Unified Settings Page

--- a/templates.js
+++ b/templates.js
@@ -1122,7 +1122,7 @@ const confirmationModalComponent = () => `
 `;
 
 // Main Spotify template - Consolidated version
-const spotifyTemplate = (req) => `
+const spotifyTemplate = (req, flash = {}) => `
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1462,6 +1462,11 @@ const spotifyTemplate = (req) => `
     
     // Initialize the app
     document.addEventListener('DOMContentLoaded', () => {
+      const flash = ${JSON.stringify(flash)};
+      if (flash.error) flash.error.forEach(m => showToast(m, 'error'));
+      if (flash.success) flash.success.forEach(m => showToast(m, 'success'));
+      if (flash.info) flash.info.forEach(m => showToast(m, 'info'));
+
       // Update the list navigation to include mobile
       const originalUpdateListNav = window.updateListNav;
       window.updateListNav = function() {


### PR DESCRIPTION
## Summary
- flash login success before redirect
- show logged out message when signing out
- pass flash messages to home view
- support flash messages in Spotify template

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846b966e778832fbaa1b6e2e4c85d0c