### PR TITLE
Implement Material style for settings page

### DIFF
--- a/public/styles/settings-material.css
+++ b/public/styles/settings-material.css
@@ -1,0 +1,43 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
+
+body {
+  font-family: 'Roboto', sans-serif;
+}
+
+.settings-container {
+  margin-top: 24px;
+}
+
+.material-card {
+  background-color: #1e1e1e;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+
+.material-btn {
+  background-color: var(--accent-color);
+  color: #fff;
+}
+.material-btn:hover {
+  background-color: var(--accent-hover);
+}
+
+@media (min-width: 992px) {
+  .settings-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 991px) {
+  .material-card { margin-bottom: 16px; }
+  .settings-grid {
+    display: block;
+  }
+}
+
+button {
+  border-radius: 4px;
+  font-weight: 500;
+}
+

--- a/settings-template.js
+++ b/settings-template.js
@@ -17,6 +17,8 @@ const settingsTemplate = (req, options) => {
   <link rel="apple-touch-icon" href="/og-image.png">
   <link rel="manifest" href="/manifest.json">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link href="/styles/settings-material.css" rel="stylesheet">
   <link href="${asset('/styles/output.css')}" rel="stylesheet">
   <style>
     /* CSS Custom Properties for theming */
@@ -55,7 +57,7 @@ const settingsTemplate = (req, options) => {
   <div class="min-h-screen flex flex-col">
     ${headerComponent(user, 'settings')}
     
-    <div class="flex-1 p-4 lg:p-8 max-w-7xl mx-auto w-full">
+    <div class="settings-container container">
       <h1 class="text-3xl font-bold text-white mb-8">Settings</h1>
       
       <!-- Flash Messages -->
@@ -77,13 +79,13 @@ const settingsTemplate = (req, options) => {
         </div>
       ` : ''}
       
-      <div class="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+      <div class="settings-grid">
         <!-- Personal Settings Section -->
         <div class="space-y-6">
           <h2 class="text-xl font-semibold text-gray-300 mb-4">Personal Settings</h2>
           
           <!-- Account Info -->
-          <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+          <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
             <h3 class="text-lg font-semibold text-white mb-4">
               <i class="fas fa-user mr-2 text-gray-400"></i>
               Account Information
@@ -174,7 +176,7 @@ const settingsTemplate = (req, options) => {
           </div>
           
           <!-- Change Password -->
-          <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+          <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
             <h3 class="text-lg font-semibold text-white mb-4">
               <i class="fas fa-lock mr-2 text-gray-400"></i>
               Change Password
@@ -233,7 +235,7 @@ const settingsTemplate = (req, options) => {
           </div>
           
         <!-- Accent Color Settings -->
-        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+        <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
         <h3 class="text-lg font-semibold text-white mb-4">
             <i class="fas fa-palette mr-2 text-gray-400"></i>
             Theme Color
@@ -268,7 +270,7 @@ const settingsTemplate = (req, options) => {
         </div>
 
         <!-- Time & Date Format Settings -->
-        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+        <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
           <h3 class="text-lg font-semibold text-white mb-4">
             <i class="fas fa-clock mr-2 text-gray-400"></i>
             Time & Date Format
@@ -296,7 +298,7 @@ const settingsTemplate = (req, options) => {
         </div>
 
         <!-- Music Service Integration -->
-        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+        <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
           <h3 class="text-lg font-semibold text-white mb-4">
             <i class="fas fa-music mr-2 text-gray-400"></i>
             Music Services
@@ -338,7 +340,7 @@ const settingsTemplate = (req, options) => {
           <!-- Your Statistics -->
           <div>
             <h2 class="text-xl font-semibold text-gray-300 mb-4">Your Statistics</h2>
-            <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+            <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
               <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
                 <div>
                   <p class="text-gray-400 text-sm">Total Lists</p>
@@ -356,7 +358,7 @@ const settingsTemplate = (req, options) => {
             <!-- Request Admin Access -->
             <div>
               <h2 class="text-xl font-semibold text-gray-300 mb-4">Admin Access</h2>
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
                 <p class="text-sm text-gray-400 mb-4">
                   Enter the admin code to gain administrator privileges.
                 </p>
@@ -390,7 +392,7 @@ const settingsTemplate = (req, options) => {
               </h2>
               
               <!-- System Stats -->
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                 <h3 class="text-lg font-semibold text-white mb-4">System Statistics</h3>
                 <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
                   <div>
@@ -432,7 +434,7 @@ const settingsTemplate = (req, options) => {
               
               <!-- Top Genres -->
               ${stats.topGenres && stats.topGenres.length > 0 ? `
-                <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+                <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                   <h3 class="text-lg font-semibold text-white mb-4">Top Genres</h3>
                   <div class="space-y-2">
                     ${stats.topGenres.map((genre, index) => `
@@ -446,7 +448,7 @@ const settingsTemplate = (req, options) => {
               ` : ''}
               
               <!-- Admin Actions -->
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                 <h3 class="text-lg font-semibold text-white mb-4">Admin Actions</h3>
                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
                   <button 
@@ -484,7 +486,7 @@ const settingsTemplate = (req, options) => {
               
               <!-- Recent Activity -->
               ${adminData?.recentActivity ? `
-                <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+                <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                   <h3 class="text-lg font-semibold text-white mb-4">Recent Activity</h3>
                   <div class="space-y-3">
                     ${adminData.recentActivity.map(activity => `
@@ -499,7 +501,7 @@ const settingsTemplate = (req, options) => {
               ` : ''}
               
               <!-- User Management -->
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
                 <h3 class="text-lg font-semibold text-white mb-4">User Management</h3>
                 <div class="overflow-x-auto">
                   <table class="w-full">
@@ -1029,6 +1031,7 @@ const settingsTemplate = (req, options) => {
       });
     ` : ''}
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>
   `;


### PR DESCRIPTION
## Summary
- style settings page with Material design
- add Materialize CSS and custom style sheet
- use responsive grid layout for desktop and mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685278143e20832f931ccdbb1503a466