### PR TITLE
Improve MusicBrainz track fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The `Dockerfile` uses a multi-stage build. The `builder` stage installs all depe
 - **User accounts** with registration, login and session handling using Passport.js and express-session.
 - **Password reset** via email using Nodemailer.
 - **Spotify-like interface** for browsing and editing your lists. Drag and drop albums to reorder and import data from MusicBrainz, iTunes and Deezer.
+- **Fetch track lists** from MusicBrainz when editing an album.
 - **Persistent storage** using PostgreSQL for all data.
 - **Admin mode** protected by a rotating access code printed to the server console. Admins can view site statistics, manage users and create backups.
 - **Custom theme** support allowing each user to pick an accent colour.

--- a/routes/api.js
+++ b/routes/api.js
@@ -527,4 +527,101 @@ app.get('/api/unfurl', ensureAuthAPI, async (req, res) => {
   }
 });
 
+// Fetch track list for a release group from MusicBrainz
+app.get('/api/musicbrainz/tracks', ensureAuthAPI, async (req, res) => {
+  const { id, artist, album } = req.query;
+  if (!id && (!artist || !album)) {
+    return res.status(400).json({ error: 'id or artist/album query required' });
+  }
+
+  const headers = { 'User-Agent': 'SuSheBot/1.0 (kvlt.example.com)' };
+
+  try {
+    let releaseGroupId = id;
+
+    const looksLikeMBID = (val) =>
+      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+        val || ''
+      );
+
+    if (!looksLikeMBID(releaseGroupId)) {
+      if (!artist || !album) {
+        return res.status(400).json({ error: 'artist and album are required' });
+      }
+
+      const query = `release:${album} AND artist:${artist}`;
+      const searchUrl =
+        `https://musicbrainz.org/ws/2/release-group/?query=${encodeURIComponent(query)}` +
+        `&type=album|ep&fmt=json&limit=5`;
+      const searchResp = await fetch(searchUrl, { headers });
+      if (!searchResp.ok) {
+        throw new Error(`MusicBrainz search responded ${searchResp.status}`);
+      }
+      const searchData = await searchResp.json();
+      const groups = searchData['release-groups'] || [];
+      if (!groups.length) {
+        return res.status(404).json({ error: 'Release group not found' });
+      }
+      releaseGroupId = groups[0].id;
+    }
+
+    const mbUrl =
+      `https://musicbrainz.org/ws/2/release?release-group=${releaseGroupId}` +
+      `&inc=recordings&fmt=json&limit=100`;
+    const resp = await fetch(mbUrl, { headers });
+    if (!resp.ok) {
+      throw new Error(`MusicBrainz responded ${resp.status}`);
+    }
+
+    const data = await resp.json();
+    if (!data.releases || !data.releases.length) {
+      return res.status(404).json({ error: 'No releases found' });
+    }
+
+    const EU = new Set([
+      'AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IE','IT',
+      'LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES','SE','GB','XE'
+    ]);
+
+    const score = (rel) => {
+      if (rel.status !== 'Official' || rel.status === 'Pseudo-Release') return -1;
+      let s = 0;
+      if (EU.has(rel.country)) s += 20;
+      if (rel.country === 'XW') s += 10;
+      if ((rel.media || []).some(m => (m.format || '').includes('Digital'))) s += 15;
+      const date = new Date(rel.date || '1900-01-01');
+      if (!isNaN(date)) s += date.getTime() / 1e10; // minor weight
+      return s;
+    };
+
+    const best = data.releases
+      .map(r => ({ ...r, _score: score(r) }))
+      .filter(r => r._score >= 0)
+      .sort((a, b) => b._score - a._score)[0];
+
+    if (!best || !best.media) {
+      return res.status(404).json({ error: 'No suitable release found' });
+    }
+
+    const tracks = [];
+    for (const medium of best.media) {
+      if (Array.isArray(medium.tracks)) {
+        medium.tracks.forEach(t => {
+          const title = t.title || (t.recording && t.recording.title) || '';
+          tracks.push(title);
+        });
+      }
+    }
+
+    if (!tracks.length) {
+      return res.status(404).json({ error: 'No tracks available' });
+    }
+
+    res.json({ tracks, releaseId: best.id });
+  } catch (err) {
+    console.error('MusicBrainz tracks error:', err);
+    res.status(500).json({ error: 'Failed to fetch tracks' });
+  }
+});
+
 };


### PR DESCRIPTION
## Summary
- include artist & album params when requesting tracks
- resolve release group via search when album ID isn't a MusicBrainz ID
- document track fetching in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68510f943a0c832fa72abf48275d8086