### PR TITLE
Allow large database restores

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,16 @@ const compression = require('compression');
 const helmet = require('helmet');
 const csrf = require('csurf');
 const multer = require('multer');
+const os = require('os');
 const upload = multer({
-  storage: multer.memoryStorage(),
-  limits: { fileSize: 50 * 1024 * 1024 } // 50MB limit
+  storage: multer.diskStorage({
+    destination: os.tmpdir(),
+    filename: (req, file, cb) => {
+      const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+      cb(null, file.fieldname + '-' + unique + '.dump');
+    }
+  }),
+  limits: { fileSize: 1024 * 1024 * 1024 } // 1GB limit
 });
 // Log any unhandled errors so the server doesn't fail silently
 process.on('unhandledRejection', (err) => {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -397,8 +397,7 @@ app.post('/admin/restore', ensureAuth, ensureAdmin, upload.single('backup'), (re
     return res.status(400).json({ error: 'No file uploaded' });
   }
 
-  const tmpFile = path.join(os.tmpdir(), `sushe_restore_${Date.now()}.dump`);
-  fs.writeFileSync(tmpFile, req.file.buffer);
+  const tmpFile = req.file.path;
 
   const restore = spawn(pgRestoreCmd, ['-c', '-d', process.env.DATABASE_URL, tmpFile]);
 


### PR DESCRIPTION
## Summary
- switch multer to disk storage and increase file size limit to 1GB
- use the uploaded file directly when restoring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68519db9d834832f9e212fb62ef6e3e3