### PR TITLE
Fix missing crypto injection in admin routes

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,5 +1,5 @@
 module.exports = (app, deps) => {
-  const { csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest, users, lists, usersAsync, listsAsync, upload, adminCode, adminCodeExpiry } = deps;
+  const { csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest, users, lists, usersAsync, listsAsync, upload, adminCode, adminCodeExpiry, crypto } = deps;
 
 // ============ ADMIN API ENDPOINTS ============
 


### PR DESCRIPTION
## Summary
- pass Node crypto module to admin routes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e9f3d1408832fb710d8c2c6d23e52