### PR TITLE
Implement CSS drop indicator for album drag-and-drop

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -217,11 +217,16 @@ body {
   cursor: grabbing;
 }
 
-.album-row.drag-placeholder {
-  background-color: rgba(220, 38, 38, 0.1);
-  border: 2px dashed #dc2626;
-  opacity: 0.8;
-  min-height: 36px;  /* Reduced from 48px */
+.album-row.drop-target::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 0;
+  border-top: 2px dashed #dc2626;
+  top: var(--drop-indicator, -2px);
+  pointer-events: none;
+  z-index: 1;
 }
 
 /* Ensure minimum heights for rows */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ safelist: [
   // Drag and drop classes
   'dragging',
   'drag-active',
-  'drag-placeholder',
+  'drop-target',
   
   // Editable cell classes
   'comment-cell',
@@ -147,6 +147,7 @@ safelist: [
   'scale-105',
   'group',
   'group-hover:scale-105',
+
   
   // Animations
   'animate-spin',


### PR DESCRIPTION
## Summary
- remove DOM placeholder handling in drag-drop module
- use CSS-based drop indicator during drag operations
- update Tailwind safelist and styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e92cddc94832fafe869cd1635773b