### PR TITLE
Add MusicBrainz track enrichment

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -750,6 +750,12 @@ const contextMenusComponent = () => `
     <button id="playAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap">
       <i class="fas fa-play mr-2 w-4 text-center"></i>Play Album
     </button>
+    <div class="relative group">
+      <button id="selectTrackOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap">
+        <i class="fas fa-music mr-2 w-4 text-center"></i>Track to Play...
+      </button>
+      <div id="trackSubmenu" class="hidden absolute left-full top-0 bg-gray-800 border border-gray-700 rounded shadow-lg py-1 z-50"></div>
+    </div>
     <button id="removeAlbumOption" class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-red-400 transition-colors whitespace-nowrap">
       <i class="fas fa-times mr-2 w-4 text-center"></i>Remove from List
     </button>


### PR DESCRIPTION
## Summary
- migrate album entries to support track data
- enrich new albums with track metadata fields
- fetch track listings from MusicBrainz with fuzzy matching and release selection
- allow choosing a track to play via new context menu option
- display track submenu and persist chosen track
- expose track queue globally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849da24dc80832f8d2aeef650c86046