### PR TITLE
Switch to v2 searchResults API for TIDAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
   `recommendations.read`, `search.write`. Offline access is not granted, so
   tokens expire and must be reauthorized when they expire.
 
+The `/api/tidal/album` endpoint uses TIDAL's v2 `searchResults` API to look up
+an album ID. This works with the `search.read` scope and does not require the
+`r_usr` scope that older search endpoints need.
+
 When running with Docker Compose, place these variables in a `.env` file or
 export them so they are available to the container.
 

--- a/index.js
+++ b/index.js
@@ -1833,19 +1833,17 @@ app.get('/api/tidal/album', ensureAuthAPI, async (req, res) => {
 
   try {
     const query = `${album} ${artist}`;
-    const params = new URLSearchParams({
-      q: query,
-      types: 'albums',
-      limit: 1,
-      countryCode: 'US'
-    });
-    const url = `https://api.tidal.com/v1/search?${params.toString()}`;
+    const searchPath = encodeURIComponent(query);
+    const params = new URLSearchParams({ countryCode: 'US' });
+    const url =
+      `https://openapi.tidal.com/v2/searchResults/${searchPath}/relationships/albums?` +
+      params.toString();
     console.debug('Tidal search URL:', url);
     console.debug('Tidal client ID header:', (process.env.TIDAL_CLIENT_ID || '').slice(0, 6) + '...');
     const resp = await fetch(url, {
       headers: {
         Authorization: `Bearer ${req.user.tidalAuth.access_token}`,
-        Accept: 'application/vnd.tidal.v1+json',
+        Accept: 'application/vnd.api+json',
         'X-Tidal-Token': process.env.TIDAL_CLIENT_ID || ''
       }
     });
@@ -1857,7 +1855,7 @@ app.get('/api/tidal/album', ensureAuthAPI, async (req, res) => {
     }
     const data = await resp.json();
     console.debug('Tidal API response body:', JSON.stringify(data, null, 2));
-    const albumId = data?.albums?.items?.[0]?.id;
+    const albumId = data?.data?.[0]?.id;
     if (!albumId) {
       return res.status(404).json({ error: 'Album not found' });
     }


### PR DESCRIPTION
## Summary
- call TIDAL v2 `searchResults` endpoint in `/api/tidal/album`
- document the v2 searchResults usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68493f3f9cfc832f88186fb245a2bda6