### PR TITLE
Remove npm cache mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,6 @@ web_modules/
 # TypeScript cache
 *.tsbuildinfo
 
-# Optional npm cache directory
-.npm
 
 # Optional eslint cache
 .eslintcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@ WORKDIR /app
 
 # Copy package files and install all dependencies (dev included)
 COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm \
-    npm cache clean --force || true && \
-    npm ci --prefer-offline --no-audit
+RUN npm ci --prefer-offline --no-audit
 
 # Copy the rest of the source and build assets
 COPY . .
@@ -23,9 +21,7 @@ WORKDIR /app
 
 # Install only production dependencies
 COPY --chown=node:node package*.json ./
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev --prefer-offline --no-audit \
-    && npm cache clean --force || true \
+RUN npm ci --omit=dev --prefer-offline --no-audit \
     && apk add --no-cache curl
 
 # Copy application files and built assets from the builder stage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ The project targets **Node.js 22** for both development and production. The incl
 
 The `Dockerfile` uses a multi-stage build. The `builder` stage installs all dependencies and compiles assets, then a second `runtime` stage copies the built files into a clean Node 22 image containing only production dependencies.
 
-Docker builds benefit from caching with BuildKit. The `Dockerfile` uses cache mounts to reuse the npm cache between builds. Set `DOCKER_BUILDKIT=1` when running `docker compose build` to enable this optimization.
 
 ## Features
 - **User accounts** with registration, login and session handling using Passport.js and express-session.


### PR DESCRIPTION
## Summary
- drop BuildKit npm cache mounts from Dockerfile
- remove obsolete caching mention from README
- drop `.npm` ignore entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0bbbb4c8832fb875bdda6810ccbc