### PR TITLE
Make drag placeholder invisible

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -218,9 +218,8 @@ body {
 }
 
 .album-row.drag-placeholder {
-  background-color: rgba(220, 38, 38, 0.1);
-  border: 2px dashed #dc2626;
-  opacity: 0.8;
+  /* Hide the original row while dragging but keep its space */
+  opacity: 0;
   min-height: 36px;  /* Reduced from 48px */
 }
 


### PR DESCRIPTION
## Summary
- hide placeholder row during drag and drop to make the dragged clone appear as the real row

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dfe2cf5b8832fbdff755393f3a8d7