### PR TITLE
Improve toast feedback on settings page

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -368,6 +368,10 @@ input[list]::-webkit-list-button {
   background-color: #059669;
 }
 
+.toast.info {
+  background-color: #2563eb;
+}
+
 /* Line clamp for comments */
 .line-clamp-2 {
   display: -webkit-box;

--- a/templates.js
+++ b/templates.js
@@ -166,7 +166,11 @@ const htmlTemplate = (content, title = 'SuShe Auth', user = null) => {
     .toast.success {
       background-color: #059669;
     }
-    
+
+    .toast.info {
+      background-color: #2563eb;
+    }
+
     /* Toast notifications with accent */
     .toast.error {
       background-color: var(--accent-color);


### PR DESCRIPTION
## Summary
- tweak global styles to support `info`-type toast messages

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846c0659e3c832f9deff5b16df6217a