### PR TITLE
Fix asset caching and CSS formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,18 @@ Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mo
    ```bash
    npm install
    ```
-2. Compile Tailwind CSS:
-   ```bash
-   npm run build:css
-   ```
-3. Start the server in development mode with automatic reload and CSS watch:
+2. Start the server in development mode with automatic reload and CSS watch:
    ```bash
    npm run dev
    ```
-4. Alternatively, run `npm start` to launch the server without watchers.
+3. Alternatively, run `npm start` to build the CSS once and launch the server without watchers.
 
 ## Environment variables
 - `SESSION_SECRET` – session encryption secret.
 - `DATA_DIR` – directory where NeDB stores databases (`./data` by default).
 - `SENDGRID_API_KEY` – optional API key for sending password reset emails. If omitted, reset links are logged to the console.
 - `BASE_URL` – base URL used in password reset emails (`http://localhost:3000` by default).
+- `ASSET_VERSION` – optional string appended to static asset URLs to bust browser caches. If omitted, the app uses the current timestamp.
 - `PORT` – server port (defaults to `3000`).
 - `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` – credentials for Spotify OAuth.
 - `SPOTIFY_REDIRECT_URI` – callback URL registered with Spotify.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "npm run build:css && node index.js",
     "dev": "concurrently \"npm run watch:css\" \"nodemon --ignore data/ --ignore *.log index.js\"",
     "build:css": "postcss src/styles/input.css -o public/styles/output.css",
     "watch:css": "postcss src/styles/input.css -o public/styles/output.css --watch",

--- a/settings-template.js
+++ b/settings-template.js
@@ -1,5 +1,5 @@
-// Import the header component and color utilities at the top of the file
-const { headerComponent } = require('./templates');
+// Import the header component, and asset helper from templates
+const { headerComponent, asset } = require('./templates');
 const { adjustColor, colorWithOpacity } = require('./color-utils');
 
 // Settings page template
@@ -17,7 +17,7 @@ const settingsTemplate = (req, options) => {
   <link rel="apple-touch-icon" href="/og-image.png">
   <link rel="manifest" href="/manifest.json">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-  <link href="/styles/output.css" rel="stylesheet">
+  <link href="${asset('/styles/output.css')}" rel="stylesheet">
   <style>
     /* CSS Custom Properties for theming */
     :root {

--- a/templates.js
+++ b/templates.js
@@ -1,5 +1,6 @@
 const { adjustColor, colorWithOpacity } = require('./color-utils');
-const { version: assetVersion } = require('./package.json');
+// Use a timestamp-based asset version to avoid browser caching issues
+const assetVersion = process.env.ASSET_VERSION || Date.now().toString();
 const asset = (p) => `${p}?v=${assetVersion}`;
 
 // Shared header component
@@ -1646,5 +1647,7 @@ module.exports = {
   resetPasswordTemplate,
   invalidTokenTemplate,
   spotifyTemplate,
-  headerComponent
+  headerComponent,
+  asset,
+  assetVersion
 };


### PR DESCRIPTION
## Summary
- export asset helper from templates.js for reuse
- reference CSS with asset() in the settings page
- document asset version env var and compile CSS automatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bef422960832fb20af004be59a48a