### PR TITLE
Improve responsiveness when switching lists

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1494,17 +1494,6 @@ async function selectList(listName) {
       localStorage.setItem('lastSelectedList', listName);
     }
     
-    // Save the last selected list to the server (keep existing code)
-    try {
-      await apiCall('/api/user/last-list', {
-        method: 'POST',
-        body: JSON.stringify({ listName })
-      });
-    } catch (error) {
-      // Don't block list selection if saving preference fails
-      console.warn('Failed to save list preference:', error);
-    }
-    
     // Update the header with current list name
     updateMobileHeader();
     
@@ -1521,6 +1510,16 @@ async function selectList(listName) {
     const fab = document.getElementById('addAlbumFAB');
     if (fab) {
       fab.style.display = listName ? 'flex' : 'none';
+    }
+
+    // Persist the selection without blocking UI
+    if (listName) {
+      apiCall('/api/user/last-list', {
+        method: 'POST',
+        body: JSON.stringify({ listName })
+      }).catch((error) => {
+        console.warn('Failed to save list preference:', error);
+      });
     }
     
   } catch (error) {

--- a/src/js/drag-drop.js
+++ b/src/js/drag-drop.js
@@ -14,12 +14,17 @@ const DragDropManager = (function() {
   // Cached rows for efficient lookups during drag
   let cachedRows = [];
 
+  // Prevent duplicate initialization
+  let initialized = false;
+
   // Initialize drag and drop for container
   function initialize() {
     const container = document.getElementById('albumContainer');
     if (!container) return;
 
-    
+    if (initialized) return;
+    initialized = true;
+
     container.addEventListener('dragover', handleContainerDragOver);
     container.addEventListener('dragleave', handleContainerDragLeave);
   }


### PR DESCRIPTION
## Summary
- do not wait for server when persisting last selected list
- avoid duplicate drag listeners on album container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68507e104388832fb3fe8373a442bc71