### PR TITLE
Fix album grid css build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
    ```bash
    npm install
    ```
-2. Compile Tailwind CSS:
+2. Compile Tailwind CSS and copy the custom album grid styles:
    ```bash
    npm run build:css
    ```

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "start": "node index.js",
     "dev": "concurrently \"npm run watch:css\" \"nodemon --ignore data/ --ignore *.log index.js\"",
-    "build:css": "postcss src/styles/input.css -o public/styles/output.css",
-    "watch:css": "postcss src/styles/input.css -o public/styles/output.css --watch",
+    "copy:css": "cp src/styles/spotify-app.css public/styles/spotify-app.css",
+    "build:css": "postcss src/styles/input.css -o public/styles/output.css && npm run copy:css",
+    "watch:css": "concurrently \"postcss src/styles/input.css -o public/styles/output.css --watch\" \"nodemon --watch src/styles/spotify-app.css --exec npm run copy:css\"",
     "test": "node --test"
   },
   "dependencies": {

--- a/src/styles/spotify-app.css
+++ b/src/styles/spotify-app.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Inter:wght@300;400;500;600;700&display=swap');
-
 /* Album grid column configuration with responsive behavior */
 :root {
   /* Default grid for desktop screens */

--- a/templates.js
+++ b/templates.js
@@ -77,6 +77,7 @@ const htmlTemplate = (content, title = 'SuShe Auth', user = null) => {
   <link rel="icon" type="image/png" href="/og-image.png">
   <link rel="apple-touch-icon" href="/og-image.png">
   <link rel="manifest" href="/manifest.json">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link href="${asset('/styles/output.css')}" rel="stylesheet">
   <style>
     /* CSS Custom Properties for theming */
@@ -119,7 +120,6 @@ const htmlTemplate = (content, title = 'SuShe Auth', user = null) => {
     }
     
     /* Custom black metal inspired fonts and effects */
-    @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Inter:wght@300;400;500;600;700&display=swap');
     
     .metal-title {
       font-family: 'Cinzel', serif;
@@ -1154,6 +1154,7 @@ const spotifyTemplate = (user) => `
   <link rel="apple-touch-icon" href="/og-image.png">
   <link rel="manifest" href="/manifest.json">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
   <link href="${asset('/styles/output.css')}" rel="stylesheet">
   <link href="${asset('/styles/spotify-app.css')}" rel="stylesheet">


### PR DESCRIPTION
## Summary
- move custom Spotify CSS into src directory
- copy the CSS to `public/styles` during `build:css`
- watch for changes to custom CSS in development
- note the updated build step in README
- load fonts via `<link>` instead of `@import`

## Testing
- `npm run build:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684be8ecdb04832fa2927d97404c94b6