### PR TITLE
Hide original row during drag

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -217,6 +217,10 @@ body {
   cursor: grabbing;
 }
 
+body.desktop-dragging .album-row.dragging {
+  opacity: 0;
+}
+
 .album-row.drag-placeholder {
   background-color: rgba(220, 38, 38, 0.1);
   border: 2px dashed #dc2626;


### PR DESCRIPTION
## Summary
- hide the stationary copy of a dragged album row in desktop view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e0402e6bc832f925c081c89a7ae8e