### PR TITLE
Add Tidal integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
 - `PORT` – server port (defaults to `3000`).
 - `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` – credentials for Spotify OAuth.
 - `SPOTIFY_REDIRECT_URI` – callback URL registered with Spotify.
+- `TIDAL_CLIENT_ID` – client ID for Tidal OAuth.
+- `TIDAL_REDIRECT_URI` – callback URL registered with Tidal.
 
 When running with Docker Compose, place these variables in a `.env` file or
 export them so they are available to the container.

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -833,11 +833,20 @@ function playAlbum(index) {
   if (!album) return;
 
   const hasSpotify = window.currentUser?.spotifyAuth;
+  const hasTidal = window.currentUser?.tidalAuth;
 
   const chooseService = () => {
     return new Promise(resolve => {
-      if (hasSpotify) {
+      if (hasSpotify && hasTidal) {
+        if (confirm('Use Spotify? Click Cancel for Tidal.')) {
+          resolve('spotify');
+        } else {
+          resolve('tidal');
+        }
+      } else if (hasSpotify) {
         resolve('spotify');
+      } else if (hasTidal) {
+        resolve('tidal');
       } else {
         showToast('No music service connected', 'error');
         resolve(null);
@@ -850,7 +859,7 @@ function playAlbum(index) {
     if (!service) return;
 
     const query = `artist=${encodeURIComponent(album.artist)}&album=${encodeURIComponent(album.album)}`;
-    const endpoint = '/api/spotify/album';
+    const endpoint = service === 'spotify' ? '/api/spotify/album' : '/api/tidal/album';
 
     fetch(`${endpoint}?${query}`, { credentials: 'include' })
       .then(async r => {
@@ -868,7 +877,11 @@ function playAlbum(index) {
       })
       .then(data => {
         if (data.id) {
-          window.location.href = `spotify:album:${data.id}`;
+          if (service === 'spotify') {
+            window.location.href = `spotify:album:${data.id}`;
+          } else {
+            window.location.href = `tidal://album/${data.id}`;
+          }
         } else if (data.error) {
           showToast(data.error, 'error');
         } else {

--- a/settings-template.js
+++ b/settings-template.js
@@ -4,7 +4,7 @@ const { adjustColor, colorWithOpacity } = require('./color-utils');
 
 // Settings page template
 const settingsTemplate = (req, options) => {
-  const { user, userStats, stats, adminData, flash, spotifyValid } = options;
+  const { user, userStats, stats, adminData, flash, spotifyValid, tidalValid } = options;
   
   return `
 <!DOCTYPE html>
@@ -285,6 +285,20 @@ const settingsTemplate = (req, options) => {
                 `
               ) : `
                 <a href="/auth/spotify" class="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-sm">Connect</a>
+              `}
+            </div>
+            <div class="flex items-center justify-between">
+              <span class="text-white">Tidal</span>
+              ${user.tidalAuth ? (
+                tidalValid ? `
+                <span class="text-green-500 text-sm mr-2">Connected</span>
+                <a href="/auth/tidal/disconnect" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-white rounded text-sm">Disconnect</a>
+                ` : `
+                <span class="text-yellow-500 text-sm mr-2">Reconnect required</span>
+                <a href="/auth/tidal" class="px-3 py-1 bg-yellow-600 hover:bg-yellow-700 text-white rounded text-sm">Reconnect</a>
+                `
+              ) : `
+                <a href="/auth/tidal" class="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-sm">Connect</a>
               `}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- support Tidal OAuth like Spotify
- allow Tidal album playback
- show Tidal connection status in settings
- choose between Spotify and Tidal on playback
- document new environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68491c3ed87c832f935efc4a6f8feb0a