### PR TITLE
Fix flash message after logout

### DIFF
--- a/index.js
+++ b/index.js
@@ -468,8 +468,12 @@ app.post('/login', (req, res, next) => {
 });
 
 // Logout
-app.get('/logout', (req, res) => {
-  req.logout(() => {
+app.get('/logout', (req, res, next) => {
+  req.logout((err) => {
+    if (err) { return next(err); }
+    if (!req.session.flash) {
+      req.session.flash = {};
+    }
     req.flash('info', 'You have been logged out');
     res.redirect('/login');
   });


### PR DESCRIPTION
## Summary
- fix flash message error when user logs out by reinstating flash storage in new session

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846bb3039a4832f99ae8d3078a97b87