### PR TITLE
Increase drag and drop debug logging

### DIFF
--- a/public/js/drag-drop.js
+++ b/public/js/drag-drop.js
@@ -17,7 +17,9 @@ const DragDropManager = (function() {
     const container = document.getElementById('albumContainer');
     if (!container) return;
 
-    console.debug('DragDropManager: initialize');
+    console.debug('DragDropManager: initialize', {
+      containerFound: !!container,
+    });
     
     container.addEventListener('dragover', handleContainerDragOver);
     container.addEventListener('drop', handleContainerDrop);
@@ -29,6 +31,11 @@ const DragDropManager = (function() {
     if (autoScrollInterval) {
       clearInterval(autoScrollInterval);
     }
+
+    console.debug('DragDropManager: startAutoScroll', {
+      direction,
+      speed,
+    });
     
     currentScrollSpeed = speed;
     scrollAcceleration = 1;
@@ -43,6 +50,10 @@ const DragDropManager = (function() {
         const adjustedSpeed = currentScrollSpeed * scrollAcceleration;
         const currentScroll = scrollableContainer.scrollTop;
         const newScroll = currentScroll + (direction * adjustedSpeed);
+        console.debug('DragDropManager: autoScroll tick', {
+          adjustedSpeed,
+          newScroll,
+        });
         
         if (direction > 0) {
           const maxScroll = scrollableContainer.scrollHeight - scrollableContainer.clientHeight;
@@ -70,6 +81,7 @@ const DragDropManager = (function() {
       autoScrollInterval = null;
       currentScrollSpeed = 0;
       scrollAcceleration = 1;
+      console.debug('DragDropManager: stopAutoScroll');
     }
   }
 
@@ -81,7 +93,11 @@ const DragDropManager = (function() {
       return;
     }
 
-    console.debug('DragDropManager: drag start', this.dataset.index);
+    console.debug('DragDropManager: drag start', {
+      index: this.dataset.index,
+      clientX: e.clientX,
+      clientY: e.clientY,
+    });
     
     draggedElement = this;
     draggedIndex = parseInt(this.dataset.index);
@@ -92,6 +108,10 @@ const DragDropManager = (function() {
     placeholder = document.createElement('div');
     placeholder.className = 'album-row drag-placeholder album-grid gap-4 px-4 py-3 border-b border-gray-800';
     placeholder.style.height = this.offsetHeight + 'px';
+
+    console.debug('DragDropManager: placeholder created', {
+      height: this.offsetHeight,
+    });
     
     this.classList.add('dragging');
     
@@ -101,6 +121,7 @@ const DragDropManager = (function() {
     requestAnimationFrame(() => {
       this.style.display = 'none';
       this.parentNode.insertBefore(placeholder, this.nextSibling);
+      console.debug('DragDropManager: placeholder inserted');
     });
   }
 
@@ -171,16 +192,26 @@ const DragDropManager = (function() {
     
     // Update placeholder position
     const afterElement = getDragAfterElement(rowsContainer, e.clientY);
+    console.debug('DragDropManager: afterElement', {
+      afterElementIndex: afterElement ? afterElement.dataset.index : null,
+      clientY: e.clientY,
+    });
     
     if (!placeholder || !placeholder.parentNode) return;
     
     if (afterElement == null) {
       rowsContainer.appendChild(placeholder);
       lastValidDropIndex = rowsContainer.children.length - 1;
+      console.debug('DragDropManager: appended placeholder', {
+        lastValidDropIndex,
+      });
     } else {
       rowsContainer.insertBefore(placeholder, afterElement);
       const allElements = Array.from(rowsContainer.children);
       lastValidDropIndex = allElements.indexOf(placeholder);
+      console.debug('DragDropManager: inserted placeholder', {
+        lastValidDropIndex,
+      });
     }
     
     this.classList.add('drag-active');
@@ -214,7 +245,9 @@ const DragDropManager = (function() {
   function handleDragEnd(e) {
     stopAutoScroll();
 
-    console.debug('DragDropManager: drag end');
+    console.debug('DragDropManager: drag end', {
+      draggedIndex,
+    });
     
     if (draggedElement) {
       draggedElement.style.display = '';
@@ -224,6 +257,7 @@ const DragDropManager = (function() {
     // Only remove placeholder if it still exists (wasn't removed by drop handler)
     if (placeholder && placeholder.parentNode) {
       placeholder.parentNode.removeChild(placeholder);
+      console.debug('DragDropManager: placeholder removed on drag end');
     }
     
     document.getElementById('albumContainer').classList.remove('drag-active');
@@ -233,13 +267,17 @@ const DragDropManager = (function() {
     placeholder = null;
     lastValidDropIndex = null;
     scrollableContainer = null;
+    console.debug('DragDropManager: state cleared after drag end');
   }
 
   async function handleContainerDrop(e, saveCallback) {
     e.preventDefault();
     e.stopPropagation();
 
-    console.debug('DragDropManager: container drop');
+    console.debug('DragDropManager: container drop', {
+      draggedIndex,
+      lastValidDropIndex,
+    });
     
     stopAutoScroll();
     this.classList.remove('drag-active');
@@ -250,6 +288,7 @@ const DragDropManager = (function() {
     
     // Calculate the final drop index
     let dropIndex = lastValidDropIndex;
+    console.debug('DragDropManager: initial dropIndex', { dropIndex });
     
     // Get the actual number of album rows (excluding placeholder)
     const albumRows = rowsContainer.querySelectorAll('.album-row:not(.drag-placeholder)');
@@ -259,9 +298,11 @@ const DragDropManager = (function() {
     if (draggedIndex < dropIndex) {
       dropIndex--;
     }
+    console.debug('DragDropManager: adjusted dropIndex after drag check', { dropIndex });
     
     // Ensure drop index is within valid bounds
     dropIndex = Math.max(0, Math.min(dropIndex, maxIndex));
+    console.debug('DragDropManager: bounded dropIndex', { dropIndex });
     
     // Only proceed if the position actually changed
     if (dropIndex !== draggedIndex) {
@@ -270,6 +311,7 @@ const DragDropManager = (function() {
         if (placeholder && placeholder.parentNode) {
           placeholder.parentNode.removeChild(placeholder);
           placeholder = null;
+          console.debug('DragDropManager: placeholder removed before inserting');
         }
         
         // Calculate where to insert the dragged element
@@ -293,6 +335,7 @@ const DragDropManager = (function() {
           // If no reference element, append to the end
           rowsContainer.appendChild(draggedElement);
         }
+        console.debug('DragDropManager: element moved', { from: draggedIndex, to: dropIndex });
         
         // Show the dragged element
         draggedElement.style.display = '';
@@ -321,6 +364,7 @@ const DragDropManager = (function() {
       if (placeholder && placeholder.parentNode) {
         placeholder.parentNode.removeChild(placeholder);
         placeholder = null;
+        console.debug('DragDropManager: placeholder removed (unchanged position)');
       }
       
       // Show the dragged element in its original position
@@ -333,7 +377,7 @@ const DragDropManager = (function() {
     draggedIndex = null;
     lastValidDropIndex = null;
     scrollableContainer = null;
-    console.debug('DragDropManager: cleanup');
+    console.debug('DragDropManager: cleanup after drop');
   }
 
   // Update positions without rebuilding
@@ -350,6 +394,10 @@ const DragDropManager = (function() {
       // Update the data-index attribute
       row.dataset.index = index;
     });
+
+    console.debug('DragDropManager: positions updated', {
+      totalRows: rows.length,
+    });
   }
 
   // Make row draggable
@@ -357,6 +405,10 @@ const DragDropManager = (function() {
     row.draggable = true;
     row.addEventListener('dragstart', handleDragStart);
     row.addEventListener('dragend', handleDragEnd);
+
+    console.debug('DragDropManager: row made draggable', {
+      index: row.dataset.index,
+    });
   }
 
   // Public API


### PR DESCRIPTION
## Summary
- add numerous `console.debug` calls throughout the desktop drag and drop code for deeper insight
- log auto-scroll details and placeholder handling
- record drop index calculations and element moves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68481079c724832f95a5a344e8a77f7c