### PR TITLE
Skip fetching stored album tracks

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -725,18 +725,23 @@ function wait(ms) {
 async function autoFetchTracksForList(name) {
   const list = lists[name];
   if (!list) return;
+
+  const toFetch = list.filter(
+    (album) => !Array.isArray(album.tracks) || album.tracks.length === 0
+  );
+  if (toFetch.length === 0) return;
+
   let updated = false;
-  for (const album of list) {
-    if (!Array.isArray(album.tracks) || album.tracks.length === 0) {
-      try {
-        await fetchTracksForAlbum(album);
-        updated = true;
-      } catch (err) {
-        console.error('Auto track fetch failed:', err);
-      }
-      await wait(3000);
+  for (const album of toFetch) {
+    try {
+      await fetchTracksForAlbum(album);
+      updated = true;
+    } catch (err) {
+      console.error('Auto track fetch failed:', err);
     }
+    await wait(3000);
   }
+
   if (updated) {
     try {
       await saveList(name, list);

--- a/src/js/musicbrainz.js
+++ b/src/js/musicbrainz.js
@@ -1151,10 +1151,12 @@ async function finishManualAdd(album) {
     // Add to current list
     window.lists[window.currentList].push(album);
 
-    try {
-      await window.fetchTracksForAlbum(album);
-    } catch (err) {
-      console.error('Auto track fetch failed:', err);
+    if (!Array.isArray(album.tracks) || album.tracks.length === 0) {
+      try {
+        await window.fetchTracksForAlbum(album);
+      } catch (err) {
+        console.error('Auto track fetch failed:', err);
+      }
     }
 
     // Save to server
@@ -1803,10 +1805,12 @@ async function addAlbumToCurrentList(album) {
   try {
     window.lists[window.currentList].push(album);
 
-    try {
-      await window.fetchTracksForAlbum(album);
-    } catch (err) {
-      console.error('Auto track fetch failed:', err);
+    if (!Array.isArray(album.tracks) || album.tracks.length === 0) {
+      try {
+        await window.fetchTracksForAlbum(album);
+      } catch (err) {
+        console.error('Auto track fetch failed:', err);
+      }
     }
 
     await window.saveList(window.currentList, window.lists[window.currentList]);


### PR DESCRIPTION
## Summary
- optimize auto-fetch logic to skip albums that already include tracks
- avoid refetching tracks on manual additions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851478067f0832f8818d3beb1a4b651