### PR TITLE
Add album playback option via Spotify/Tidal

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -745,6 +745,9 @@ const contextMenusComponent = () => `
     <button id="editAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap">
       <i class="fas fa-edit mr-2 w-4 text-center"></i>Edit Details
     </button>
+    <button id="playAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap">
+      <i class="fas fa-play mr-2 w-4 text-center"></i>Play Album
+    </button>
     <button id="removeAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-red-400 transition-colors whitespace-nowrap">
       <i class="fas fa-times mr-2 w-4 text-center"></i>Remove from List
     </button>


### PR DESCRIPTION
## Summary
- expose new API routes to search Spotify or Tidal for an album
- add "Play Album" entry to album context menu
- add "Play Album" option to the mobile action sheet
- implement `playAlbum` helper on the client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487ce3f76c832fb9f24f2d6b02a599