### PR TITLE
Add PostgreSQL backend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `Dockerfile` uses a multi-stage build. The `builder` stage installs all depe
 - **User accounts** with registration, login and session handling using Passport.js and express-session.
 - **Password reset** via email using Nodemailer.
 - **Spotify-like interface** for browsing and editing your lists. Drag and drop albums to reorder and import data from MusicBrainz, iTunes and Deezer.
-- **Persistent storage** using NeDB databases stored locally in the `data` directory.
+- **Persistent storage** using NeDB databases or PostgreSQL. Set `DATABASE_URL` to use PostgreSQL. Existing data is migrated automatically on startup.
 - **Admin mode** protected by a rotating access code printed to the server console. Admins can view site statistics, manage users and create backups.
 - **Custom theme** support allowing each user to pick an accent colour.
 - **REST API** endpoints for list management and a proxy for Deezer API requests.
@@ -30,7 +30,8 @@ The `Dockerfile` uses a multi-stage build. The `builder` stage installs all depe
 
 ## Environment variables
 - `SESSION_SECRET` – session encryption secret.
-- `DATA_DIR` – directory where NeDB stores databases (`./data` by default).
+- `DATA_DIR` – directory where NeDB stores databases (`./data` by default). Ignored when using PostgreSQL.
+- `DATABASE_URL` – PostgreSQL connection string. When set, the application uses PostgreSQL instead of NeDB.
 - `SENDGRID_API_KEY` – optional API key for sending password reset emails. If omitted, reset links are logged to the console.
 - `BASE_URL` – base URL used in password reset emails (`http://localhost:3000` by default).
 - `ASSET_VERSION` – optional string appended to static asset URLs to bust browser caches. If omitted, the app uses the current timestamp.
@@ -74,5 +75,7 @@ A `Dockerfile` and `docker-compose.yml` are included. You can build and start th
 ```bash
 docker compose up --build
 ```
+
+If `DATABASE_URL` is set, the application connects to PostgreSQL. When the server starts it will automatically copy any NeDB data into the database if the tables are empty. The server waits for PostgreSQL to become reachable before starting so it may take a few seconds on first boot.
 
 The admin access code is displayed in the server logs and rotates every five minutes.

--- a/db/index.js
+++ b/db/index.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const fs = require('fs');
+const Datastore = require('@seald-io/nedb');
+const promisifyDatastore = require('../db-utils');
+const { PgDatastore, Pool, waitForPostgres } = require('./postgres');
+const { migrateIfNeeded } = require('../scripts/migrate-to-postgres');
+
+const dataDir = process.env.DATA_DIR || './data';
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+console.log('Initializing database layer');
+
+let users, lists, usersAsync, listsAsync;
+let ready = Promise.resolve();
+
+if (process.env.DATABASE_URL) {
+  console.log('Using PostgreSQL backend');
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const usersMap = {
+    _id: '_id',
+    email: 'email',
+    username: 'username',
+    hash: 'hash',
+    accentColor: 'accent_color',
+    lastSelectedList: 'last_selected_list',
+    role: 'role',
+    spotifyAuth: 'spotify_auth',
+    tidalAuth: 'tidal_auth',
+    tidalCountry: 'tidal_country',
+    resetToken: 'reset_token',
+    resetExpires: 'reset_expires',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  };
+  const listsMap = {
+    _id: '_id',
+    userId: 'user_id',
+    name: 'name',
+    data: 'data',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  };
+  users = new PgDatastore(pool, 'users', usersMap);
+  lists = new PgDatastore(pool, 'lists', listsMap);
+  usersAsync = users;
+  listsAsync = lists;
+  ready = waitForPostgres(pool)
+    .then(() => migrateIfNeeded({ pool, dataDir }))
+    .then(() => console.log('Database ready')); 
+} else {
+  console.log('Using NeDB data directory:', dataDir);
+  users = new Datastore({ filename: path.join(dataDir, 'users.db'), autoload: true });
+  lists = new Datastore({ filename: path.join(dataDir, 'lists.db'), autoload: true });
+  usersAsync = promisifyDatastore(users);
+  listsAsync = promisifyDatastore(lists);
+  lists.ensureIndex({ fieldName: 'userId' });
+  lists.ensureIndex({ fieldName: 'name' });
+}
+
+module.exports = { users, lists, usersAsync, listsAsync, dataDir, ready };

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -1,0 +1,140 @@
+const { Pool } = require('pg');
+
+async function waitForPostgres(pool, retries = 10, interval = 3000) {
+  console.log('Checking PostgreSQL connection...');
+  for (let i = 0; i < retries; i++) {
+    try {
+      await pool.query('SELECT 1');
+      console.log('PostgreSQL is reachable');
+      return;
+    } catch (err) {
+      console.log(`Waiting for PostgreSQL... (${i + 1}/${retries})`);
+      await new Promise(res => setTimeout(res, interval));
+    }
+  }
+  throw new Error('PostgreSQL not reachable');
+}
+
+class PgDatastore {
+  constructor(pool, table, fieldMap) {
+    this.pool = pool;
+    this.table = table;
+    this.fieldMap = fieldMap;
+    this.inverseMap = Object.fromEntries(
+      Object.entries(fieldMap).map(([k, v]) => [v, k])
+    );
+  }
+
+  _mapField(field) {
+    return this.fieldMap[field] || field;
+  }
+
+  _buildWhere(query, startIndex = 1) {
+    const conditions = [];
+    const values = [];
+    let idx = startIndex;
+    for (const [field, val] of Object.entries(query)) {
+      const col = this._mapField(field);
+      if (val && typeof val === 'object' && !Array.isArray(val)) {
+        if ('$gt' in val) {
+          conditions.push(`${col} > $${idx}`);
+          values.push(val['$gt']);
+          idx++;
+        } else if ('$exists' in val) {
+          if (val['$exists']) {
+            conditions.push(`${col} IS NOT NULL`);
+          } else {
+            conditions.push(`${col} IS NULL`);
+          }
+        } else {
+          conditions.push(`${col} = $${idx}`);
+          values.push(val);
+          idx++;
+        }
+      } else {
+        conditions.push(`${col} = $${idx}`);
+        values.push(val);
+        idx++;
+      }
+    }
+    return { text: conditions.length ? 'WHERE ' + conditions.join(' AND ') : '', values };
+  }
+
+  _mapRow(row) {
+    const mapped = {};
+    for (const [col, val] of Object.entries(row)) {
+      mapped[this.inverseMap[col] || col] = val;
+    }
+    return mapped;
+  }
+
+  async findOne(query) {
+    const { text, values } = this._buildWhere(query);
+    const res = await this.pool.query(`SELECT * FROM ${this.table} ${text} LIMIT 1`, values);
+    return res.rows[0] ? this._mapRow(res.rows[0]) : null;
+  }
+
+  async find(query) {
+    const { text, values } = this._buildWhere(query);
+    const res = await this.pool.query(`SELECT * FROM ${this.table} ${text}`, values);
+    return res.rows.map(r => this._mapRow(r));
+  }
+
+  async count(query) {
+    const { text, values } = this._buildWhere(query);
+    const res = await this.pool.query(`SELECT COUNT(*) AS cnt FROM ${this.table} ${text}`, values);
+    return parseInt(res.rows[0].cnt, 10);
+  }
+
+  async insert(doc) {
+    const cols = [];
+    const placeholders = [];
+    const values = [];
+    let idx = 1;
+    for (const [field, val] of Object.entries(doc)) {
+      const col = this._mapField(field);
+      cols.push(col);
+      placeholders.push(`$${idx}`);
+      values.push(val);
+      idx++;
+    }
+    const res = await this.pool.query(
+      `INSERT INTO ${this.table} (${cols.join(',')}) VALUES (${placeholders.join(',')}) RETURNING *`,
+      values
+    );
+    return this._mapRow(res.rows[0]);
+  }
+
+  async update(query, update, options = {}) {
+    const { $set = {}, $unset = {} } = update;
+    const setClauses = [];
+    const values = [];
+    let idx = 1;
+    for (const [field, val] of Object.entries($set)) {
+      setClauses.push(`${this._mapField(field)} = $${idx}`);
+      values.push(val);
+      idx++;
+    }
+    for (const field of Object.keys($unset)) {
+      setClauses.push(`${this._mapField(field)} = NULL`);
+    }
+    if (setClauses.length === 0) return 0;
+    const where = this._buildWhere(query, idx);
+    const res = await this.pool.query(
+      `UPDATE ${this.table} SET ${setClauses.join(', ')} ${where.text}`,
+      values.concat(where.values)
+    );
+    return res.rowCount;
+  }
+
+  async remove(query) {
+    const { text, values } = this._buildWhere(query);
+    const res = await this.pool.query(`DELETE FROM ${this.table} ${text}`, values);
+    return res.rowCount;
+  }
+
+  // For compatibility with NeDB
+  ensureIndex() {}
+}
+
+module.exports = { PgDatastore, Pool, waitForPostgres };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,22 @@ services:
       - SPOTIFY_REDIRECT_URI=${SPOTIFY_REDIRECT_URI}
       - TIDAL_CLIENT_ID=${TIDAL_CLIENT_ID}
       - TIDAL_REDIRECT_URI=${TIDAL_REDIRECT_URI}
+      - DATABASE_URL=postgres://postgres:example@db:5432/sushe
     volumes:
       - sushe-data:/app/data
+    depends_on:
+      - db
     restart: unless-stopped
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: example
+      POSTGRES_DB: sushe
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
 
 volumes:
   sushe-data:
+  postgres-data:
+

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const session = require('express-session');
 const FileStore = require('session-file-store')(session);
 const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
-const Datastore = require('@seald-io/nedb');
+// Datastore setup is handled in ./db which supports NeDB or PostgreSQL
 const bcrypt = require('bcryptjs');
 const crypto = require('crypto');
 const nodemailer = require('nodemailer');
@@ -38,31 +38,9 @@ const {
 // Import the new settings template
 const { settingsTemplate } = require('./settings-template');
 const { isTokenValid } = require('./auth-utils');
+// Databases are initialized in ./db and can use NeDB or PostgreSQL
+const { users, lists, usersAsync, listsAsync, dataDir, ready } = require('./db');
 
-// Create data directory if it doesn't exist
-const dataDir = process.env.DATA_DIR || './data';
-if (!require('fs').existsSync(dataDir)) {
-  require('fs').mkdirSync(dataDir, { recursive: true });
-}
-
-// Initialize NeDB databases
-const users = new Datastore({ 
-  filename: path.join(dataDir, 'users.db'), 
-  autoload: true 
-});
-const lists = new Datastore({
-  filename: path.join(dataDir, 'lists.db'),
-  autoload: true
-});
-
-// Promisified DB helpers for async/await
-const promisifyDatastore = require('./db-utils');
-const usersAsync = promisifyDatastore(users);
-const listsAsync = promisifyDatastore(lists);
-
-// Create indexes for better performance
-lists.ensureIndex({ fieldName: 'userId' });
-lists.ensureIndex({ fieldName: 'name' });
 
 // Map of SSE subscribers keyed by `${userId}:${listName}`
 const listSubscribers = new Map();
@@ -405,9 +383,16 @@ app.use((err, req, res, next) => {
   res.status(500).send('Something went wrong!');
 });
 
-// Start server
+// Start server once database is ready
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`🔥 Server burning at http://localhost:${PORT} 🔥`);
-  console.log(`🔥 Environment: ${process.env.NODE_ENV || 'development'} 🔥`);
-});
+ready
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`🔥 Server burning at http://localhost:${PORT} 🔥`);
+      console.log(`🔥 Environment: ${process.env.NODE_ENV || 'development'} 🔥`);
+    });
+  })
+  .catch((err) => {
+    console.error('Failed to initialize database', err);
+    process.exit(1);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "nodemailer": "^7.0.3",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
+        "pg": "^8.11.3",
         "session-file-store": "^1.5.0"
       },
       "devDependencies": {
@@ -3224,6 +3225,95 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
+    "node_modules/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-7SKfdvP8CTNXjMUzfcVTaI+TDzBEeaUnVwiVGZQD1Hh33Kpev7liQba9uLd4CfN8r9mCVsD0JIpq03+Unpz+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.0",
+        "pg-pool": "^3.10.0",
+        "pg-protocol": "^1.10.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.5"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.5.tgz",
+      "integrity": "sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.0.tgz",
+      "integrity": "sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.0.tgz",
+      "integrity": "sha512-DzZ26On4sQ0KmqnO34muPcmKbhrjmyiO4lCCR0VwEd7MjmiKf5NTg/6+apUEu0NF7ESa37CGzFxH513CoUmWnA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
+      "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3482,6 +3572,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
@@ -4086,6 +4215,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:js": "vite build",
     "watch:css": "postcss src/styles/input.css -o public/styles/output.css --watch",
     "watch:js": "vite build --watch",
-    "test": "node --test"
+    "test": "node --test",
+    "migrate:postgres": "node scripts/migrate-to-postgres.js"
   },
   "dependencies": {
     "@seald-io/nedb": "^4.1.1",
@@ -26,7 +27,8 @@
     "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-    "session-file-store": "^1.5.0"
+    "session-file-store": "^1.5.0",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",

--- a/scripts/migrate-to-postgres.js
+++ b/scripts/migrate-to-postgres.js
@@ -1,0 +1,125 @@
+const path = require('path');
+const fs = require('fs');
+const Datastore = require('@seald-io/nedb');
+const { Pool } = require('../db/postgres');
+const promisifyDatastore = require('../db-utils');
+
+async function ensureTables(pool) {
+  console.log('Ensuring PostgreSQL tables exist');
+  await pool.query(`CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    _id TEXT UNIQUE NOT NULL,
+    email TEXT UNIQUE,
+    username TEXT UNIQUE,
+    hash TEXT,
+    accent_color TEXT,
+    last_selected_list TEXT,
+    role TEXT,
+    spotify_auth JSONB,
+    tidal_auth JSONB,
+    tidal_country TEXT,
+    reset_token TEXT,
+    reset_expires BIGINT,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+  )`);
+  await pool.query(`CREATE TABLE IF NOT EXISTS lists (
+    id SERIAL PRIMARY KEY,
+    _id TEXT UNIQUE NOT NULL,
+    user_id TEXT NOT NULL REFERENCES users(_id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    data JSONB,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT unique_user_name UNIQUE(user_id, name)
+  )`);
+}
+
+async function migrate({ pool, dataDir }) {
+  console.log('Migrating data from NeDB to PostgreSQL...');
+  const usersDb = new Datastore({ filename: path.join(dataDir, 'users.db'), autoload: true });
+  const listsDb = new Datastore({ filename: path.join(dataDir, 'lists.db'), autoload: true });
+  const usersAsync = promisifyDatastore(usersDb);
+  const listsAsync = promisifyDatastore(listsDb);
+
+  await ensureTables(pool);
+  const users = await usersAsync.find({});
+  for (const user of users) {
+    await pool.query(
+      `INSERT INTO users (_id,email,username,hash,accent_color,last_selected_list,role,spotify_auth,tidal_auth,tidal_country,reset_token,reset_expires,created_at,updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+       ON CONFLICT (_id) DO NOTHING`,
+      [
+        user._id,
+        user.email,
+        user.username,
+        user.hash,
+        user.accentColor,
+        user.lastSelectedList,
+        user.role || null,
+        JSON.stringify(user.spotifyAuth),
+        JSON.stringify(user.tidalAuth),
+        user.tidalCountry,
+        user.resetToken,
+        user.resetExpires,
+        user.createdAt ? new Date(user.createdAt) : null,
+        user.updatedAt ? new Date(user.updatedAt) : null
+      ]
+    );
+  }
+
+  const lists = await listsAsync.find({});
+  for (const list of lists) {
+    await pool.query(
+      `INSERT INTO lists (_id,user_id,name,data,created_at,updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (_id) DO NOTHING`,
+      [
+        list._id,
+        list.userId,
+        list.name,
+        JSON.stringify(list.data),
+        list.createdAt ? new Date(list.createdAt) : null,
+        list.updatedAt ? new Date(list.updatedAt) : null
+      ]
+    );
+  }
+}
+
+async function migrateIfNeeded({ pool, dataDir }) {
+  console.log('Checking if migration to PostgreSQL is needed...');
+  await ensureTables(pool);
+  const { rows } = await pool.query('SELECT COUNT(*) AS cnt FROM users');
+  const pgCount = parseInt(rows[0].cnt, 10);
+  if (pgCount > 0) {
+    return; // already migrated
+  }
+
+  // Check if NeDB has any users to migrate
+  if (!fs.existsSync(path.join(dataDir, 'users.db'))) return;
+  const usersDb = new Datastore({ filename: path.join(dataDir, 'users.db'), autoload: true });
+  const usersAsync = promisifyDatastore(usersDb);
+  const nedbCount = await usersAsync.count({});
+  if (nedbCount === 0) return;
+
+  await migrate({ pool, dataDir });
+  console.log('Migration complete');
+}
+
+module.exports = { migrateIfNeeded };
+
+if (require.main === module) {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('DATABASE_URL not set');
+    process.exit(1);
+  }
+  const pool = new Pool({ connectionString });
+  console.log('Starting standalone migration');
+  migrateIfNeeded({ pool, dataDir: process.env.DATA_DIR || './data' })
+    .then(() => pool.end())
+    .catch(err => {
+      console.error('Migration failed', err);
+      pool.end().finally(() => process.exit(1));
+    });
+}


### PR DESCRIPTION
## Summary
- add PostgreSQL datastore implementation
- autoload DB tables and wait for ready state
- provide migration script from NeDB to PostgreSQL
- add pg dependency and migration script in package.json
- document new DATABASE_URL usage and docker compose changes
- automatically migrate NeDB data to PostgreSQL on startup
- fix Postgres adapter to map column names back to camelCase
- add startup wait for PostgreSQL so the server doesn't hang
- add debug logs for build and migration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fe9cdc5c8832f82f37f97875ae8bb