### PR TITLE
Fix header spacing and unify genre columns

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -186,10 +186,10 @@ body {
     padding-bottom: 0.375rem !important;
   }
   
-  /* Adjust header padding to match */
-  .album-grid.px-4.py-3 {
-    padding-top: 0.5rem !important;    /* Reduced from 0.625rem */
-    padding-bottom: 0.5rem !important;
+  /* Adjust header padding to match rows */
+  .album-header {
+    padding-top: 0.375rem !important;
+    padding-bottom: 0.375rem !important;
   }
 }
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1855,7 +1855,7 @@ function displayAlbums(albums) {
     
     // Header - using album-grid class
     const header = document.createElement('div');
-    header.className = 'album-grid gap-4 px-4 py-2 text-xs font-semibold uppercase tracking-wider text-gray-400 border-b border-gray-800 sticky top-0 bg-black z-10';
+    header.className = 'album-row album-header album-grid gap-4 px-4 py-2 text-sm font-semibold uppercase tracking-wider text-gray-400 border-b border-gray-800 sticky top-0 bg-black z-10';
     header.style.alignItems = 'center';
     header.innerHTML = `
       <div class="text-center">#</div>
@@ -1894,7 +1894,7 @@ function displayAlbums(albums) {
         genre2 = '';
       }
       const genre2Display = genre2 || 'Genre 2';
-      const genre2Class = genre2 ? 'text-gray-400' : 'text-gray-500 italic';
+      const genre2Class = genre2 ? 'text-gray-300' : 'text-gray-500 italic';
       
       let comment = album.comments || album.comment || '';
       if (comment === 'Comment') {


### PR DESCRIPTION
## Summary
- align album list header styling with album rows
- match `Genre 2` column's text style to `Genre 1`

## Testing
- `npm test`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_6851a21b6910832fabb6d3ad004f4005