### PR TITLE
Fix mobile album height on iOS

### DIFF
--- a/public/styles/spotify-app.css
+++ b/public/styles/spotify-app.css
@@ -29,6 +29,8 @@
   /* Bottom padding for fixed nav */
   .main-content {
     padding-bottom: 4rem;
+    height: 100%;
+    height: -webkit-fill-available;
   }
 }
 
@@ -92,6 +94,7 @@ body {
   height: 100vh;
   height: 100dvh;
   height: calc(var(--vh, 1vh) * 100);
+  height: -webkit-fill-available;
 }
 
 .metal-title {
@@ -131,7 +134,33 @@ body {
   min-height: 100vh;
   min-height: 100dvh;
   min-height: calc(var(--vh, 1vh) * 100);
+  min-height: -webkit-fill-available;
+  height: 100%;
+  height: -webkit-fill-available;
   position: relative;
+}
+
+/* Mobile album list container */
+.mobile-album-list {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  height: 100%;
+  height: -webkit-fill-available;
+}
+
+main.flex-1 {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  height: -webkit-fill-available;
+}
+
+main.flex-1 > div.h-full {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 /* Subtle background enhancement for desktop only */

--- a/templates.js
+++ b/templates.js
@@ -893,18 +893,36 @@ const spotifyTemplate = (user) => `
       height: 100vh;
       height: 100dvh;
       height: calc(var(--vh, 1vh) * 100);
+      height: -webkit-fill-available;
     }
 
     body {
       height: 100vh;
       height: 100dvh;
       height: calc(var(--vh, 1vh) * 100);
+      height: -webkit-fill-available;
     }
     
     .main-content {
       display: grid;
       grid-template-columns: 0 1fr; /* Mobile: no sidebar */
       overflow: hidden;
+      height: 100%;
+      height: -webkit-fill-available;
+    }
+
+    main.flex-1 {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      height: -webkit-fill-available;
+    }
+
+    main.flex-1 > div.h-full {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
     }
     
     @media (min-width: 1024px) {
@@ -952,11 +970,15 @@ const spotifyTemplate = (user) => `
     /* Album container responsive padding */
     #albumContainer {
       padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+      height: 100%;
+      height: -webkit-fill-available;
     }
 
     @media (max-width: 1023px) {
       #albumContainer {
         padding-bottom: calc(5rem + env(safe-area-inset-bottom)); /* Space for FAB on mobile */
+        height: 100%;
+        height: -webkit-fill-available;
       }
     }
     


### PR DESCRIPTION
## Summary
- set album container and mobile list styles to fill available height
- adjust main layout styles so nested content uses flexbox and full height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68525feb00ac832f8f99acf3d4e4e2bc