### PR TITLE
Add helmet and CSRF protection

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const crypto = require('crypto');
 const nodemailer = require('nodemailer');
 const path = require('path');
 const compression = require('compression');
+const helmet = require('helmet');
+const csrf = require('csurf');
 const multer = require('multer');
 const upload = multer({ 
   storage: multer.memoryStorage(),
@@ -222,6 +224,9 @@ passport.deserializeUser((id, done) => users.findOne({ _id: id }, done));
 
 // Create Express app
 const app = express();
+const csrfProtection = csrf();
+
+app.use(helmet());
 
 // Basic Express middleware
 app.use(express.static('public', { maxAge: '1y', immutable: true }));
@@ -359,11 +364,11 @@ function rateLimitAdminRequest(req, res, next) {
 // ============ ROUTES ============
 
 // Registration routes
-app.get('/register', (req, res) => {
+app.get('/register', csrfProtection, (req, res) => {
   res.send(htmlTemplate(registerTemplate(req, res.locals.flash), 'Join the KVLT - Black Metal Auth'));
 });
 
-app.post('/register', async (req, res) => {
+app.post('/register', csrfProtection, async (req, res) => {
   try {
     const { email, username, password, confirmPassword } = req.body;
     
@@ -486,11 +491,11 @@ app.post('/api/user/last-list', ensureAuthAPI, (req, res) => {
 });
 
 // Login routes
-app.get('/login', (req, res) => {
+app.get('/login', csrfProtection, (req, res) => {
   res.send(htmlTemplate(loginTemplate(req, res.locals.flash), 'SuShe Online'));
 });
 
-app.post('/login', (req, res, next) => {
+app.post('/login', csrfProtection, (req, res, next) => {
   console.log('Login POST request received for:', req.body.email);
   
   passport.authenticate('local', (err, user, info) => {
@@ -538,7 +543,7 @@ app.get('/', ensureAuth, (req, res) => {
 });
 
 // Unified Settings Page
-app.get('/settings', ensureAuth, async (req, res) => {
+app.get('/settings', ensureAuth, csrfProtection, async (req, res) => {
   try {
     const spotifyValid = isTokenValid(req.user.spotifyAuth);
     const tidalValid = isTokenValid(req.user.tidalAuth);
@@ -864,7 +869,7 @@ users.update(
 
 
 // Change password endpoint
-app.post('/settings/change-password', ensureAuth, async (req, res) => {
+app.post('/settings/change-password', ensureAuth, csrfProtection, async (req, res) => {
   try {
     const { currentPassword, newPassword, confirmPassword } = req.body;
     
@@ -918,7 +923,7 @@ app.post('/settings/change-password', ensureAuth, async (req, res) => {
 });
 
 // Admin request endpoint
-app.post('/settings/request-admin', ensureAuth, rateLimitAdminRequest, async (req, res) => {
+app.post('/settings/request-admin', ensureAuth, csrfProtection, rateLimitAdminRequest, async (req, res) => {
   console.log('Admin request received from:', req.user.email);
   
   try {
@@ -1654,12 +1659,12 @@ app.delete('/api/lists/:name', ensureAuthAPI, (req, res) => {
 // ============ PASSWORD RESET ROUTES ============
 
 // Forgot password page
-app.get('/forgot', (req, res) => {
+app.get('/forgot', csrfProtection, (req, res) => {
   res.send(htmlTemplate(forgotPasswordTemplate(req, res.locals.flash), 'Password Recovery - Black Metal Auth'));
 });
 
 // Handle forgot password submission
-app.post('/forgot', (req, res) => {
+app.post('/forgot', csrfProtection, (req, res) => {
   const { email } = req.body;
   
   if (!email) {
@@ -1736,7 +1741,7 @@ app.post('/forgot', (req, res) => {
 });
 
 // Reset password page
-app.get('/reset/:token', (req, res) => {
+app.get('/reset/:token', csrfProtection, (req, res) => {
   users.findOne({ resetToken: req.params.token, resetExpires: { $gt: Date.now() } }, (err, user) => {
     if (!user) {
       return res.send(htmlTemplate(invalidTokenTemplate(), 'Invalid Token - Black Metal Auth'));
@@ -1746,7 +1751,7 @@ app.get('/reset/:token', (req, res) => {
 });
 
 // Handle password reset
-app.post('/reset/:token', async (req, res) => {
+app.post('/reset/:token', csrfProtection, async (req, res) => {
   users.findOne({ resetToken: req.params.token, resetExpires: { $gt: Date.now() } }, async (err, user) => {
     if (err) {
       console.error('Error finding user with reset token:', err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
         "@seald-io/nedb": "^4.1.1",
         "bcryptjs": "^3.0.2",
         "compression": "^1.7.4",
+        "csurf": "^1.11.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
+        "helmet": "^8.1.0",
         "multer": "^2.0.1",
         "nodemailer": "^7.0.3",
         "passport": "^0.7.0",
@@ -860,6 +862,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "license": "MIT",
+      "dependencies": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -871,6 +887,86 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/csurf/node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/csurf/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/csurf/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/debug": {
@@ -1483,6 +1579,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -2751,6 +2856,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==",
+      "license": "MIT"
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -3522,6 +3633,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "session-file-store": "^1.5.0",
-    "compression": "^1.7.4"
+    "compression": "^1.7.4",
+    "helmet": "^8.1.0",
+    "csurf": "^1.11.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",

--- a/settings-template.js
+++ b/settings-template.js
@@ -181,6 +181,7 @@ const settingsTemplate = (req, options) => {
             </h3>
             
             <form action="/settings/change-password" method="POST" class="space-y-4">
+              <input type="hidden" name="_csrf" value="${req.csrfToken()}" />
               <div>
                 <label class="block text-sm font-medium text-gray-400 mb-2" for="currentPassword">
                   Current Password
@@ -332,6 +333,7 @@ const settingsTemplate = (req, options) => {
                   Enter the admin code to gain administrator privileges.
                 </p>
                 <form action="/settings/request-admin" method="POST" class="space-y-4">
+                  <input type="hidden" name="_csrf" value="${req.csrfToken()}" />
                   <div>
                     <input 
                       type="text" 

--- a/templates.js
+++ b/templates.js
@@ -230,6 +230,7 @@ const registerTemplate = (req, flash) => htmlTemplate(`
     </div>
     
     <form method="post" action="/register" class="space-y-6">
+      <input type="hidden" name="_csrf" value="${req.csrfToken()}" />
       <div>
         <label class="block text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2" for="email">
           Email Address
@@ -321,6 +322,7 @@ const loginTemplate = (req, flash) => htmlTemplate(`
     </div>
     
     <form method="post" action="/login" class="space-y-6" id="loginForm">
+      <input type="hidden" name="_csrf" value="${req.csrfToken()}" />
       <div>
         <label class="block text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2" for="email">
           Email Address
@@ -516,6 +518,7 @@ const forgotPasswordTemplate = (req, flash) => `
     </div>
     
     <form method="post" action="/forgot" class="space-y-6">
+      <input type="hidden" name="_csrf" value="${req.csrfToken()}" />
       <div>
         <label class="block text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2" for="email">
           Email Address
@@ -557,6 +560,7 @@ const resetPasswordTemplate = (token) => `
     </div>
     
     <form method="post" action="/reset/${token}" class="space-y-6">
+      <input type="hidden" name="_csrf" value="${req.csrfToken()}" />
       <div>
         <label class="block text-gray-400 text-xs font-semibold uppercase tracking-wider mb-2" for="password">
           New Password


### PR DESCRIPTION
## Summary
- use helmet for HTTP security headers
- add csurf middleware and CSRF tokens in server routes
- embed CSRF hidden fields in HTML forms
- update settings forms with CSRF tokens
- include dependencies in package.json

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d4f40c9c0832fbe6c189de8535fc1