### PR TITLE
Fix track listing feature

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2093,8 +2093,12 @@ window.showMobileAlbumMenu = function(indexOrElement) {
 };
 
 // Mobile edit form (basic implementation)
-window.showMobileEditForm = function(index) {
+window.showMobileEditForm = async function(index) {
   const album = lists[currentList][index];
+  if (album && !album.tracks && album.album_id && typeof window.fetchReleaseGroupTracks === 'function') {
+    album.tracks = await window.fetchReleaseGroupTracks(album.album_id);
+    await saveList(currentList, lists[currentList]);
+  }
   
   // Create the edit modal
   const editModal = document.createElement('div');
@@ -2225,13 +2229,22 @@ window.showMobileEditForm = function(index) {
         <!-- Comments -->
         <div class="w-full">
           <label class="block text-gray-400 text-sm mb-2">Comments</label>
-          <textarea 
-            id="editComments" 
+        <textarea
+            id="editComments"
             rows="3"
             class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-red-600 transition duration-200 resize-none"
             placeholder="Add your notes..."
           >${album.comments || album.comment || ''}</textarea>
         </div>
+
+        ${album.tracks && album.tracks.length ? `
+        <div class="w-full">
+          <label class="block text-gray-400 text-sm mb-2">Tracks</label>
+          <ol class="list-decimal list-inside text-gray-300 space-y-1 text-sm">
+            ${album.tracks.map(t => `<li>${t}</li>`).join('')}
+          </ol>
+        </div>
+        ` : ''}
         
         <!-- Spacer for bottom padding -->
         <div class="h-4"></div>

--- a/src/js/musicbrainz.js
+++ b/src/js/musicbrainz.js
@@ -1720,7 +1720,8 @@ async function addAlbumToList(releaseGroup) {
       country: resolvedCountry,
       genre_1: '',
       genre_2: '',
-      comments: ''
+      comments: '',
+      tracks: []
   };
   
   // Enhanced cover art retrieval
@@ -1795,8 +1796,17 @@ async function addAlbumToList(releaseGroup) {
 
 async function addAlbumToCurrentList(album) {
   try {
+    if (album.album_id) {
+      try {
+        album.tracks = await fetchReleaseGroupTracks(album.album_id);
+      } catch (err) {
+        console.error('Failed to fetch track list:', err);
+        album.tracks = [];
+      }
+    }
+
     lists[currentList].push(album);
-    
+
     await saveList(currentList, lists[currentList]);
     
     selectList(currentList);
@@ -1811,6 +1821,40 @@ async function addAlbumToCurrentList(album) {
     lists[currentList].pop();
   }
 }
+
+// Fetch track list from MusicBrainz for a given release group
+async function fetchReleaseGroupTracks(releaseGroupId) {
+  try {
+    const rgData = await rateLimitedFetch(`${MUSICBRAINZ_API}/release-group/${releaseGroupId}?inc=releases&fmt=json`);
+    const releases = rgData.releases || [];
+    if (!releases.length) return [];
+    // Prefer the first official release
+    releases.sort((a, b) => {
+      const dateA = a.date || '';
+      const dateB = b.date || '';
+      return dateA.localeCompare(dateB);
+    });
+    const releaseId = releases[0].id;
+    const release = await rateLimitedFetch(`${MUSICBRAINZ_API}/release/${releaseId}?inc=recordings&fmt=json`);
+    const tracks = [];
+    if (release.media) {
+      for (const medium of release.media) {
+        if (medium.tracks) {
+          for (const track of medium.tracks) {
+            if (track.title) tracks.push(track.title);
+          }
+        }
+      }
+    }
+    return tracks;
+  } catch (err) {
+    console.error('Error fetching track list:', err);
+    return [];
+  }
+}
+
+// Expose helper for use in other modules
+window.fetchReleaseGroupTracks = fetchReleaseGroupTracks;
 
 function hasNonLatinCharacters(str) {
   if (!str) return false;


### PR DESCRIPTION
## Summary
- expose `fetchReleaseGroupTracks` globally for use outside musicbrainz module
- reference `window.fetchReleaseGroupTracks` in edit form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ee9ea7398832f8e21a0a4357b8a32