### PR TITLE
Fix Tidal playback

### DIFF
--- a/index.js
+++ b/index.js
@@ -1834,7 +1834,7 @@ app.get('/api/tidal/album', ensureAuthAPI, async (req, res) => {
 
   try {
     const query = `${artist} ${album}`;
-    const url = `https://api.tidal.com/v1/search/albums?query=${encodeURIComponent(query)}&limit=1`;
+    const url = `https://api.tidal.com/v1/search/albums?query=${encodeURIComponent(query)}&limit=1&countryCode=US`;
     const resp = await fetch(url, {
       headers: {
         Authorization: `Bearer ${req.user.tidalAuth.access_token}`,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -886,7 +886,7 @@ function playAlbum(index) {
           if (service === 'spotify') {
             window.location.href = `spotify:album:${data.id}`;
           } else {
-            window.location.href = `tidal://album/${data.id}`;
+            window.location.href = `https://tidal.com/browse/album/${data.id}`;
           }
         } else if (data.error) {
           showToast(data.error, 'error');


### PR DESCRIPTION
## Summary
- fix Tidal album search by including `countryCode`
- use https URL to open Tidal album so mobile deep link works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848a6050134832fa33237dc7fdf9f43