### PR TITLE
Remove references to old Tidal integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,6 @@ services:
       - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID}
       - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}
       - SPOTIFY_REDIRECT_URI=${SPOTIFY_REDIRECT_URI}
-      - TIDAL_CLIENT_ID=${TIDAL_CLIENT_ID}
-      - TIDAL_CLIENT_SECRET=${TIDAL_CLIENT_SECRET}
-      - TIDAL_REDIRECT_URI=${TIDAL_REDIRECT_URI}
     volumes:
       - sushe-data:/app/data
     restart: unless-stopped

--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@ function broadcastListUpdate(userId, name, data) {
   }
 }
 
-// Removed Tidal OAuth helper functions and refresh logic
 
 function sanitizeUser(user) {
   if (!user) return null;
@@ -1175,7 +1174,6 @@ app.get('/auth/spotify/disconnect', ensureAuth, (req, res) => {
   res.redirect('/settings');
 });
 
-// Removed Tidal authentication routes
 
 // Admin: Make user admin
 app.post('/admin/make-admin', ensureAuth, ensureAdmin, (req, res) => {
@@ -1711,7 +1709,6 @@ app.get('/api/spotify/album', ensureAuthAPI, async (req, res) => {
   }
 });
 
-// Removed Tidal album search API endpoint
 
 // Fetch metadata for link previews
 app.get('/api/unfurl', ensureAuthAPI, async (req, res) => {


### PR DESCRIPTION
## Summary
- delete comments that referenced removed Tidal features in `index.js`
- drop unused Tidal env vars from `docker-compose.yml`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684918165580832fa31a5fca78cb5c53