### PR TITLE
Enable long press dragging on mobile

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2049,7 +2049,7 @@ function displayAlbums(albums) {
           </div>
 
           <!-- Album cover -->
-          <div class="flex-shrink-0 p-1 pl-0">
+          <div class="flex-shrink-0 p-2 pl-0">
             ${album.cover_image ? `
               <img src="data:image/${album.cover_image_format || 'PNG'};base64,${album.cover_image}"
                   alt="${albumName}"

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1389,15 +1389,16 @@ function initializeMobileSorting(container) {
   // Create sortable with enhanced settings
   const sortable = Sortable.create(sortableContainer, {
     animation: 150,
-    handle: '.drag-handle',
+    // Allow dragging the entire card but require a short press on touch devices
+    // Slightly shorter delay for easier triggering
+    delay: 200,
+    delayOnTouchOnly: true,
     preventOnFilter: true,
     forceFallback: true,
     fallbackClass: 'sortable-drag',
     ghostClass: 'sortable-ghost',
     chosenClass: 'sortable-chosen',
     dragClass: 'sortable-drag',
-    delay: 0,
-    delayOnTouchOnly: false,
     touchStartThreshold: 0,
     
     // Disable built-in auto-scroll
@@ -1407,6 +1408,10 @@ function initializeMobileSorting(container) {
       evt.item.dataset.originalIndex = evt.oldIndex;
       document.body.style.overflow = 'hidden';
       document.body.classList.add('sorting-active'); // Add this
+      // Small haptic feedback on supporting devices
+      if (navigator.vibrate) {
+        navigator.vibrate(10);
+      }
       lastTouchY = null;
       
       if (scrollableParent) {
@@ -2090,23 +2095,12 @@ function displayAlbums(albums) {
             </div>
           </div>
 
-          <!-- Actions and drag handle on the right -->
-          <div class="flex flex-col items-center flex-shrink-0 w-8 border-l border-gray-800/50">
+          <!-- Action button (dragging via long press on card) -->
+          <div class="flex items-center justify-center h-full flex-shrink-0 w-8 border-l border-gray-800/50">
             <button onclick="event.stopPropagation(); showMobileAlbumMenu(this)"
                     class="p-2 text-gray-400 active:text-gray-200">
               <i class="fas fa-ellipsis-v"></i>
             </button>
-            <div class="drag-handle flex-1 w-full flex items-center justify-center cursor-move select-none text-gray-600"
-                style="touch-action: none; -webkit-user-select: none; -webkit-touch-callout: none;">
-              <svg width="16" height="24" viewBox="0 0 16 24" fill="none" class="pointer-events-none opacity-50">
-                <circle cx="5" cy="6" r="1.5" fill="currentColor"/>
-                <circle cx="5" cy="12" r="1.5" fill="currentColor"/>
-                <circle cx="5" cy="18" r="1.5" fill="currentColor"/>
-                <circle cx="11" cy="6" r="1.5" fill="currentColor"/>
-                <circle cx="11" cy="12" r="1.5" fill="currentColor"/>
-                <circle cx="11" cy="18" r="1.5" fill="currentColor"/>
-              </svg>
-            </div>
           </div>
         </div>
       `;

--- a/templates.js
+++ b/templates.js
@@ -971,7 +971,8 @@ const spotifyTemplate = (user) => `
     }
     
     .sortable-chosen {
-      background-color: rgba(55, 65, 81, 0.5);
+      background-color: rgba(55, 65, 81, 0.6);
+      box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3) inset;
     }
     
     /* Touch optimization */


### PR DESCRIPTION
## Summary
- allow Sortable to start drag after a short touch-and-hold
- remove mobile drag handle and rely on long press anywhere on the card
- shorten touch delay and add haptic feedback
- highlight the card when drag begins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685280282cfc832fb5aa9d7c7979a015