### PR TITLE
Remove deprecated NeDB migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ parses the request correctly.
 When running with Docker Compose, place these variables in a `.env` file or
 export them so they are available to the container.
 
-## Upgrading from NeDB
-Existing installations using the old NeDB backend are migrated automatically
-whenever the server starts. If `users.db` or `lists.db` are found in the
-`DATA_DIR` directory, the files are read and all documents imported into
-`sushe.sqlite`. Existing records are left untouched.
-
 ## Running with Docker
 A `Dockerfile` and `docker-compose.yml` are included. You can build and start the app with:
 ```bash

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ if (!require('fs').existsSync(dataDir)) {
   require('fs').mkdirSync(dataDir, { recursive: true });
 }
 
-// Initialize SQLite database (imports any NeDB files on startup)
+// Initialize SQLite database
 const initSQLite = require('./sqlite-store');
 const { users, lists } = initSQLite(dataDir);
 

--- a/sqlite-store.js
+++ b/sqlite-store.js
@@ -182,45 +182,6 @@ function initSQLite(dataDir) {
   const usersStore = new SQLiteStore(db, 'users', ['_id','email','username','hash','spotifyAuth','tidalAuth','tidalCountry','accentColor','lastSelectedList','role','resetToken','resetExpires','createdAt','updatedAt','adminGrantedAt'], ['spotifyAuth','tidalAuth']);
   const listsStore = new SQLiteStore(db, 'lists', ['_id','userId','name','data','createdAt','updatedAt'], ['data']);
 
-  const oldUsersFile = path.join(dataDir, 'users.db');
-  const oldListsFile = path.join(dataDir, 'lists.db');
-  if (fs.existsSync(oldUsersFile) || fs.existsSync(oldListsFile)) {
-    console.log('Migrating NeDB data to SQLite...');
-    const readNeDB = (p) =>
-      fs.readFileSync(p, 'utf8')
-        .split(/\n/)
-        .filter(Boolean)
-        .map(line => {
-          try { return JSON.parse(line); } catch { return null; }
-        })
-        .filter(doc => doc && !doc.$$indexCreated && !doc.$$deleted);
-    if (fs.existsSync(oldUsersFile)) {
-      for (const doc of readNeDB(oldUsersFile)) {
-        const row = usersStore.rowFromDoc(doc);
-        const cols = Object.keys(row).join(',');
-        const placeholders = Object.keys(row).map(k => '@' + k).join(',');
-        try {
-          db.prepare(`INSERT OR IGNORE INTO users (${cols}) VALUES (${placeholders})`).run(row);
-        } catch (e) {
-          console.error('Failed to insert user doc', e);
-        }
-      }
-    }
-    if (fs.existsSync(oldListsFile)) {
-      for (const doc of readNeDB(oldListsFile)) {
-        const row = listsStore.rowFromDoc(doc);
-        const cols = Object.keys(row).join(',');
-        const placeholders = Object.keys(row).map(k => '@' + k).join(',');
-        try {
-          db.prepare(`INSERT OR IGNORE INTO lists (${cols}) VALUES (${placeholders})`).run(row);
-        } catch (e) {
-          console.error('Failed to insert list doc', e);
-        }
-      }
-    }
-    console.log('Migration complete');
-  }
-
   return { users: usersStore, lists: listsStore };
 }
 


### PR DESCRIPTION
## Summary
- clean up comments referencing NeDB
- drop automatic migration from NeDB files
- update README to remove migration section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b09827794832f8051bbd15e88d82f