### PR TITLE
Improve cache headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ parses the request correctly.
 When running with Docker Compose, place these variables in a `.env` file or
 export them so they are available to the container.
 
+## Caching
+
+Static files in the `public` directory are served with a one-year lifetime and
+marked `immutable`. Each asset URL includes a version string (controlled via
+`ASSET_VERSION`), so browsers fetch a new file whenever that value changes.
+
+Dynamic pages and API responses set `Cache-Control: no-store` (along with
+`Pragma: no-cache` and `Expires: 0`) to prevent cached HTML or JSON from being
+reused.
+
 ## Running with Docker
 A `Dockerfile` and `docker-compose.yml` are included. You can build and start the app with:
 ```bash

--- a/index.js
+++ b/index.js
@@ -224,8 +224,16 @@ passport.deserializeUser((id, done) => users.findOne({ _id: id }, done));
 const app = express();
 
 // Basic Express middleware
-app.use(express.static('public'));
+app.use(express.static('public', { maxAge: '1y', immutable: true }));
 app.use(compression());
+app.use((req, res, next) => {
+  res.set({
+    'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+    Pragma: 'no-cache',
+    Expires: '0'
+  });
+  next();
+});
 app.use(express.urlencoded({ extended: false, limit: '10mb' }));
 app.use(express.json({ limit: '10mb' }));
 


### PR DESCRIPTION
## Summary
- set long-term caching for static assets
- disable caching for dynamic routes
- document caching behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0ece4378832fb901259d0c1b72bc