### PR TITLE
Add last active tracking to admin user list

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -19,10 +19,12 @@ async function ensureTables(pool) {
     tidal_country TEXT,
     reset_token TEXT,
     reset_expires BIGINT,
+    last_active_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ
   )`);
   await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS date_format TEXT');
+  await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ');
   await pool.query(`CREATE TABLE IF NOT EXISTS lists (
     id SERIAL PRIMARY KEY,
     _id TEXT UNIQUE NOT NULL,
@@ -61,6 +63,7 @@ if (process.env.DATABASE_URL) {
     tidalCountry: 'tidal_country',
     resetToken: 'reset_token',
     resetExpires: 'reset_expires',
+    lastActiveAt: 'last_active_at',
     createdAt: 'created_at',
     updatedAt: 'updated_at'
   };

--- a/index.js
+++ b/index.js
@@ -323,6 +323,10 @@ app.use(passport.session());
 // Middleware to protect routes
 function ensureAuth(req, res, next) {
   if (req.user || (req.isAuthenticated && req.isAuthenticated())) {
+    if (req.user) {
+      users.update({ _id: req.user._id }, { $set: { lastActiveAt: new Date() } }, () => {});
+      req.user.lastActiveAt = new Date();
+    }
     return next();
   }
   res.redirect('/login');

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -161,7 +161,10 @@ app.post('/login', csrfProtection, (req, res, next) => {
       }
       
       console.log('User logged in successfully:', user.email);
-      
+
+      // Update last active timestamp
+      users.update({ _id: user._id }, { $set: { lastActiveAt: new Date() } }, () => {});
+
       // Force session save and handle errors
       req.session.save((err) => {
         if (err) {
@@ -543,6 +546,14 @@ ready.then(() => {
   users.update(
     { tidalCountry: { $exists: false } },
     { $set: { tidalCountry: null } },
+    { multi: true },
+    () => {}
+  );
+
+  // Ensure lastActiveAt exists on existing users
+  users.update(
+    { lastActiveAt: { $exists: false } },
+    { $set: { lastActiveAt: new Date() } },
     { multi: true },
     () => {}
   );

--- a/settings-template.js
+++ b/settings-template.js
@@ -493,6 +493,7 @@ const settingsTemplate = (req, options) => {
                         <th class="pb-2 text-sm font-medium text-gray-400">User</th>
                         <th class="pb-2 text-sm font-medium text-gray-400">Lists</th>
                         <th class="pb-2 text-sm font-medium text-gray-400">Role</th>
+                        <th class="pb-2 text-sm font-medium text-gray-400">Last Active</th>
                         <th class="pb-2 text-sm font-medium text-gray-400">Actions</th>
                       </tr>
                     </thead>
@@ -509,10 +510,15 @@ const settingsTemplate = (req, options) => {
                             <span class="text-sm text-gray-300">${u.listCount}</span>
                           </td>
                           <td class="py-3">
-                            ${u.role === 'admin' ? 
-                              '<span class="text-xs bg-yellow-900/50 text-yellow-400 px-2 py-1 rounded">Admin</span>' : 
+                            ${u.role === 'admin' ?
+                              '<span class="text-xs bg-yellow-900/50 text-yellow-400 px-2 py-1 rounded">Admin</span>' :
                               '<span class="text-xs bg-gray-800 text-gray-400 px-2 py-1 rounded">User</span>'
                             }
+                          </td>
+                          <td class="py-3">
+                            <span class="text-xs text-gray-400">
+                              ${u.lastActiveAt ? new Date(u.lastActiveAt).toLocaleString() : 'N/A'}
+                            </span>
                           </td>
                           <td class="py-3">
                             <div class="flex gap-2">


### PR DESCRIPTION
## Summary
- track last activity for each user in database
- update login and authenticated routes to store last activity
- display Last Active column in admin user management table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68500a209444832faea6119c71e14fba