### PR TITLE
Fix Tidal album search

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
 - `SPOTIFY_REDIRECT_URI` – callback URL registered with Spotify.
 - `TIDAL_CLIENT_ID` – client ID for Tidal OAuth.
 - `TIDAL_REDIRECT_URI` – callback URL registered with Tidal.
+  The client ID is also sent as the `X-Tidal-Token` header on API
+  requests.
 - The TIDAL integration is authorized for the following scopes:
   `user.read`, `collection.read`, `search.read`, `playlists.write`,
   `playlists.read`, `entitlements.read`, `collection.write`, `playback`,

--- a/index.js
+++ b/index.js
@@ -1835,7 +1835,8 @@ app.get('/api/tidal/album', ensureAuthAPI, async (req, res) => {
     const resp = await fetch(url, {
       headers: {
         Authorization: `Bearer ${req.user.tidalAuth.access_token}`,
-        Accept: 'application/vnd.tidal.v1+json'
+        Accept: 'application/vnd.tidal.v1+json',
+        'X-Tidal-Token': process.env.TIDAL_CLIENT_ID || ''
       }
     });
     if (!resp.ok) {


### PR DESCRIPTION
## Summary
- include `X-Tidal-Token` header when calling Tidal search
- document how `TIDAL_CLIENT_ID` is used

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684929756e14832fabb9f1c9539916eb