### PR TITLE
Improve responsiveness when switching lists

### DIFF
--- a/src/js/drag-drop.js
+++ b/src/js/drag-drop.js
@@ -14,12 +14,17 @@ const DragDropManager = (function() {
   // Cached rows for efficient lookups during drag
   let cachedRows = [];
 
+  // Prevent duplicate initialization
+  let initialized = false;
+
   // Initialize drag and drop for container
   function initialize() {
     const container = document.getElementById('albumContainer');
     if (!container) return;
 
-    
+    if (initialized) return;
+    initialized = true;
+
     container.addEventListener('dragover', handleContainerDragOver);
     container.addEventListener('dragleave', handleContainerDragLeave);
   }


### PR DESCRIPTION
## Summary
- do not wait for server when persisting last selected list
- avoid duplicate drag listeners on album container
- cache sidebar list names in localStorage for faster startup
- skip saving last list if it's already persisted

## Testing
- `npm test`
- `npm start` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507e104388832fb3fe8373a442bc71