### PR TITLE
Fix restore after SQLite migration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1438,9 +1438,15 @@ app.post('/admin/restore', ensureAuth, ensureAdmin, upload.single('backup'), asy
     await usersAsync.remove({}, { multi: true });
     await listsAsync.remove({}, { multi: true });
 
-    // Restore users and lists
-    await usersAsync.insert(backup.users);
-    await listsAsync.insert(backup.lists);
+    // Restore users
+    for (const user of backup.users) {
+      await usersAsync.insert(user);
+    }
+
+    // Restore lists
+    for (const list of backup.lists) {
+      await listsAsync.insert(list);
+    }
 
     // Clear all sessions after restore
     req.sessionStore.clear((err) => {


### PR DESCRIPTION
## Summary
- restore route loops over each document when inserting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684adbd5cc70832f97a1d54fa9eaf42a