### PR TITLE
Add track list support for albums

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -757,6 +757,13 @@ const contextMenusComponent = () => `
     <button id="playAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap">
       <i class="fas fa-play mr-2 w-4 text-center"></i>Play Album
     </button>
+    <div class="relative">
+      <button id="trackSelectOption" class="block w-full text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap flex items-center justify-between">
+        <span><i class="fas fa-music mr-2 w-4 text-center"></i>Track to play...</span>
+        <i class="fas fa-caret-right ml-2"></i>
+      </button>
+      <div id="trackSubmenu" class="hidden absolute left-full top-0 bg-gray-800 border border-gray-700 rounded shadow-lg py-1 z-50"></div>
+    </div>
     <button id="removeAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-red-400 transition-colors whitespace-nowrap">
       <i class="fas fa-times mr-2 w-4 text-center"></i>Remove from List
     </button>


### PR DESCRIPTION
## Summary
- fetch track lists from MusicBrainz and store them in album objects
- allow choosing a track to play via new context menu option
- support mobile track selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684970377db4832f997a3c30c026db62