### PR TITLE
Add playlist context menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,12 @@ const {
 const { settingsTemplate } = require('./settings-template');
 const { isTokenValid } = require('./auth-utils');
 
+// Available music service integrations
+const musicServices = [
+  { id: 'spotify', name: 'Spotify' },
+  { id: 'tidal', name: 'Tidal' }
+];
+
 // Create data directory if it doesn't exist
 const dataDir = process.env.DATA_DIR || './data';
 if (!require('fs').existsSync(dataDir)) {
@@ -526,7 +532,7 @@ app.get('/logout', (req, res) => {
 
 // Home (protected) - Spotify-like interface
 app.get('/', ensureAuth, (req, res) => {
-  res.send(spotifyTemplate(sanitizeUser(req.user)));
+  res.send(spotifyTemplate(sanitizeUser(req.user), musicServices));
 });
 
 // Unified Settings Page

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -28,6 +28,11 @@ document.addEventListener('click', () => {
   if (contextMenu) {
     contextMenu.classList.add('hidden');
   }
+
+  const playlistSubmenu = document.getElementById('playlistSubmenu');
+  if (playlistSubmenu) {
+    playlistSubmenu.classList.add('hidden');
+  }
   
   const albumContextMenu = document.getElementById('albumContextMenu');
   if (albumContextMenu) {
@@ -303,6 +308,12 @@ async function downloadListAsJSON(listName) {
     console.error('Error downloading/sharing list:', error);
     showToast('Error downloading list', 'error');
   }
+}
+
+// Placeholder for creating playlists on music services
+function addListAsPlaylist(listName, service) {
+  console.log('Add list as playlist', listName, service);
+  showToast('Playlist creation not implemented', 'error');
 }
 
 // Initialize import conflict handling
@@ -719,8 +730,10 @@ function initializeContextMenu() {
   const contextMenu = document.getElementById('contextMenu');
   const downloadOption = document.getElementById('downloadListOption');
   const renameOption = document.getElementById('renameListOption');
+  const playlistOption = document.getElementById('addPlaylistOption');
+  const playlistSubmenu = document.getElementById('playlistSubmenu');
   const deleteOption = document.getElementById('deleteListOption');
-  
+
   if (!contextMenu || !deleteOption || !renameOption || !downloadOption) return;
   
   // Handle download option click
@@ -737,11 +750,45 @@ function initializeContextMenu() {
   // Handle rename option click
   renameOption.onclick = () => {
     contextMenu.classList.add('hidden');
-    
+
     if (!currentContextList) return;
-    
+
     openRenameModal(currentContextList);
   };
+
+  // Setup playlist submenu
+  if (playlistOption && playlistSubmenu) {
+    playlistSubmenu.innerHTML = '';
+    (window.musicServices || []).forEach(s => {
+      const btn = document.createElement('button');
+      btn.className = 'block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap';
+      btn.textContent = `...in ${s.name}`;
+      btn.dataset.service = s.id;
+      playlistSubmenu.appendChild(btn);
+    });
+
+    playlistOption.onmouseenter = () => playlistSubmenu.classList.remove('hidden');
+    playlistOption.onmouseleave = (e) => {
+      if (!playlistOption.contains(e.relatedTarget) && !playlistSubmenu.contains(e.relatedTarget)) {
+        playlistSubmenu.classList.add('hidden');
+      }
+    };
+    playlistSubmenu.onmouseleave = (e) => {
+      if (!playlistOption.contains(e.relatedTarget)) {
+        playlistSubmenu.classList.add('hidden');
+      }
+    };
+    playlistSubmenu.onclick = (e) => {
+      const target = e.target.closest('button');
+      if (!target) return;
+      const service = target.dataset.service;
+      playlistSubmenu.classList.add('hidden');
+      contextMenu.classList.add('hidden');
+      if (!currentContextList) return;
+      addListAsPlaylist(currentContextList, service);
+      currentContextList = null;
+    };
+  }
   
   // Handle delete option click
   deleteOption.onclick = async () => {

--- a/templates.js
+++ b/templates.js
@@ -737,6 +737,13 @@ const contextMenusComponent = () => `
     <button id="renameListOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap">
       <i class="fas fa-edit mr-2 w-4 text-center"></i>Rename List
     </button>
+    <div class="relative">
+      <button id="addPlaylistOption" class="block w-full text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap flex items-center justify-between">
+        <span><i class="fas fa-list-ul mr-2 w-4 text-center"></i>Add as playlist...</span>
+        <i class="fas fa-caret-right ml-2"></i>
+      </button>
+      <div id="playlistSubmenu" class="hidden absolute left-full top-0 bg-gray-800 border border-gray-700 rounded shadow-lg py-1 z-50"></div>
+    </div>
     <button id="deleteListOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-red-400 transition-colors whitespace-nowrap">
       <i class="fas fa-trash mr-2 w-4 text-center"></i>Delete List
     </button>
@@ -1138,7 +1145,7 @@ const serviceSelectModalComponent = () => `
 `;
 
 // Main Spotify template - Consolidated version
-const spotifyTemplate = (user) => `
+const spotifyTemplate = (user, services = []) => `
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1452,6 +1459,7 @@ const spotifyTemplate = (user) => `
   <script>
     // Global state
     window.currentUser = ${JSON.stringify(user)};
+    window.musicServices = ${JSON.stringify(services)};
     window.lastSelectedList = ${JSON.stringify(user.lastSelectedList || null)};
 
     function updateViewportHeight() {
@@ -1545,23 +1553,25 @@ const spotifyTemplate = (user) => `
               <div class="p-4">
                 <div class="w-12 h-1 bg-gray-600 rounded-full mx-auto mb-4"></div>
                 <h3 class="font-semibold text-white mb-4">\${listName}</h3>
-                
-                <button onclick="downloadListAsJSON('\${listName}'); this.closest('.fixed').remove();" 
+
+                <button onclick="downloadListAsJSON('\${listName}'); this.closest('.fixed').remove();"
                         class="w-full text-left py-3 px-4 hover:bg-gray-800 rounded">
                   <i class="fas fa-download mr-3 text-gray-400"></i>Download List
                 </button>
-                
-                <button onclick="openRenameModal('\${listName}'); this.closest('.fixed').remove();" 
+
+                <button onclick="openRenameModal('\${listName}'); this.closest('.fixed').remove();"
                         class="w-full text-left py-3 px-4 hover:bg-gray-800 rounded">
                   <i class="fas fa-edit mr-3 text-gray-400"></i>Rename List
                 </button>
-                
-                <button onclick="if(confirm('Delete this list?')) { document.getElementById('deleteListOption').click(); currentContextList='\${listName}'; } this.closest('.fixed').remove();" 
+
+                <!-- playlist buttons will be inserted here -->
+
+                <button onclick="if(confirm('Delete this list?')) { document.getElementById('deleteListOption').click(); currentContextList='\${listName}'; } this.closest('.fixed').remove();"
                         class="w-full text-left py-3 px-4 hover:bg-gray-800 rounded text-red-500">
                   <i class="fas fa-trash mr-3"></i>Delete List
                 </button>
-                
-                <button onclick="this.closest('.fixed').remove()" 
+
+                <button onclick="this.closest('.fixed').remove()"
                         class="w-full text-center py-3 px-4 mt-2 bg-gray-800 rounded">
                   Cancel
                 </button>
@@ -1569,6 +1579,20 @@ const spotifyTemplate = (user) => `
             </div>
           \`;
           document.body.appendChild(actionSheet);
+
+          const container = actionSheet.querySelector('.p-4');
+          const deleteBtn = container.querySelector('button.text-red-500');
+
+          (window.musicServices || []).forEach(s => {
+            const btn = document.createElement('button');
+            btn.className = 'w-full text-left py-3 px-4 hover:bg-gray-800 rounded';
+            btn.innerHTML = `<i class="fas fa-list-ul mr-3 text-gray-400"></i>Add as playlist in ${s.name}`;
+            btn.onclick = () => {
+              addListAsPlaylist(listName, s.id);
+              actionSheet.remove();
+            };
+            container.insertBefore(btn, deleteBtn);
+          });
         } else {
           // Desktop context menu
           currentContextList = listName;


### PR DESCRIPTION
## Summary
- add constant musicServices and pass to spotifyTemplate
- expose window.musicServices in spotify template
- add new context menu item for creating playlists
- dynamically build playlist submenu based on integrations
- stub playlist creation handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684969751700832fa7703c9ac1b96c5a