### PR TITLE
Fix release date editing placeholder

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -11,6 +11,7 @@ async function ensureTables(pool) {
     username TEXT UNIQUE,
     hash TEXT,
     accent_color TEXT,
+    date_format TEXT,
     last_selected_list TEXT,
     role TEXT,
     spotify_auth JSONB,
@@ -21,6 +22,7 @@ async function ensureTables(pool) {
     created_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ
   )`);
+  await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS date_format TEXT');
   await pool.query(`CREATE TABLE IF NOT EXISTS lists (
     id SERIAL PRIMARY KEY,
     _id TEXT UNIQUE NOT NULL,
@@ -51,6 +53,7 @@ if (process.env.DATABASE_URL) {
     username: 'username',
     hash: 'hash',
     accentColor: 'accent_color',
+    dateFormat: 'date_format',
     lastSelectedList: 'last_selected_list',
     role: 'role',
     spotifyAuth: 'spotify_auth',

--- a/index.js
+++ b/index.js
@@ -69,12 +69,13 @@ function broadcastListUpdate(userId, name, data) {
 
 function sanitizeUser(user) {
   if (!user) return null;
-  const { _id, email, username, accentColor, lastSelectedList, role } = user;
+  const { _id, email, username, accentColor, dateFormat, lastSelectedList, role } = user;
   return {
     _id,
     email,
     username,
     accentColor,
+    dateFormat,
     lastSelectedList,
     role,
     spotifyAuth: !!user.spotifyAuth,
@@ -373,7 +374,7 @@ const deps = {
   users, lists, usersAsync, listsAsync, upload, bcrypt, crypto, nodemailer,
   composeForgotPasswordEmail, isValidEmail, isValidUsername, isValidPassword,
   broadcastListUpdate, listSubscribers, sanitizeUser, adminCodeAttempts, adminCode, adminCodeExpiry, generateAdminCode, lastCodeUsedBy, lastCodeUsedAt,
-  dataDir, pool
+  dataDir, pool, ready
 };
 
 authRoutes(app, deps);

--- a/settings-template.js
+++ b/settings-template.js
@@ -267,6 +267,25 @@ const settingsTemplate = (req, options) => {
         </div>
         </div>
 
+        <!-- Date Format Settings -->
+        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+        <h3 class="text-lg font-semibold text-white mb-4">
+            <i class="fas fa-calendar-alt mr-2 text-gray-400"></i>
+            Date Format
+        </h3>
+        <p class="text-sm text-gray-400 mb-4">
+            Choose how release dates are displayed
+        </p>
+        <div class="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+            <select id="dateFormatSelect" class="px-4 py-2 bg-gray-800 border border-gray-700 rounded text-white">
+            <option value="YYYY-MM-DD" ${user.dateFormat === 'YYYY-MM-DD' ? 'selected' : ''}>YYYY-MM-DD</option>
+            <option value="DD/MM/YYYY" ${user.dateFormat === 'DD/MM/YYYY' ? 'selected' : ''}>DD/MM/YYYY</option>
+            <option value="MM/DD/YYYY" ${user.dateFormat === 'MM/DD/YYYY' ? 'selected' : ''}>MM/DD/YYYY</option>
+            </select>
+            <button onclick="updateDateFormat(document.getElementById('dateFormatSelect').value)" class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded transition duration-200">Save</button>
+        </div>
+        </div>
+
         <!-- Music Service Integration -->
         <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
           <h3 class="text-lg font-semibold text-white mb-4">
@@ -771,6 +790,34 @@ const settingsTemplate = (req, options) => {
     
     function resetAccentColor() {
       updateAccentColor('#dc2626');
+    }
+
+    async function updateDateFormat(format) {
+      try {
+        const allowed = ['YYYY-MM-DD', 'DD/MM/YYYY', 'MM/DD/YYYY'];
+        if (!allowed.includes(format)) {
+          showToast('Invalid date format', 'error');
+          return;
+        }
+
+        const response = await fetch('/settings/update-date-format', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dateFormat: format }),
+          credentials: 'same-origin'
+        });
+
+        const data = await response.json();
+        if (data.success) {
+          showToast('Date format updated!');
+          setTimeout(() => location.reload(), 1000);
+        } else {
+          showToast(data.error || 'Error updating date format', 'error');
+        }
+      } catch (error) {
+        console.error('Error updating date format:', error);
+        showToast('Error updating date format', 'error');
+      }
     }
     
     // Client-side color adjustment function

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -116,88 +116,78 @@ function showServicePicker(hasSpotify, hasTidal) {
   });
 }
 
-// Standardize date formats for release dates
-function formatReleaseDate(dateStr) {
-  if (!dateStr) return '';
-  
-  // Handle various date formats
-  let date;
-  
-  // Try to parse the date string
+// Parse a date string into components {year, month, day}
+function parseDateParts(dateStr) {
+  if (!dateStr) return null;
   try {
-    // Check if it's just a year (e.g., "2023")
     if (/^\d{4}$/.test(dateStr)) {
-      return dateStr; // Just return the year as-is
+      return { year: dateStr };
     }
-    
-    // Check if it's year-month (e.g., "2023-12")
     if (/^\d{4}-\d{2}$/.test(dateStr)) {
       const [year, month] = dateStr.split('-');
-      return `${month}-${year}`;
+      return { year, month };
     }
-    
-    // Check various full date formats
-    // ISO format: "2023-12-25"
     if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
       const [year, month, day] = dateStr.split('-');
-      return `${day}-${month}-${year}`;
+      return { year, month, day };
     }
-    
-    // US format: "12/25/2023" or "12-25-2023"
     if (/^\d{1,2}[/-]\d{1,2}[/-]\d{4}$/.test(dateStr)) {
       const parts = dateStr.split(/[/-]/);
-      const month = parts[0].padStart(2, '0');
-      const day = parts[1].padStart(2, '0');
-      const year = parts[2];
-      return `${day}-${month}-${year}`;
-    }
-    
-    // European format: "25/12/2023" or "25-12-2023"
-    if (/^\d{1,2}[/-]\d{1,2}[/-]\d{4}$/.test(dateStr)) {
-      const parts = dateStr.split(/[/-]/);
-      // Try to detect if it's DD/MM or MM/DD by checking if first part > 12
-      const firstPart = parseInt(parts[0]);
-      const secondPart = parseInt(parts[1]);
-      
-      if (firstPart > 12) {
-        // Likely DD/MM/YYYY
-        const day = parts[0].padStart(2, '0');
-        const month = parts[1].padStart(2, '0');
-        const year = parts[2];
-        return `${day}-${month}-${year}`;
-      } else if (secondPart > 12) {
-        // Likely MM/DD/YYYY
-        const month = parts[0].padStart(2, '0');
-        const day = parts[1].padStart(2, '0');
-        const year = parts[2];
-        return `${day}-${month}-${year}`;
+      const first = parseInt(parts[0]);
+      const second = parseInt(parts[1]);
+      let day, month;
+      if (first > 12) {
+        day = parts[0];
+        month = parts[1];
+      } else if (second > 12) {
+        month = parts[0];
+        day = parts[1];
       } else {
-        // Ambiguous, assume DD/MM/YYYY for European format
-        const day = parts[0].padStart(2, '0');
-        const month = parts[1].padStart(2, '0');
-        const year = parts[2];
-        return `${day}-${month}-${year}`;
+        day = parts[0];
+        month = parts[1];
       }
+      return { year: parts[2], month: month.padStart(2, '0'), day: day.padStart(2, '0') };
     }
-    
-    // Try to parse as a general date
-    date = new Date(dateStr);
-    
-    // Check if the date is valid
+    const date = new Date(dateStr);
     if (!isNaN(date.getTime())) {
-      const day = date.getDate().toString().padStart(2, '0');
-      const month = (date.getMonth() + 1).toString().padStart(2, '0');
-      const year = date.getFullYear();
-      return `${day}-${month}-${year}`;
+      return {
+        year: date.getFullYear().toString(),
+        month: (date.getMonth() + 1).toString().padStart(2, '0'),
+        day: date.getDate().toString().padStart(2, '0')
+      };
     }
-    
-    // If all parsing fails, return the original string
-    return dateStr;
-    
   } catch (e) {
-    // If any error occurs, return the original string
-    return dateStr;
+    return null;
   }
+  return null;
+}
+
+function applyDateFormat(parts, format) {
+  if (!parts) return '';
+  if (!parts.month) return parts.year;
+
+  const delim = format.includes('/') ? '/' : '-';
+
+  if (!parts.day) {
+    if (format.startsWith('YYYY')) {
+      return `${parts.year}${delim}${parts.month}`;
+    }
+    return `${parts.month}${delim}${parts.year}`;
+  }
+
+  return format
+    .replace('YYYY', parts.year)
+    .replace('MM', parts.month)
+    .replace('DD', parts.day);
+}
+
+// Format release dates using the user's preferred format
+function formatReleaseDate(dateStr) {
+  if (!dateStr) return '';
+  const format = window.currentUser?.dateFormat || 'YYYY-MM-DD';
+  const parts = parseDateParts(dateStr);
+  if (!parts) return dateStr;
+  return applyDateFormat(parts, format);
 }
 
 // Load available countries
@@ -2151,7 +2141,7 @@ window.showMobileEditForm = function(index) {
           <input 
             type="date" 
             id="editReleaseDate" 
-            value="${album.release_date ? (album.release_date.length === 4 ? album.release_date + '-01-01' : album.release_date) : new Date().toISOString().split('T')[0]}"
+            value="${album.release_date ? (album.release_date.length === 4 ? album.release_date + "-01-01" : (album.release_date.length === 7 ? album.release_date + "-01" : album.release_date)) : new Date().toISOString().split('T')[0]}"
             class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-red-600 transition duration-200"
             style="display: block; width: 100%; min-height: 48px; -webkit-appearance: none;"
           >


### PR DESCRIPTION
## Summary
- ensure mobile editor pre-fills date input when stored value has YYYY-MM format
- allow each user to pick a preferred date format in settings
- use the user's date format when displaying release dates
- add migration guard for date_format column

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685004c160d4832f867fa18f7598f93c