### PR TITLE
Fix asset caching and CSS build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,11 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
    ```bash
    npm install
    ```
-2. Compile Tailwind CSS:
-   ```bash
-   npm run build:css
-   ```
-3. Start the server in development mode with automatic reload and CSS watch:
+2. Start the server in development mode with automatic reload and CSS watch:
    ```bash
    npm run dev
    ```
-4. Alternatively, run `npm start` to launch the server without watchers.
+3. Alternatively, run `npm start` to build the CSS once and launch the server without watchers.
 
 ## Environment variables
 - `SESSION_SECRET` – session encryption secret.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "npm run build:css && node index.js",
     "dev": "concurrently \"npm run watch:css\" \"nodemon --ignore data/ --ignore *.log index.js\"",
     "build:css": "postcss src/styles/input.css -o public/styles/output.css",
     "watch:css": "postcss src/styles/input.css -o public/styles/output.css --watch",

--- a/templates.js
+++ b/templates.js
@@ -1,5 +1,6 @@
 const { adjustColor, colorWithOpacity } = require('./color-utils');
-const { version: assetVersion } = require('./package.json');
+// Use a timestamp-based asset version to avoid browser caching issues
+const assetVersion = process.env.ASSET_VERSION || Date.now().toString();
 const asset = (p) => `${p}?v=${assetVersion}`;
 
 // Shared header component


### PR DESCRIPTION
## Summary
- build Tailwind CSS automatically on server start
- version static assets with a timestamp so browsers fetch updates
- update docs for new workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bef422960832fb20af004be59a48a