### PR TITLE
Add Spotify and Tidal auth scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
 - `SENDGRID_API_KEY` – optional API key for sending password reset emails. If omitted, reset links are logged to the console.
 - `BASE_URL` – base URL used in password reset emails (`http://localhost:3000` by default).
 - `PORT` – server port (defaults to `3000`).
+- `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` – credentials for Spotify OAuth.
+- `SPOTIFY_REDIRECT_URI` – callback URL registered with Spotify.
+- `TIDAL_CLIENT_ID` and `TIDAL_CLIENT_SECRET` – credentials for Tidal OAuth.
+- `TIDAL_REDIRECT_URI` – callback URL registered with Tidal.
 
 ## Running with Docker
 A `Dockerfile` and `docker-compose.yml` are included. You can build and start the app with:

--- a/settings-template.js
+++ b/settings-template.js
@@ -262,7 +262,35 @@ const settingsTemplate = (req, options) => {
             </button>
         </div>
         </div>
-        
+
+        <!-- Music Service Integration -->
+        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+          <h3 class="text-lg font-semibold text-white mb-4">
+            <i class="fas fa-music mr-2 text-gray-400"></i>
+            Music Services
+          </h3>
+          <div class="space-y-4">
+            <div class="flex items-center justify-between">
+              <span class="text-white">Spotify</span>
+              ${user.spotifyAuth ? `
+                <span class="text-green-500 text-sm mr-2">Connected</span>
+                <a href="/auth/spotify/disconnect" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-white rounded text-sm">Disconnect</a>
+              ` : `
+                <a href="/auth/spotify" class="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-sm">Connect</a>
+              `}
+            </div>
+            <div class="flex items-center justify-between">
+              <span class="text-white">Tidal</span>
+              ${user.tidalAuth ? `
+                <span class="text-green-500 text-sm mr-2">Connected</span>
+                <a href="/auth/tidal/disconnect" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-white rounded text-sm">Disconnect</a>
+              ` : `
+                <a href="/auth/tidal" class="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-sm">Connect</a>
+              `}
+            </div>
+          </div>
+        </div>
+
         <!-- Statistics & Admin Section -->
         <div class="space-y-6">
           <!-- Your Statistics -->


### PR DESCRIPTION
## Summary
- document new environment variables for Tidal/Spotify
- store music service auth tokens in user records
- add Spotify/Tidal OAuth routes and migration
- display connection status and actions on the settings page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684850038390832faa2736ea246aa979