### PR TITLE
Use Unix socket for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `Dockerfile` uses a multi-stage build. The `builder` stage installs all depe
 ## Environment variables
 - `SESSION_SECRET` – session encryption secret.
 - `DATA_DIR` – directory for session files (`./data` by default).
-- `DATABASE_URL` – PostgreSQL connection string.
+- `DATABASE_URL` – PostgreSQL connection string. The included Docker configuration uses a Unix socket at /var/run/postgresql by default.
 - `LOG_SQL` – set to `true` to print all SQL queries for debugging.
 - `SENDGRID_API_KEY` – optional API key for sending password reset emails. If omitted, reset links are logged to the console.
 - `BASE_URL` – base URL used in password reset emails (`http://localhost:3000` by default).
@@ -77,7 +77,7 @@ A `Dockerfile` and `docker-compose.yml` are included. You can build and start th
 docker compose up --build
 ```
 
-The application uses PostgreSQL exclusively. The server waits for PostgreSQL to become reachable before starting so it may take a few seconds on first boot.
+The application uses PostgreSQL exclusively. The compose file shares the database socket directory so the app connects via a Unix socket for improved performance. The server waits for PostgreSQL to become reachable before starting so it may take a few seconds on first boot.
 
 The admin access code is displayed in the server logs and rotates every five minutes.
 Backup and restore operations rely on the `pg_dump` and `pg_restore` utilities.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,10 @@ services:
       - SPOTIFY_REDIRECT_URI=${SPOTIFY_REDIRECT_URI}
       - TIDAL_CLIENT_ID=${TIDAL_CLIENT_ID}
       - TIDAL_REDIRECT_URI=${TIDAL_REDIRECT_URI}
-      - DATABASE_URL=postgres://postgres:example@db:5432/sushe
+      - DATABASE_URL=postgres://postgres:example@/sushe?host=/var/run/postgresql
     volumes:
       - sushe-data:/app/data
+      - postgres-socket:/var/run/postgresql
     depends_on:
       - db
     restart: unless-stopped
@@ -31,8 +32,10 @@ services:
       POSTGRES_DB: sushe
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - postgres-socket:/var/run/postgresql
 
 volumes:
   sushe-data:
   postgres-data:
+  postgres-socket:
 


### PR DESCRIPTION
## Summary
- connect to PostgreSQL over a shared Unix socket by default
- document new default socket connection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68507a9b685c832f86bf851c2a49b428