### PR TITLE
Make drag placeholder invisible

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -212,15 +212,16 @@ body {
 }
 
 
+
+/* Clone that follows the cursor */
 .album-row.dragging {
-  opacity: 0.2;
+  opacity: 1;
   cursor: grabbing;
 }
 
+/* Placeholder left in the list */
 .album-row.drag-placeholder {
-  background-color: rgba(220, 38, 38, 0.1);
-  border: 2px dashed #dc2626;
-  opacity: 0.8;
+  visibility: hidden;
   min-height: 36px;  /* Reduced from 48px */
 }
 


### PR DESCRIPTION
## Summary
- hide placeholder row during drag and keep the clone fully visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dfe2cf5b8832fbdff755393f3a8d7