### PR TITLE
Fix service selection label

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -841,7 +841,14 @@ function playAlbum(index) {
         showConfirmation('Play Album', 'Which service would you like to use?', '', 'Spotify', () => resolve('spotify'));
         const cancelBtn = document.getElementById('confirmationCancelBtn');
         const originalCancel = cancelBtn.onclick;
-        cancelBtn.onclick = () => { hideConfirmation(); resolve('tidal'); cancelBtn.onclick = originalCancel; };
+        const originalText = cancelBtn.textContent;
+        cancelBtn.textContent = 'Tidal';
+        cancelBtn.onclick = () => {
+          hideConfirmation();
+          resolve('tidal');
+          cancelBtn.onclick = originalCancel;
+          cancelBtn.textContent = originalText;
+        };
       } else if (hasSpotify) {
         resolve('spotify');
       } else if (hasTidal) {


### PR DESCRIPTION
## Summary
- adjust Play Album service selector to show a Tidal button instead of generic Cancel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684886a90ab0832faf66ca9104d6c717