### PR TITLE
Fix album container height on iOS

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -89,6 +89,9 @@ body {
   margin: 0;
   padding: 0;
   overflow: hidden;
+  height: 100vh;
+  height: 100dvh;
+  height: calc(var(--vh, 1vh) * 100);
 }
 
 .metal-title {
@@ -126,6 +129,7 @@ body {
 /* Enhanced album row styles */
 #albumContainer {
   min-height: 100vh;
+  min-height: 100dvh;
   min-height: calc(var(--vh, 1vh) * 100);
   position: relative;
 }

--- a/templates.js
+++ b/templates.js
@@ -891,6 +891,13 @@ const spotifyTemplate = (user) => `
       display: grid;
       grid-template-rows: auto 1fr;
       height: 100vh;
+      height: 100dvh;
+      height: calc(var(--vh, 1vh) * 100);
+    }
+
+    body {
+      height: 100vh;
+      height: 100dvh;
       height: calc(var(--vh, 1vh) * 100);
     }
     
@@ -1157,6 +1164,9 @@ const spotifyTemplate = (user) => `
     updateViewportHeight();
     window.addEventListener('resize', updateViewportHeight);
     window.addEventListener('orientationchange', updateViewportHeight);
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', updateViewportHeight);
+    }
     
     // Mobile menu toggle
     function toggleMobileMenu() {


### PR DESCRIPTION
## Summary
- ensure `<body>` fills the mobile viewport using dynamic units
- update inline template styles with the same dynamic height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68525037950c832fabc574feb33cd555