### PR TITLE
Fix restore route bug

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -369,8 +369,12 @@ app.post('/admin/restore', ensureAuth, ensureAdmin, upload.single('backup'), asy
     await listsAsync.remove({}, { multi: true });
 
     // Restore users and lists
-    await usersAsync.insert(backup.users);
-    await listsAsync.insert(backup.lists);
+    for (const user of backup.users) {
+      await usersAsync.insert(user);
+    }
+    for (const list of backup.lists) {
+      await listsAsync.insert(list);
+    }
 
     // Clear all sessions after restore
     req.sessionStore.clear((err) => {


### PR DESCRIPTION
## Summary
- restore route should insert each user/list one at a time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685017d44748832fa6e138bd19f517e4