### PR TITLE
Fix stale list data on list selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1299,6 +1299,21 @@ app.get('/api/lists/subscribe/:name', ensureAuthAPI, (req, res) => {
   });
 });
 
+// Get a single list
+app.get('/api/lists/:name', ensureAuthAPI, (req, res) => {
+  const { name } = req.params;
+  lists.findOne({ userId: req.user._id, name }, (err, list) => {
+    if (err) {
+      console.error('Error fetching list:', err);
+      return res.status(500).json({ error: 'Error fetching list' });
+    }
+    if (!list) {
+      return res.status(404).json({ error: 'List not found' });
+    }
+    res.json(list.data);
+  });
+});
+
 // Create or update a list
 app.post('/api/lists/:name', ensureAuthAPI, (req, res) => {
   const { name } = req.params;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1361,7 +1361,17 @@ async function selectList(listName) {
     console.log('Selecting list:', listName);
     currentList = listName;
     subscribeToList(listName);
-    
+
+    // Always fetch the latest data when a list is selected
+    if (listName) {
+      try {
+        const freshData = await apiCall(`/api/lists/${encodeURIComponent(listName)}`);
+        lists[listName] = freshData;
+      } catch (err) {
+        console.warn('Failed to fetch latest list data:', err);
+      }
+    }
+
     // Save to localStorage immediately (synchronous)
     if (listName) {
       localStorage.setItem('lastSelectedList', listName);


### PR DESCRIPTION
## Summary
- add API endpoint to fetch a single list
- always fetch latest list data when selecting a list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684840fcbdfc832fb416c22766729e48