### PR TITLE
Implement shared album records

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -59,6 +59,23 @@ async function ensureTables(pool) {
     updated_at TIMESTAMPTZ
   )`);
   await pool.query(`ALTER TABLE list_items ADD COLUMN IF NOT EXISTS tracks JSONB`);
+
+  // Albums table stores shared metadata reused across lists
+  await pool.query(`CREATE TABLE IF NOT EXISTS albums (
+    id SERIAL PRIMARY KEY,
+    _id TEXT UNIQUE NOT NULL,
+    artist TEXT,
+    album TEXT,
+    release_date TEXT,
+    country TEXT,
+    genre_1 TEXT,
+    genre_2 TEXT,
+    tracks JSONB,
+    cover_image TEXT,
+    cover_image_format TEXT,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+  )`);
 }
 
 const dataDir = process.env.DATA_DIR || './data';
@@ -67,7 +84,15 @@ if (!fs.existsSync(dataDir)) {
 }
 console.log('Initializing database layer');
 
-let users, lists, listItems, usersAsync, listsAsync, listItemsAsync, pool;
+let users,
+  lists,
+  listItems,
+  albums,
+  usersAsync,
+  listsAsync,
+  listItemsAsync,
+  albumsAsync,
+  pool;
 let ready = Promise.resolve();
 
 if (process.env.DATABASE_URL) {
@@ -119,12 +144,28 @@ if (process.env.DATABASE_URL) {
     createdAt: 'created_at',
     updatedAt: 'updated_at'
   };
+  const albumsMap = {
+    _id: '_id',
+    artist: 'artist',
+    album: 'album',
+    releaseDate: 'release_date',
+    country: 'country',
+    genre1: 'genre_1',
+    genre2: 'genre_2',
+    tracks: 'tracks',
+    coverImage: 'cover_image',
+    coverImageFormat: 'cover_image_format',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  };
   users = new PgDatastore(pool, 'users', usersMap);
   lists = new PgDatastore(pool, 'lists', listsMap);
   listItems = new PgDatastore(pool, 'list_items', listItemsMap);
+  albums = new PgDatastore(pool, 'albums', albumsMap);
   usersAsync = users;
   listsAsync = lists;
   listItemsAsync = listItems;
+  albumsAsync = albums;
   async function migrateUsers() {
     try {
       await users.update(
@@ -198,13 +239,64 @@ if (process.env.DATABASE_URL) {
     }
   }
 
+  async function migrateAlbums() {
+    const itemsRes = await pool.query(
+      'SELECT album_id, artist, album, release_date, country, genre_1, genre_2, tracks, cover_image, cover_image_format FROM list_items'
+    );
+    for (const row of itemsRes.rows) {
+      if (!row.album_id) continue;
+      let tracks = null;
+      if (row.tracks !== null && row.tracks !== undefined) {
+        if (Array.isArray(row.tracks) || typeof row.tracks === 'object') {
+          tracks = row.tracks;
+        } else if (typeof row.tracks === 'string' && row.tracks.trim() !== '') {
+          try {
+            tracks = JSON.parse(row.tracks);
+          } catch (err) {
+            console.warn('Skipping invalid tracks JSON for album', row.album_id);
+          }
+        }
+      }
+      await pool.query(
+        `INSERT INTO albums (_id, artist, album, release_date, country, genre_1, genre_2, tracks, cover_image, cover_image_format, created_at, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW(),NOW())
+         ON CONFLICT (_id) DO NOTHING`,
+        [
+          row.album_id,
+          row.artist || '',
+          row.album || '',
+          row.release_date || '',
+          row.country || '',
+          row.genre_1 || '',
+          row.genre_2 || '',
+          tracks,
+          row.cover_image || '',
+          row.cover_image_format || ''
+        ]
+      );
+    }
+  }
+
   ready = waitForPostgres(pool)
     .then(() => ensureTables(pool))
     .then(() => migrateLists())
+    .then(() => migrateAlbums())
     .then(() => migrateUsers())
     .then(() => console.log('Database ready'));
 } else {
   throw new Error('DATABASE_URL must be set');
 }
 
-module.exports = { users, lists, listItems, usersAsync, listsAsync, listItemsAsync, dataDir, ready, pool };
+module.exports = {
+  users,
+  lists,
+  listItems,
+  albums,
+  usersAsync,
+  listsAsync,
+  listItemsAsync,
+  albumsAsync,
+  dataDir,
+  ready,
+  pool
+};

--- a/index.js
+++ b/index.js
@@ -46,7 +46,19 @@ const {
 const { settingsTemplate } = require('./settings-template');
 const { isTokenValid } = require('./auth-utils');
 // Databases are initialized in ./db using PostgreSQL
-const { users, lists, listItems, usersAsync, listsAsync, listItemsAsync, dataDir, ready, pool } = require('./db');
+const {
+  users,
+  lists,
+  listItems,
+  albums,
+  usersAsync,
+  listsAsync,
+  listItemsAsync,
+  albumsAsync,
+  dataDir,
+  ready,
+  pool
+} = require('./db');
 
 
 // Map of SSE subscribers keyed by `${userId}:${listName}`
@@ -387,8 +399,23 @@ const apiRoutes = require("./routes/api");
 
 const deps = {
   htmlTemplate, registerTemplate, loginTemplate, forgotPasswordTemplate, resetPasswordTemplate, invalidTokenTemplate, spotifyTemplate, settingsTemplate, isTokenValid,
-  csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest,
-  users, lists, listItems, usersAsync, listsAsync, listItemsAsync, upload, bcrypt, crypto, nodemailer,
+  csrfProtection,
+  ensureAuth,
+  ensureAuthAPI,
+  ensureAdmin,
+  rateLimitAdminRequest,
+  users,
+  lists,
+  listItems,
+  albums,
+  usersAsync,
+  listsAsync,
+  listItemsAsync,
+  albumsAsync,
+  upload,
+  bcrypt,
+  crypto,
+  nodemailer,
   composeForgotPasswordEmail, isValidEmail, isValidUsername, isValidPassword,
   broadcastListUpdate, listSubscribers, sanitizeUser, adminCodeAttempts, adminCode, adminCodeExpiry, generateAdminCode, lastCodeUsedBy, lastCodeUsedAt,
   dataDir, pool, passport


### PR DESCRIPTION
## Summary
- add `albums` table for shared metadata
- migrate existing list items into the albums table
- update DB layer to expose new datastore
- wire albums datastore to route dependencies
- join album data when exporting lists or fetching list content
- update list creation to sync album details
- handle invalid tracks when migrating albums

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685149484098832fb2829865dead6bfe