### PR TITLE
Auto fetch throttle improvements

### DIFF
--- a/src/js/musicbrainz.js
+++ b/src/js/musicbrainz.js
@@ -1150,7 +1150,13 @@ async function finishManualAdd(album) {
   try {
     // Add to current list
     window.lists[window.currentList].push(album);
-    
+
+    try {
+      await window.fetchTracksForAlbum(album);
+    } catch (err) {
+      console.error('Auto track fetch failed:', err);
+    }
+
     // Save to server
     await window.saveList(window.currentList, window.lists[window.currentList]);
     
@@ -1796,6 +1802,12 @@ async function addAlbumToList(releaseGroup) {
 async function addAlbumToCurrentList(album) {
   try {
     window.lists[window.currentList].push(album);
+
+    try {
+      await window.fetchTracksForAlbum(album);
+    } catch (err) {
+      console.error('Auto track fetch failed:', err);
+    }
 
     await window.saveList(window.currentList, window.lists[window.currentList]);
 


### PR DESCRIPTION
## Summary
- throttle all MusicBrainz fetches server-side with a shared queue
- wait 3 seconds between automatic track fetches on the client
- fetch tracks for new albums automatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68513f1b8fe0832fbbc76b187571883c