### PR TITLE
Implement relational list storage and database backup

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const {
 const { settingsTemplate } = require('./settings-template');
 const { isTokenValid } = require('./auth-utils');
 // Databases are initialized in ./db using PostgreSQL
-const { users, lists, usersAsync, listsAsync, dataDir, ready, pool } = require('./db');
+const { users, lists, listItems, usersAsync, listsAsync, listItemsAsync, dataDir, ready, pool } = require('./db');
 
 
 // Map of SSE subscribers keyed by `${userId}:${listName}`
@@ -370,7 +370,7 @@ const apiRoutes = require("./routes/api");
 const deps = {
   htmlTemplate, registerTemplate, loginTemplate, forgotPasswordTemplate, resetPasswordTemplate, invalidTokenTemplate, spotifyTemplate, settingsTemplate, isTokenValid,
   csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest,
-  users, lists, usersAsync, listsAsync, upload, bcrypt, crypto, nodemailer,
+  users, lists, listItems, usersAsync, listsAsync, listItemsAsync, upload, bcrypt, crypto, nodemailer,
   composeForgotPasswordEmail, isValidEmail, isValidUsername, isValidPassword,
   broadcastListUpdate, listSubscribers, sanitizeUser, adminCodeAttempts, adminCode, adminCodeExpiry, generateAdminCode, lastCodeUsedBy, lastCodeUsedAt,
   dataDir, pool, passport

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -192,9 +192,13 @@ app.get('/settings', ensureAuth, csrfProtection, async (req, res) => {
     const sanitized = sanitizeUser(req.user);
     // Get user's personal stats
     const userLists = await listsAsync.find({ userId: req.user._id });
+    let albumCount = 0;
+    for (const l of userLists) {
+      albumCount += await listItemsAsync.count({ listId: l._id });
+    }
     const userStats = {
       listCount: userLists.length,
-      totalAlbums: userLists.reduce((sum, l) => sum + (Array.isArray(l.data) ? l.data.length : 0), 0)
+      totalAlbums: albumCount
     };
     
     // If admin, get admin data
@@ -229,7 +233,9 @@ app.get('/settings', ensureAuth, csrfProtection, async (req, res) => {
         ? Math.round(((usersThisWeek - usersLastWeek) / usersLastWeek) * 100)
         : (usersThisWeek > 0 ? 100 : 0);
 
-      allLists.forEach(list => {
+      for (const list of allLists) {
+        const items = await listItemsAsync.find({ listId: list._id });
+
         if (list.updatedAt && new Date(list.updatedAt) >= sevenDaysAgo) {
           const userIndex = allUsers.findIndex(u => u._id === list.userId);
           if (userIndex !== -1 && !allUsers[userIndex].counted) {
@@ -238,22 +244,18 @@ app.get('/settings', ensureAuth, csrfProtection, async (req, res) => {
           }
         }
 
-        if (Array.isArray(list.data)) {
-          totalAlbums += list.data.length;
-          list.data.forEach(album => {
-            if (album.genre_1 || album.genre) {
-              const genre = album.genre_1 || album.genre;
-              if (genre && genre !== '' && genre !== 'Genre 1') {
-                genreCounts.set(genre, (genreCounts.get(genre) || 0) + 1);
-              }
-            }
+        totalAlbums += items.length;
+        for (const album of items) {
+          const genre = album.genre1;
+          if (genre && genre !== '' && genre !== 'Genre 1') {
+            genreCounts.set(genre, (genreCounts.get(genre) || 0) + 1);
+          }
 
-            if (album.genre_2 && album.genre_2 !== '' && album.genre_2 !== 'Genre 2' && album.genre_2 !== '-') {
-              genreCounts.set(album.genre_2, (genreCounts.get(album.genre_2) || 0) + 1);
-            }
-          });
+          if (album.genre2 && album.genre2 !== '' && album.genre2 !== 'Genre 2' && album.genre2 !== '-') {
+            genreCounts.set(album.genre2, (genreCounts.get(album.genre2) || 0) + 1);
+          }
         }
-      });
+      }
 
               // Get top genres
               const topGenres = Array.from(genreCounts.entries())

--- a/settings-template.js
+++ b/settings-template.js
@@ -427,13 +427,19 @@ const settingsTemplate = (req, options) => {
                   >
                     <i class="fas fa-download mr-2"></i>Export Users
                   </button>
-                  <button 
+                  <button
+                    onclick="if(confirm('Download database export as JSON?')) window.location.href='/admin/export'"
+                    class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded transition duration-200 text-sm"
+                  >
+                    <i class="fas fa-file-export mr-2"></i>Export Database
+                  </button>
+                  <button
                     onclick="if(confirm('Download complete database backup?')) window.location.href='/admin/backup'"
                     class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded transition duration-200 text-sm"
                   >
                     <i class="fas fa-database mr-2"></i>Backup Database
                   </button>
-                  <button 
+                  <button
                     onclick="showRestoreModal()"
                     class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded transition duration-200 text-sm"
                   >
@@ -555,12 +561,12 @@ const settingsTemplate = (req, options) => {
       <form id="restoreForm" enctype="multipart/form-data" class="p-6">
         <div class="mb-4">
           <label class="block text-sm font-medium text-gray-400 mb-2">
-            Select backup file (.json)
+            Select backup file (.dump)
           </label>
           <input 
             type="file" 
             name="backup"
-            accept=".json"
+            accept=".dump"
             required
             class="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-white file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-gray-700 file:text-white hover:file:bg-gray-600"
           >


### PR DESCRIPTION
## Summary
- migrate list data to relational `list_items`
- update API and admin routes for relational lists
- add pg_dump backup and restore endpoints
- support JSON export of data
- update admin UI for backup/restore options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685032261b44832f94d33068ecc7bbc4