### PR TITLE
Improve SSE responsiveness

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -111,6 +111,9 @@ app.post('/api/lists/:name', ensureAuthAPI, (req, res) => {
 
     const timestamp = new Date();
     if (existingList) {
+      // Broadcast immediately so other devices update without waiting
+      broadcastListUpdate(req.user._id, name, data);
+
       await lists.update(
         { _id: existingList._id },
         { $set: { updatedAt: timestamp } }
@@ -138,6 +141,9 @@ app.post('/api/lists/:name', ensureAuthAPI, (req, res) => {
       res.json({ success: true, message: 'List updated' });
       broadcastListUpdate(req.user._id, name, data);
     } else {
+      // Broadcast immediately so other devices update without waiting
+      broadcastListUpdate(req.user._id, name, data);
+
       const newList = await listsAsync.insert({
         userId: req.user._id,
         name,


### PR DESCRIPTION
## Summary
- broadcast list updates before the database save so devices on slower networks see reorders quicker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685095b4710c832fb6dab62d4d4d3467