### PR TITLE
Use real user country with Tidal search

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
 
 The `/api/tidal/album` endpoint uses TIDAL's v2 `searchResults` API to look up
 an album ID. This works with the `search.read` scope and does not require the
-`r_usr` scope that older search endpoints need.
+`r_usr` scope that older search endpoints need. The user's profile is fetched
+after OAuth to store their `countryCode`, which is then used for all searches
+instead of the hard-coded `US` locale.
 
 When running with Docker Compose, place these variables in a `.env` file or
 export them so they are available to the container.


### PR DESCRIPTION
## Summary
- store `tidalCountry` for users
- fetch country during Tidal OAuth
- fall back to fetching profile on search and save
- include migration for existing users
- document new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849551e0b0c832fac11550c08c4d9cd