### PR TITLE
Fix drag-drop not saving reordered list

### DIFF
--- a/public/js/drag-drop.js
+++ b/public/js/drag-drop.js
@@ -18,7 +18,9 @@ const DragDropManager = (function() {
     if (!container) return;
     
     container.addEventListener('dragover', handleContainerDragOver);
-    container.addEventListener('drop', handleContainerDrop);
+    // Drop handler is registered via setupDropHandler so that a save callback
+    // can be provided. Avoid adding it here to prevent duplicate listeners
+    // which would clear drag state before the save callback runs.
     container.addEventListener('dragleave', handleContainerDragLeave);
   }
 


### PR DESCRIPTION
## Summary
- avoid installing default drop handler in `initialize` so we don't overwrite the callback-based handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e6cda62c832faa648d4f1351f763