### PR TITLE
Improve settings organization

### DIFF
--- a/public/styles/settings-material.css
+++ b/public/styles/settings-material.css
@@ -1,0 +1,43 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
+
+body {
+  font-family: 'Roboto', sans-serif;
+}
+
+.settings-container {
+  margin-top: 24px;
+}
+
+.material-card {
+  background-color: #1e1e1e;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+
+.material-btn {
+  background-color: var(--accent-color);
+  color: #fff;
+}
+.material-btn:hover {
+  background-color: var(--accent-hover);
+}
+
+@media (min-width: 992px) {
+  .settings-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 991px) {
+  .material-card { margin-bottom: 16px; }
+  .settings-grid {
+    display: block;
+  }
+}
+
+button {
+  border-radius: 4px;
+  font-weight: 500;
+}
+

--- a/settings-template.js
+++ b/settings-template.js
@@ -17,6 +17,8 @@ const settingsTemplate = (req, options) => {
   <link rel="apple-touch-icon" href="/og-image.png">
   <link rel="manifest" href="/manifest.json">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link href="/styles/settings-material.css" rel="stylesheet">
   <link href="${asset('/styles/output.css')}" rel="stylesheet">
   <style>
     /* CSS Custom Properties for theming */
@@ -53,9 +55,9 @@ const settingsTemplate = (req, options) => {
 </head>
 <body class="bg-black text-gray-200">
   <div class="min-h-screen flex flex-col">
-    ${headerComponent(user, 'settings')}
+    ${headerComponent(user, 'settings', user.lastSelectedList || '')}
     
-    <div class="flex-1 p-4 lg:p-8 max-w-7xl mx-auto w-full">
+    <div class="settings-container container">
       <h1 class="text-3xl font-bold text-white mb-8">Settings</h1>
       
       <!-- Flash Messages -->
@@ -77,13 +79,13 @@ const settingsTemplate = (req, options) => {
         </div>
       ` : ''}
       
-      <div class="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
-        <!-- Personal Settings Section -->
+      <div class="settings-grid">
+        <!-- Account Settings -->
         <div class="space-y-6">
-          <h2 class="text-xl font-semibold text-gray-300 mb-4">Personal Settings</h2>
+          <h2 class="text-xl font-semibold text-gray-300 mb-4">Account Settings</h2>
           
           <!-- Account Info -->
-          <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+          <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
             <h3 class="text-lg font-semibold text-white mb-4">
               <i class="fas fa-user mr-2 text-gray-400"></i>
               Account Information
@@ -174,7 +176,7 @@ const settingsTemplate = (req, options) => {
           </div>
           
           <!-- Change Password -->
-          <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+          <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
             <h3 class="text-lg font-semibold text-white mb-4">
               <i class="fas fa-lock mr-2 text-gray-400"></i>
               Change Password
@@ -231,9 +233,14 @@ const settingsTemplate = (req, options) => {
               </button>
             </form>
           </div>
+        </div>
+
+        <!-- Appearance Settings -->
+        <div class="space-y-6">
+          <h2 class="text-xl font-semibold text-gray-300 mb-4">Appearance</h2>
           
         <!-- Accent Color Settings -->
-        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+        <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
         <h3 class="text-lg font-semibold text-white mb-4">
             <i class="fas fa-palette mr-2 text-gray-400"></i>
             Theme Color
@@ -268,7 +275,7 @@ const settingsTemplate = (req, options) => {
         </div>
 
         <!-- Time & Date Format Settings -->
-        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+        <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
           <h3 class="text-lg font-semibold text-white mb-4">
             <i class="fas fa-clock mr-2 text-gray-400"></i>
             Time & Date Format
@@ -294,9 +301,13 @@ const settingsTemplate = (req, options) => {
             </button>
           </div>
         </div>
+        </div>
+        <!-- Integrations -->
+        <div class="space-y-6">
+          <h2 class="text-xl font-semibold text-gray-300 mb-4">Integrations</h2>
 
         <!-- Music Service Integration -->
-        <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+        <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
           <h3 class="text-lg font-semibold text-white mb-4">
             <i class="fas fa-music mr-2 text-gray-400"></i>
             Music Services
@@ -332,13 +343,14 @@ const settingsTemplate = (req, options) => {
             </div>
           </div>
         </div>
+        </div>
 
         <!-- Statistics & Admin Section -->
         <div class="space-y-6">
           <!-- Your Statistics -->
           <div>
             <h2 class="text-xl font-semibold text-gray-300 mb-4">Your Statistics</h2>
-            <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+            <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
               <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
                 <div>
                   <p class="text-gray-400 text-sm">Total Lists</p>
@@ -356,7 +368,7 @@ const settingsTemplate = (req, options) => {
             <!-- Request Admin Access -->
             <div>
               <h2 class="text-xl font-semibold text-gray-300 mb-4">Admin Access</h2>
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
                 <p class="text-sm text-gray-400 mb-4">
                   Enter the admin code to gain administrator privileges.
                 </p>
@@ -390,7 +402,7 @@ const settingsTemplate = (req, options) => {
               </h2>
               
               <!-- System Stats -->
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                 <h3 class="text-lg font-semibold text-white mb-4">System Statistics</h3>
                 <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
                   <div>
@@ -432,7 +444,7 @@ const settingsTemplate = (req, options) => {
               
               <!-- Top Genres -->
               ${stats.topGenres && stats.topGenres.length > 0 ? `
-                <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+                <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                   <h3 class="text-lg font-semibold text-white mb-4">Top Genres</h3>
                   <div class="space-y-2">
                     ${stats.topGenres.map((genre, index) => `
@@ -446,7 +458,7 @@ const settingsTemplate = (req, options) => {
               ` : ''}
               
               <!-- Admin Actions -->
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                 <h3 class="text-lg font-semibold text-white mb-4">Admin Actions</h3>
                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
                   <button 
@@ -484,7 +496,7 @@ const settingsTemplate = (req, options) => {
               
               <!-- Recent Activity -->
               ${adminData?.recentActivity ? `
-                <div class="bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
+                <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800 mb-6">
                   <h3 class="text-lg font-semibold text-white mb-4">Recent Activity</h3>
                   <div class="space-y-3">
                     ${adminData.recentActivity.map(activity => `
@@ -499,7 +511,7 @@ const settingsTemplate = (req, options) => {
               ` : ''}
               
               <!-- User Management -->
-              <div class="bg-gray-900 rounded-lg p-6 border border-gray-800">
+              <div class="material-card bg-gray-900 rounded-lg p-6 border border-gray-800">
                 <h3 class="text-lg font-semibold text-white mb-4">User Management</h3>
                 <div class="overflow-x-auto">
                   <table class="w-full">
@@ -1029,6 +1041,7 @@ const settingsTemplate = (req, options) => {
       });
     ` : ''}
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>
   `;

--- a/templates.js
+++ b/templates.js
@@ -39,55 +39,40 @@ const loginSnippetFn = ejs.compile(
 
 // Shared header component
 const headerComponent = (user, activeSection = 'home', currentListName = '') => `
-  <header class="sticky top-0 bg-gray-900 border-b border-gray-800 z-50">
-    <!-- Desktop Header -->
-    <div class="hidden lg:flex items-center justify-between py-4 px-6">
-      <div class="flex items-center gap-8">
-        <a href="/" class="text-2xl font-bold text-red-600 hover:text-red-500 transition duration-200">SuShe</a>
-        <nav class="flex gap-6">
+  <header class="bg-gray-900 border-b border-gray-800 z-50">
+    <div class="flex items-center justify-between py-3 lg:py-4 px-3 lg:px-6">
+      <div class="flex items-center gap-2 lg:gap-8">
+        ${activeSection === 'home' ? `
+          <button onclick="toggleMobileMenu()" class="lg:hidden p-2 -m-2 text-gray-400 active:text-white touch-target">
+            <i class="fas fa-bars text-lg"></i>
+          </button>
+        ` : `
+          <a href="/" class="lg:hidden p-2 -m-2 text-gray-400 active:text-white touch-target">
+            <i class="fas fa-arrow-left text-lg"></i>
+          </a>
+        `}
+        <a href="/" class="text-xl lg:text-2xl font-bold text-red-600 hover:text-red-500 transition duration-200">SuShe</a>
+        <nav class="hidden lg:flex gap-6">
           <a href="/" class="${activeSection === 'home' ? 'text-red-600' : 'text-gray-300 hover:text-white'} transition duration-200">
             <i class="fas fa-home mr-2"></i>Home
           </a>
         </nav>
       </div>
-      
-      <div class="flex items-center gap-6">
-        <span class="text-sm text-gray-400">${user?.email}</span>
-        <a href="/logout" class="text-gray-400 hover:text-white transition duration-200" title="Logout">
-          <i class="fas fa-sign-out-alt text-lg"></i>
-        </a>
-        <a href="/settings" class="text-gray-400 hover:text-white transition duration-200" title="Settings">
-          <i class="fas fa-cog text-lg"></i>
-        </a>
-      </div>
-    </div>
-    
-    <!-- Mobile Header -->
-    <div class="lg:hidden flex items-center justify-between p-3 gap-2">
-      <div class="flex items-center gap-2 min-w-0">
+
+      <div class="mobile-only flex items-center gap-2 min-w-0 flex-1 mx-2">
         ${activeSection === 'home' ? `
-          <button onclick="toggleMobileLists()" class="p-2 -m-2 text-gray-400 active:text-white">
-            <i class="fas fa-bars text-lg"></i>
-          </button>
-        ` : `
-          <a href="/" class="p-2 -m-2 text-gray-400 active:text-white">
-            <i class="fas fa-arrow-left text-lg"></i>
-          </a>
-        `}
-        <a href="/" class="text-xl font-bold text-red-600 flex-shrink-0 ml-2">SuShe</a>
-        ${currentListName && activeSection === 'home' ? `
-          <span class="text-gray-600 flex-shrink-0">/</span>
-          <span class="text-sm text-yellow-500 font-medium truncate">${currentListName}</span>
+          <span id="headerListName" class="text-sm text-yellow-500 font-medium truncate ${currentListName ? '' : 'hidden'}">${currentListName}</span>
         ` : ''}
       </div>
-      
-      <div class="flex items-center gap-1 flex-shrink-0">
+
+      <div class="flex items-center gap-2 lg:gap-6">
+        <span class="hidden lg:inline text-sm text-gray-400">${user?.email}</span>
         ${activeSection !== 'settings' ? `
-          <a href="/settings" class="p-2 text-gray-400 active:text-white" title="Settings">
+          <a href="/settings" class="p-2 lg:p-0 text-gray-400 hover:text-white transition duration-200 touch-target" title="Settings">
             <i class="fas fa-cog text-lg"></i>
           </a>
         ` : ''}
-        <a href="/logout" class="p-2 text-gray-400 active:text-white" title="Logout">
+        <a href="/logout" class="p-2 lg:p-0 text-gray-400 hover:text-white transition duration-200 touch-target" title="Logout">
           <i class="fas fa-sign-out-alt text-lg"></i>
         </a>
       </div>
@@ -991,42 +976,7 @@ const spotifyTemplate = (user) => `
 <body class="bg-black text-gray-200">
   <div class="app-layout">
     <!-- Unified Header -->
-    <header class="bg-gray-900 border-b border-gray-800 z-50">
-      <div class="flex items-center justify-between py-3 lg:py-4 px-3 lg:px-6">
-        <!-- Mobile menu button / Desktop logo -->
-        <div class="flex items-center gap-2 lg:gap-8">
-          <button onclick="toggleMobileMenu()" class="lg:hidden p-2 -m-2 text-gray-400 active:text-white touch-target">
-            <i class="fas fa-bars text-lg"></i>
-          </button>
-          <a href="/" class="text-xl lg:text-2xl font-bold text-red-600 hover:text-red-500 transition duration-200">SuShe</a>
-          
-          <!-- Desktop navigation -->
-          <nav class="hidden lg:flex gap-6">
-            <a href="/" class="text-red-600 transition duration-200">
-              <i class="fas fa-home mr-2"></i>Home
-            </a>
-          </nav>
-        </div>
-        
-        <!-- Current list name (mobile only) -->
-        <div class="mobile-only flex items-center gap-2 min-w-0 flex-1 mx-2">
-          <span id="headerListName" class="text-sm text-yellow-500 font-medium truncate ${user.lastSelectedList ? '' : 'hidden'}">
-            ${user.lastSelectedList || ''}
-          </span>
-        </div>
-        
-        <!-- User menu -->
-        <div class="flex items-center gap-2 lg:gap-6">
-          <span class="hidden lg:inline text-sm text-gray-400">${user?.email}</span>
-          <a href="/settings" class="p-2 lg:p-0 text-gray-400 hover:text-white transition duration-200 touch-target" title="Settings">
-            <i class="fas fa-cog text-lg"></i>
-          </a>
-          <a href="/logout" class="p-2 lg:p-0 text-gray-400 hover:text-white transition duration-200 touch-target" title="Logout">
-            <i class="fas fa-sign-out-alt text-lg"></i>
-          </a>
-        </div>
-      </div>
-    </header>
+    ${headerComponent(user, 'home', user.lastSelectedList || '')}
     
     <!-- Main Content Area -->
     <div class="main-content">


### PR DESCRIPTION
## Summary
- group settings into Account, Appearance, and Integrations sections
- match settings header with the main page layout
- unify header code and show current list name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685278143e20832f931ccdbb1503a466