### PR TITLE
Implement shared album records

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,19 @@ const {
 const { settingsTemplate } = require('./settings-template');
 const { isTokenValid } = require('./auth-utils');
 // Databases are initialized in ./db using PostgreSQL
-const { users, lists, listItems, usersAsync, listsAsync, listItemsAsync, dataDir, ready, pool } = require('./db');
+const {
+  users,
+  lists,
+  listItems,
+  albums,
+  usersAsync,
+  listsAsync,
+  listItemsAsync,
+  albumsAsync,
+  dataDir,
+  ready,
+  pool
+} = require('./db');
 
 
 // Map of SSE subscribers keyed by `${userId}:${listName}`
@@ -387,8 +399,23 @@ const apiRoutes = require("./routes/api");
 
 const deps = {
   htmlTemplate, registerTemplate, loginTemplate, forgotPasswordTemplate, resetPasswordTemplate, invalidTokenTemplate, spotifyTemplate, settingsTemplate, isTokenValid,
-  csrfProtection, ensureAuth, ensureAuthAPI, ensureAdmin, rateLimitAdminRequest,
-  users, lists, listItems, usersAsync, listsAsync, listItemsAsync, upload, bcrypt, crypto, nodemailer,
+  csrfProtection,
+  ensureAuth,
+  ensureAuthAPI,
+  ensureAdmin,
+  rateLimitAdminRequest,
+  users,
+  lists,
+  listItems,
+  albums,
+  usersAsync,
+  listsAsync,
+  listItemsAsync,
+  albumsAsync,
+  upload,
+  bcrypt,
+  crypto,
+  nodemailer,
   composeForgotPasswordEmail, isValidEmail, isValidUsername, isValidPassword,
   broadcastListUpdate, listSubscribers, sanitizeUser, adminCodeAttempts, adminCode, adminCodeExpiry, generateAdminCode, lastCodeUsedBy, lastCodeUsedAt,
   dataDir, pool, passport


### PR DESCRIPTION
## Summary
- add `albums` table for shared metadata
- migrate existing list items into the albums table
- update DB layer to expose new datastore
- wire albums datastore to route dependencies
- join album data when exporting lists or fetching list content
- update list creation to sync album details
- handle invalid tracks when migrating albums
- fix album updates so blank fields don't overwrite existing data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685149484098832fb2829865dead6bfe