### PR TITLE
Add track selection in album editor

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -55,12 +55,14 @@ async function ensureTables(pool) {
     genre_2 TEXT,
     comments TEXT,
     tracks JSONB,
+    track_pick TEXT,
     cover_image TEXT,
     cover_image_format TEXT,
     created_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ
   )`);
   await pool.query(`ALTER TABLE list_items ADD COLUMN IF NOT EXISTS tracks JSONB`);
+  await pool.query(`ALTER TABLE list_items ADD COLUMN IF NOT EXISTS track_pick TEXT`);
   await pool.query(`CREATE INDEX IF NOT EXISTS idx_list_items_list_id ON list_items(list_id)`);
   await pool.query(`CREATE INDEX IF NOT EXISTS idx_list_items_album_id ON list_items(album_id)`);
 
@@ -160,6 +162,7 @@ if (process.env.DATABASE_URL) {
     genre2: 'genre_2',
     comments: 'comments',
     tracks: 'tracks',
+    trackPick: 'track_pick',
     coverImage: 'cover_image',
     coverImageFormat: 'cover_image_format',
     createdAt: 'created_at',
@@ -236,8 +239,8 @@ if (process.env.DATABASE_URL) {
         for (let i = 0; i < row.data.length; i++) {
           const album = row.data[i];
           await pool.query(
-            `INSERT INTO list_items (_id, list_id, position, artist, album, album_id, release_date, country, genre_1, genre_2, comments, tracks, cover_image, cover_image_format, created_at, updated_at)
-             VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW())`,
+            `INSERT INTO list_items (_id, list_id, position, artist, album, album_id, release_date, country, genre_1, genre_2, comments, tracks, track_pick, cover_image, cover_image_format, created_at, updated_at)
+             VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW(), NOW())`,
             [
               row._id,
               i + 1,
@@ -250,6 +253,7 @@ if (process.env.DATABASE_URL) {
               album.genre_2 || '',
               album.comments || album.comment || '',
               Array.isArray(album.tracks) ? album.tracks : null,
+              album.track_pick || null,
               album.cover_image || '',
               album.cover_image_format || ''
             ]

--- a/routes/api.js
+++ b/routes/api.js
@@ -84,6 +84,7 @@ app.get('/api/lists', ensureAuthAPI, (req, res) => {
           country: albumData?.country || item.country,
           genre_1: albumData?.genre1 || item.genre1,
           genre_2: albumData?.genre2 || item.genre2,
+          track_pick: item.trackPick,
           comments: item.comments,
           tracks: albumData?.tracks || item.tracks,
           cover_image: albumData?.coverImage || item.coverImage,
@@ -155,6 +156,7 @@ app.get('/api/lists/:name', ensureAuthAPI, (req, res) => {
         country: albumData?.country || item.country,
         genre_1: albumData?.genre1 || item.genre1,
         genre_2: albumData?.genre2 || item.genre2,
+        track_pick: item.trackPick,
         comments: item.comments,
         tracks: albumData?.tracks || item.tracks,
         cover_image: albumData?.coverImage || item.coverImage,
@@ -197,15 +199,15 @@ app.post('/api/lists/:name', ensureAuthAPI, (req, res) => {
         listId = resList.rows[0]._id;
       }
 
-      const placeholders = [];
-      const values = [];
-      let idx = 1;
-      for (let i = 0; i < data.length; i++) {
-        const album = data[i];
-        if (album.album_id) {
-          await upsertAlbumRecord(album, timestamp);
-        }
-        placeholders.push(`($${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++})`);
+        const placeholders = [];
+        const values = [];
+        let idx = 1;
+        for (let i = 0; i < data.length; i++) {
+          const album = data[i];
+          if (album.album_id) {
+            await upsertAlbumRecord(album, timestamp);
+          }
+        placeholders.push(`($${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++}, $${idx++})`);
         values.push(
           crypto.randomBytes(12).toString('hex'),
           listId,
@@ -219,6 +221,7 @@ app.post('/api/lists/:name', ensureAuthAPI, (req, res) => {
           album.genre_2 || '',
           album.comments || album.comment || '',
           Array.isArray(album.tracks) ? JSON.stringify(album.tracks) : null,
+          album.track_pick || null,
           album.cover_image || '',
           album.cover_image_format || '',
           timestamp,
@@ -228,7 +231,7 @@ app.post('/api/lists/:name', ensureAuthAPI, (req, res) => {
 
       if (placeholders.length) {
         await client.query(
-          `INSERT INTO list_items (_id, list_id, position, artist, album, album_id, release_date, country, genre_1, genre_2, comments, tracks, cover_image, cover_image_format, created_at, updated_at) VALUES ${placeholders.join(',')}`,
+          `INSERT INTO list_items (_id, list_id, position, artist, album, album_id, release_date, country, genre_1, genre_2, comments, tracks, track_pick, cover_image, cover_image_format, created_at, updated_at) VALUES ${placeholders.join(',')}`,
           values
         );
       }


### PR DESCRIPTION
## Summary
- allow storing a selected track for each list item
- expose track_pick field through list APIs
- extend mobile edit form with track selection via checkboxes or number input
- remove redundant track listing

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68529f174e48832f9c639628c32fb08c