### PR TITLE
Fix Tidal search failing with apostrophes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ an album ID. This works with the `search.read` scope and does not require the
 `r_usr` scope that older search endpoints need. The user's profile is fetched
 after OAuth to store their `countryCode`, which is then used for all searches
 instead of the hard-coded `US` locale.
+Note that apostrophes must be percent-encoded in the query string; the server
+manually replaces `'` with `%27` after `encodeURIComponent` so the Tidal API
+parses the request correctly.
 
 When running with Docker Compose, place these variables in a `.env` file or
 export them so they are available to the container.

--- a/index.js
+++ b/index.js
@@ -1893,7 +1893,9 @@ app.get('/api/tidal/album', ensureAuthAPI, async (req, res) => {
     }
 
     const query = `${album} ${artist}`;
-    const searchPath = encodeURIComponent(query);
+    // encodeURIComponent does not escape apostrophes, which breaks the
+    // Tidal searchResults path. Replace them manually after encoding.
+    const searchPath = encodeURIComponent(query).replace(/'/g, '%27');
     const params = new URLSearchParams({ countryCode });
     const url =
       `https://openapi.tidal.com/v2/searchResults/${searchPath}/relationships/albums?` +


### PR DESCRIPTION
## Summary
- encode apostrophes in Tidal search queries so the API can parse them
- document the apostrophe encoding requirement in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495e32e2fc832fb33d9df638c342fa