### PR TITLE
Add drag-and-drop debug logs

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -607,6 +607,8 @@ async function saveList(name, data) {
       delete cleaned.rank;
       return cleaned;
     });
+
+    console.debug('saveList', name, cleanedData);
     
     await apiCall(`/api/lists/${encodeURIComponent(name)}`, {
       method: 'POST',
@@ -1744,18 +1746,20 @@ function displayAlbums(albums) {
     // Initialize drag and drop
     if (window.DragDropManager) {
       window.DragDropManager.initialize();
-      
+
       window.DragDropManager.setupDropHandler(async (draggedIndex, dropIndex, needsRebuild) => {
+        console.debug('Drop handler invoked', { draggedIndex, dropIndex, needsRebuild });
         if (needsRebuild) {
           displayAlbums(lists[currentList]);
           return;
         }
-        
+
         if (draggedIndex !== null && dropIndex !== null) {
+          console.debug('Reordering list', { list: currentList, from: draggedIndex, to: dropIndex });
           const list = lists[currentList];
           const [movedItem] = list.splice(draggedIndex, 1);
           list.splice(dropIndex, 0, movedItem);
-          
+
           await saveList(currentList, list);
         }
       });

--- a/public/js/drag-drop.js
+++ b/public/js/drag-drop.js
@@ -16,6 +16,8 @@ const DragDropManager = (function() {
   function initialize() {
     const container = document.getElementById('albumContainer');
     if (!container) return;
+
+    console.debug('DragDropManager: initialize');
     
     container.addEventListener('dragover', handleContainerDragOver);
     container.addEventListener('drop', handleContainerDrop);
@@ -78,6 +80,8 @@ const DragDropManager = (function() {
       e.preventDefault();
       return;
     }
+
+    console.debug('DragDropManager: drag start', this.dataset.index);
     
     draggedElement = this;
     draggedIndex = parseInt(this.dataset.index);
@@ -103,6 +107,8 @@ const DragDropManager = (function() {
   function handleContainerDragOver(e) {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
+
+    console.debug('DragDropManager: container drag over');
     
     const rowsContainer = this.querySelector('.album-rows-container') || this;
     
@@ -182,10 +188,11 @@ const DragDropManager = (function() {
 
   function handleContainerDragLeave(e) {
     const rect = this.getBoundingClientRect();
-    if (e.clientX < rect.left || e.clientX > rect.right || 
+    if (e.clientX < rect.left || e.clientX > rect.right ||
         e.clientY < rect.top || e.clientY > rect.bottom) {
       this.classList.remove('drag-active');
       stopAutoScroll();
+      console.debug('DragDropManager: container drag leave');
     }
   }
 
@@ -206,6 +213,8 @@ const DragDropManager = (function() {
 
   function handleDragEnd(e) {
     stopAutoScroll();
+
+    console.debug('DragDropManager: drag end');
     
     if (draggedElement) {
       draggedElement.style.display = '';
@@ -229,6 +238,8 @@ const DragDropManager = (function() {
   async function handleContainerDrop(e, saveCallback) {
     e.preventDefault();
     e.stopPropagation();
+
+    console.debug('DragDropManager: container drop');
     
     stopAutoScroll();
     this.classList.remove('drag-active');
@@ -292,6 +303,7 @@ const DragDropManager = (function() {
         
         // Call the save callback if provided
         if (saveCallback) {
+          console.debug('DragDropManager: saving', { from: draggedIndex, to: dropIndex });
           await saveCallback(draggedIndex, dropIndex);
         }
         
@@ -305,6 +317,7 @@ const DragDropManager = (function() {
       }
     } else {
       // Position didn't change, just clean up
+      console.debug('DragDropManager: position unchanged');
       if (placeholder && placeholder.parentNode) {
         placeholder.parentNode.removeChild(placeholder);
         placeholder = null;
@@ -320,6 +333,7 @@ const DragDropManager = (function() {
     draggedIndex = null;
     lastValidDropIndex = null;
     scrollableContainer = null;
+    console.debug('DragDropManager: cleanup');
   }
 
   // Update positions without rebuilding
@@ -352,6 +366,7 @@ const DragDropManager = (function() {
     setupDropHandler: function(saveCallback) {
       const container = document.getElementById('albumContainer');
       if (container) {
+        console.debug('DragDropManager: setup drop handler');
         // Remove any existing drop handler
         container.removeEventListener('drop', container._dropHandler);
         


### PR DESCRIPTION
## Summary
- add console.debug statements to DragDropManager lifecycle events
- log when the drag-drop handler updates a list and when `saveList` executes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480e770fc4832f860cccab460a8d16