### PR TITLE
Add user-configurable time format

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -11,6 +11,7 @@ async function ensureTables(pool) {
     username TEXT UNIQUE,
     hash TEXT,
     accent_color TEXT,
+    time_format TEXT,
     last_selected_list TEXT,
     role TEXT,
     admin_granted_at TIMESTAMPTZ,
@@ -25,6 +26,7 @@ async function ensureTables(pool) {
   )`);
   await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS admin_granted_at TIMESTAMPTZ`);
   await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS last_activity TIMESTAMPTZ`);
+  await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS time_format TEXT`);
   await pool.query(`CREATE TABLE IF NOT EXISTS lists (
     id SERIAL PRIMARY KEY,
     _id TEXT UNIQUE NOT NULL,
@@ -73,6 +75,7 @@ if (process.env.DATABASE_URL) {
     username: 'username',
     hash: 'hash',
     accentColor: 'accent_color',
+    timeFormat: 'time_format',
     lastSelectedList: 'last_selected_list',
     role: 'role',
     adminGrantedAt: 'admin_granted_at',

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ function sanitizeUser(user) {
     email,
     username,
     accentColor,
+    timeFormat: user.timeFormat || '24h',
     lastSelectedList,
     role,
     spotifyAuth: !!user.spotifyAuth,

--- a/settings-template.js
+++ b/settings-template.js
@@ -1,5 +1,5 @@
 // Import the header component, and asset helper from templates
-const { headerComponent, asset } = require('./templates');
+const { headerComponent, asset, formatDateTime } = require('./templates');
 const { adjustColor, colorWithOpacity } = require('./color-utils');
 
 // Settings page template
@@ -267,6 +267,23 @@ const settingsTemplate = (req, options) => {
         </div>
         </div>
 
+        <!-- Time Format Settings -->
+        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+          <h3 class="text-lg font-semibold text-white mb-4">
+            <i class="fas fa-clock mr-2 text-gray-400"></i>
+            Time Format
+          </h3>
+          <div class="flex items-center gap-3">
+            <select id="timeFormatSelect" class="bg-gray-800 border border-gray-700 rounded text-white px-3 py-2">
+              <option value="24h" ${user.timeFormat !== '12h' ? 'selected' : ''}>24-hour</option>
+              <option value="12h" ${user.timeFormat === '12h' ? 'selected' : ''}>12-hour</option>
+            </select>
+            <button onclick="updateTimeFormat(document.getElementById('timeFormatSelect').value)" class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded transition duration-200">
+              Save
+            </button>
+          </div>
+        </div>
+
         <!-- Music Service Integration -->
         <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
           <h3 class="text-lg font-semibold text-white mb-4">
@@ -503,7 +520,7 @@ const settingsTemplate = (req, options) => {
                             }
                           </td>
                           <td class="py-3">
-                            <span class="text-sm text-gray-300">${u.lastActivity ? new Date(u.lastActivity).toLocaleString() : '-'}</span>
+                            <span class="text-sm text-gray-300">${u.lastActivity ? formatDateTime(u.lastActivity, user.timeFormat !== '24h') : '-'}</span>
                           </td>
                           <td class="py-3">
                             <div class="flex gap-2">
@@ -781,6 +798,29 @@ const settingsTemplate = (req, options) => {
     
     function resetAccentColor() {
       updateAccentColor('#dc2626');
+    }
+
+    async function updateTimeFormat(format) {
+      try {
+        const response = await fetch('/settings/update-time-format', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ timeFormat: format }),
+          credentials: 'same-origin'
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+          showToast('Time format updated!');
+          setTimeout(() => location.reload(), 500);
+        } else {
+          showToast(data.error || 'Error updating time format', 'error');
+        }
+      } catch (error) {
+        console.error('Error updating time format:', error);
+        showToast('Error updating time format', 'error');
+      }
     }
     
     // Client-side color adjustment function

--- a/templates.js
+++ b/templates.js
@@ -6,6 +6,19 @@ const ejs = require('ejs');
 const assetVersion = process.env.ASSET_VERSION || Date.now().toString();
 const asset = (p) => `${p}?v=${assetVersion}`;
 
+const formatDateTime = (date, hour12) => {
+  if (!date) return '';
+  const options = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12
+  };
+  return new Date(date).toLocaleString('en-US', options);
+};
+
 const viewsDir = path.join(__dirname, 'views');
 // Precompile EJS templates for caching
 const layoutTemplateFn = ejs.compile(
@@ -1322,6 +1335,7 @@ module.exports = {
   invalidTokenTemplate,
   spotifyTemplate,
   headerComponent,
+  formatDateTime,
   asset,
   assetVersion
 };


### PR DESCRIPTION
## Summary
- allow each user to choose 12h or 24h time format
- store the preference in the database and user model
- update settings page with new option
- show last activity using the selected format
- expose helper for date formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685060b7ec28832f947388f68a733ae0