### PR TITLE
Add desktop album edit option

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -752,8 +752,18 @@ function updateMobileHeader() {
 function initializeAlbumContextMenu() {
   const contextMenu = document.getElementById('albumContextMenu');
   const removeOption = document.getElementById('removeAlbumOption');
-  
-  if (!contextMenu || !removeOption) return;
+  const editOption = document.getElementById('editAlbumOption');
+
+  if (!contextMenu || !removeOption || !editOption) return;
+
+  // Handle edit option click
+  editOption.onclick = () => {
+    contextMenu.classList.add('hidden');
+
+    if (currentContextAlbum === null) return;
+
+    showMobileEditForm(currentContextAlbum);
+  };
   
   // Handle remove option click
   removeOption.onclick = async () => {
@@ -1952,7 +1962,7 @@ window.showMobileEditForm = function(index) {
   
   // Create the edit modal
   const editModal = document.createElement('div');
-  editModal.className = 'fixed inset-0 z-50 lg:hidden bg-gray-900 flex flex-col overflow-hidden';
+  editModal.className = 'fixed inset-0 z-50 bg-gray-900 flex flex-col overflow-hidden lg:max-w-2xl lg:mx-auto lg:my-8 lg:rounded-lg lg:shadow-2xl';
   editModal.innerHTML = `
     <!-- Header -->
     <div class="flex items-center justify-between p-4 border-b border-gray-800 flex-shrink-0">

--- a/templates.js
+++ b/templates.js
@@ -739,6 +739,9 @@ const contextMenusComponent = () => `
   
   <!-- Context Menu for Albums -->
   <div id="albumContextMenu" class="hidden fixed bg-gray-800 border border-gray-700 rounded shadow-lg py-1 z-50">
+    <button id="editAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap">
+      <i class="fas fa-edit mr-2 w-4 text-center"></i>Edit Details
+    </button>
     <button id="removeAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-red-400 transition-colors whitespace-nowrap">
       <i class="fas fa-times mr-2 w-4 text-center"></i>Remove from List
     </button>


### PR DESCRIPTION
## Summary
- add `Edit Details` option to desktop album context menu
- enable edit modal for desktop
- hook up new menu item to open the edit form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68481c407f6c832fb76d64aaae50269f