### PR TITLE
Fix restore path for versioned pg client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 # Install only production dependencies
 COPY --chown=node:node package*.json ./
 RUN npm ci --omit=dev --prefer-offline --no-audit \
-    && apk add --no-cache curl
+    && apk add --no-cache curl postgresql16-client
 
 # Copy application files and built assets from the builder stage
 COPY --chown=node:node --from=builder /app ./

--- a/README.md
+++ b/README.md
@@ -80,3 +80,11 @@ docker compose up --build
 The application uses PostgreSQL exclusively. The server waits for PostgreSQL to become reachable before starting so it may take a few seconds on first boot.
 
 The admin access code is displayed in the server logs and rotates every five minutes.
+Backup and restore operations rely on the `pg_dump` and `pg_restore` utilities.
+The Docker image installs `postgresql16-client` to provide these commands.
+When running the app without Docker, ensure `pg_dump` and `pg_restore`
+come from the same major version as your PostgreSQL server (for the provided
+docker setup this is version 16, installable as `postgresql16-client`).
+If your distribution installs versioned binaries under a directory like
+`/usr/lib/postgresql/16/bin`, set the `PG_DUMP` and `PG_RESTORE` environment
+variables to the full paths of those executables.

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const {
 const { settingsTemplate } = require('./settings-template');
 const { isTokenValid } = require('./auth-utils');
 // Databases are initialized in ./db using PostgreSQL
-const { users, lists, usersAsync, listsAsync, dataDir, ready, pool } = require('./db');
+const { users, lists, listItems, usersAsync, listsAsync, listItemsAsync, dataDir, ready, pool } = require('./db');
 
 
 // Map of SSE subscribers keyed by `${userId}:${listName}`
@@ -370,7 +370,7 @@ const apiRoutes = require("./routes/api");
 const deps = {
   htmlTemplate, registerTemplate, loginTemplate, forgotPasswordTemplate, resetPasswordTemplate, invalidTokenTemplate, spotifyTemplate, settingsTemplate, isTokenValid,
   csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest,
-  users, lists, usersAsync, listsAsync, upload, bcrypt, crypto, nodemailer,
+  users, lists, listItems, usersAsync, listsAsync, listItemsAsync, upload, bcrypt, crypto, nodemailer,
   composeForgotPasswordEmail, isValidEmail, isValidUsername, isValidPassword,
   broadcastListUpdate, listSubscribers, sanitizeUser, adminCodeAttempts, adminCode, adminCodeExpiry, generateAdminCode, lastCodeUsedBy, lastCodeUsedAt,
   dataDir, pool, passport

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,5 +1,13 @@
 module.exports = (app, deps) => {
-  const { csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest, users, lists, usersAsync, listsAsync, upload, adminCode, adminCodeExpiry, crypto } = deps;
+  const { csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest, users, lists, listItems, usersAsync, listsAsync, listItemsAsync, upload, adminCode, adminCodeExpiry, crypto } = deps;
+  const { spawn } = require('child_process');
+  const fs = require('fs');
+  const path = require('path');
+
+  const pgMajor = process.env.PG_MAJOR || '16';
+  const binDir = process.env.PG_BIN || `/usr/lib/postgresql/${pgMajor}/bin`;
+  const pgDumpCmd = fs.existsSync(path.join(binDir, 'pg_dump')) ? path.join(binDir, 'pg_dump') : (process.env.PG_DUMP || 'pg_dump');
+  const pgRestoreCmd = fs.existsSync(path.join(binDir, 'pg_restore')) ? path.join(binDir, 'pg_restore') : (process.env.PG_RESTORE || 'pg_restore');
 
 // ============ ADMIN API ENDPOINTS ============
 
@@ -302,106 +310,109 @@ app.get('/admin/export-users', ensureAuth, ensureAdmin, (req, res) => {
 });
 
 // Admin: Get user lists
-app.get('/admin/user-lists/:userId', ensureAuth, ensureAdmin, (req, res) => {
+app.get('/admin/user-lists/:userId', ensureAuth, ensureAdmin, async (req, res) => {
   const { userId } = req.params;
-  
-  lists.find({ userId }, (err, userLists) => {
-    if (err) {
-      console.error('Error fetching user lists:', err);
-      return res.status(500).json({ error: 'Error fetching user lists' });
+
+  try {
+    const userLists = await listsAsync.find({ userId });
+    const listsData = [];
+    for (const list of userLists) {
+      const count = await listItemsAsync.count({ listId: list._id });
+      listsData.push({
+        name: list.name,
+        albumCount: count,
+        createdAt: list.createdAt,
+        updatedAt: list.updatedAt
+      });
     }
-    
-    const listsData = userLists.map(list => ({
-      name: list.name,
-      albumCount: Array.isArray(list.data) ? list.data.length : 0,
-      createdAt: list.createdAt,
-      updatedAt: list.updatedAt
-    }));
-    
+
     res.json({ lists: listsData });
-  });
+  } catch (err) {
+    console.error('Error fetching user lists:', err);
+    res.status(500).json({ error: 'Error fetching user lists' });
+  }
 });
 
-// Admin: Database backup
-app.get('/admin/backup', ensureAuth, ensureAdmin, async (req, res) => {
+// Admin: Export database to JSON
+app.get('/admin/export', ensureAuth, ensureAdmin, async (req, res) => {
   try {
+    const listsData = await listsAsync.find({});
+    for (const l of listsData) {
+      const items = await listItemsAsync.find({ listId: l._id });
+      items.sort((a, b) => a.position - b.position);
+      l.data = items.map(it => ({
+        artist: it.artist,
+        album: it.album,
+        album_id: it.albumId,
+        release_date: it.releaseDate,
+        country: it.country,
+        genre_1: it.genre1,
+        genre_2: it.genre2,
+        comments: it.comments,
+        cover_image: it.coverImage,
+        cover_image_format: it.coverImageFormat
+      }));
+    }
     const backup = {
       exportDate: new Date().toISOString(),
       users: await usersAsync.find({}),
-      lists: await listsAsync.find({})
+      lists: listsData
     };
 
     res.setHeader('Content-Type', 'application/json');
-    res.setHeader('Content-Disposition', 'attachment; filename="sushe-backup.json"');
+    res.setHeader('Content-Disposition', 'attachment; filename="sushe-export.json"');
     res.send(JSON.stringify(backup, null, 2));
   } catch (error) {
-    console.error('Backup error:', error);
-    res.status(500).send('Error creating backup');
+    console.error('Export error:', error);
+    res.status(500).send('Error creating export');
   }
 });
 
-// Admin: Restore database
-app.post('/admin/restore', ensureAuth, ensureAdmin, upload.single('backup'), async (req, res) => {
-  try {
-    if (!req.file) {
-      return res.status(400).json({ error: 'No file uploaded' });
-    }
+// Admin: Backup entire database using pg_dump
+app.get('/admin/backup', ensureAuth, ensureAdmin, (req, res) => {
+  const dump = spawn(pgDumpCmd, ['-Fc', process.env.DATABASE_URL]);
+  res.setHeader('Content-Disposition', 'attachment; filename="sushe-db.dump"');
+  res.setHeader('Content-Type', 'application/octet-stream');
+  dump.stdout.pipe(res);
+  dump.stderr.on('data', d => console.error('pg_dump:', d.toString()));
+  dump.on('error', err => {
+    console.error('Backup error:', err);
+    res.status(500).send('Error creating backup');
+  });
+});
 
-    // Parse the JSON backup
-    let backup;
-    try {
-      backup = JSON.parse(req.file.buffer.toString());
-    } catch (parseError) {
-      console.error('Invalid backup file:', parseError);
-      return res.status(400).json({ error: 'Invalid backup file format' });
-    }
+// Admin: Restore database from pg_dump file
+const os = require('os');
 
-    // Validate backup structure
-    if (!backup.users || !backup.lists || !Array.isArray(backup.users) || !Array.isArray(backup.lists)) {
-      return res.status(400).json({ error: 'Invalid backup structure' });
-    }
-
-    console.log(`Restoring backup from ${backup.exportDate}`);
-    console.log(`Contains ${backup.users.length} users and ${backup.lists.length} lists`);
-
-    // Clear existing data
-    await usersAsync.remove({}, { multi: true });
-    await listsAsync.remove({}, { multi: true });
-
-    // Restore users and lists
-    const allowedUserFields = Object.keys(usersAsync.fieldMap);
-    const allowedListFields = Object.keys(listsAsync.fieldMap);
-
-    for (const user of backup.users) {
-      const sanitized = {};
-      for (const field of allowedUserFields) {
-        if (user[field] !== undefined) sanitized[field] = user[field];
-      }
-      await usersAsync.insert(sanitized);
-    }
-
-    for (const list of backup.lists) {
-      const sanitized = {};
-      for (const field of allowedListFields) {
-        if (list[field] !== undefined) sanitized[field] = list[field];
-      }
-      await listsAsync.insert(sanitized);
-    }
-
-    // Clear all sessions after restore
-    req.sessionStore.clear((err) => {
-      if (err) {
-        console.error('Error clearing sessions after restore:', err);
-      }
-    });
-
-    console.log(`Database restored successfully by ${req.user.email}`);
-    res.json({ success: true, message: 'Database restored successfully' });
-
-  } catch (error) {
-    console.error('Restore error:', error);
-    res.status(500).json({ error: 'Error restoring database' });
+app.post('/admin/restore', ensureAuth, ensureAdmin, upload.single('backup'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
   }
+
+  const tmpFile = path.join(os.tmpdir(), `sushe_restore_${Date.now()}.dump`);
+  fs.writeFileSync(tmpFile, req.file.buffer);
+
+  const restore = spawn(pgRestoreCmd, ['-c', '-d', process.env.DATABASE_URL, tmpFile]);
+
+  restore.stderr.on('data', data => console.error('pg_restore:', data.toString()));
+
+  restore.on('error', err => {
+    console.error('Restore error:', err);
+    res.status(500).json({ error: 'Error restoring database' });
+  });
+
+  restore.on('exit', code => {
+    fs.unlink(tmpFile, () => {});
+    if (code === 0) {
+      req.sessionStore.clear(err => {
+        if (err) console.error('Error clearing sessions after restore:', err);
+        res.json({ success: true, message: 'Database restored successfully' });
+      });
+    } else {
+      console.error('pg_restore exited with code', code);
+      res.status(500).json({ error: 'Error restoring database' });
+    }
+  });
 });
 
 // Admin: Clear all sessions

--- a/settings-template.js
+++ b/settings-template.js
@@ -427,13 +427,19 @@ const settingsTemplate = (req, options) => {
                   >
                     <i class="fas fa-download mr-2"></i>Export Users
                   </button>
-                  <button 
+                  <button
+                    onclick="if(confirm('Download database export as JSON?')) window.location.href='/admin/export'"
+                    class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded transition duration-200 text-sm"
+                  >
+                    <i class="fas fa-file-export mr-2"></i>Export Database
+                  </button>
+                  <button
                     onclick="if(confirm('Download complete database backup?')) window.location.href='/admin/backup'"
                     class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded transition duration-200 text-sm"
                   >
                     <i class="fas fa-database mr-2"></i>Backup Database
                   </button>
-                  <button 
+                  <button
                     onclick="showRestoreModal()"
                     class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded transition duration-200 text-sm"
                   >
@@ -555,12 +561,12 @@ const settingsTemplate = (req, options) => {
       <form id="restoreForm" enctype="multipart/form-data" class="p-6">
         <div class="mb-4">
           <label class="block text-sm font-medium text-gray-400 mb-2">
-            Select backup file (.json)
+            Select backup file (.dump)
           </label>
           <input 
             type="file" 
             name="backup"
-            accept=".json"
+            accept=".dump"
             required
             class="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-white file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-gray-700 file:text-white hover:file:bg-gray-600"
           >


### PR DESCRIPTION
## Summary
- configure `pg_dump`/`pg_restore` paths based on env vars and default
- save uploaded dump to a temp file for restore
- document using `PG_DUMP`/`PG_RESTORE` env vars when running locally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685032261b44832f94d33068ecc7bbc4