### PR TITLE
Fix mobile album height on iOS

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -92,6 +92,7 @@ body {
   height: 100vh;
   height: 100dvh;
   height: calc(var(--vh, 1vh) * 100);
+  height: -webkit-fill-available;
 }
 
 .metal-title {
@@ -131,6 +132,7 @@ body {
   min-height: 100vh;
   min-height: 100dvh;
   min-height: calc(var(--vh, 1vh) * 100);
+  min-height: -webkit-fill-available;
   position: relative;
 }
 

--- a/templates.js
+++ b/templates.js
@@ -893,12 +893,14 @@ const spotifyTemplate = (user) => `
       height: 100vh;
       height: 100dvh;
       height: calc(var(--vh, 1vh) * 100);
+      height: -webkit-fill-available;
     }
 
     body {
       height: 100vh;
       height: 100dvh;
       height: calc(var(--vh, 1vh) * 100);
+      height: -webkit-fill-available;
     }
     
     .main-content {


### PR DESCRIPTION
## Summary
- use `-webkit-fill-available` so iOS Safari calculates the full height
- update main layout styles with the same fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68525feb00ac832f8f99acf3d4e4e2bc