### PR TITLE
Add preferred music service setting

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -19,6 +19,7 @@ async function ensureTables(pool) {
     spotify_auth JSONB,
     tidal_auth JSONB,
     tidal_country TEXT,
+    music_service TEXT,
     reset_token TEXT,
     reset_expires BIGINT,
     created_at TIMESTAMPTZ,
@@ -29,6 +30,7 @@ async function ensureTables(pool) {
   await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS last_activity TIMESTAMPTZ`);
   await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS time_format TEXT`);
   await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS date_format TEXT`);
+  await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS music_service TEXT`);
   await pool.query(`CREATE INDEX IF NOT EXISTS idx_users_reset_token ON users(reset_token)`);
   await pool.query(`CREATE INDEX IF NOT EXISTS idx_users_reset_token_expires ON users(reset_token, reset_expires)`);
   await pool.query(`CREATE TABLE IF NOT EXISTS lists (
@@ -135,6 +137,7 @@ if (process.env.DATABASE_URL) {
     spotifyAuth: 'spotify_auth',
     tidalAuth: 'tidal_auth',
     tidalCountry: 'tidal_country',
+    musicService: 'music_service',
     resetToken: 'reset_token',
     resetExpires: 'reset_expires',
     createdAt: 'created_at',
@@ -225,6 +228,12 @@ if (process.env.DATABASE_URL) {
       await users.update(
         { tidalCountry: { $exists: false } },
         { $set: { tidalCountry: null } },
+        { multi: true }
+      );
+
+      await users.update(
+        { musicService: { $exists: false } },
+        { $set: { musicService: null } },
         { multi: true }
       );
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -87,7 +87,8 @@ function sanitizeUser(user) {
     lastSelectedList,
     role,
     spotifyAuth: !!user.spotifyAuth,
-    tidalAuth: !!user.tidalAuth
+    tidalAuth: !!user.tidalAuth,
+    musicService: user.musicService || null
   };
 }
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -510,6 +510,39 @@ app.post('/settings/update-date-format', ensureAuth, async (req, res) => {
   }
 });
 
+// Update preferred music service endpoint
+app.post('/settings/update-music-service', ensureAuth, async (req, res) => {
+  try {
+    const { musicService } = req.body;
+    if (musicService && !['spotify', 'tidal'].includes(musicService)) {
+      return res.status(400).json({ error: 'Invalid music service' });
+    }
+
+    users.update(
+      { _id: req.user._id },
+      { $set: { musicService: musicService || null, updatedAt: new Date() } },
+      {},
+      (err) => {
+        if (err) {
+          console.error('Error updating music service:', err);
+          return res.status(500).json({ error: 'Error updating music service' });
+        }
+
+        req.user.musicService = musicService || null;
+        req.session.save((err) => {
+          if (err) console.error('Session save error:', err);
+          res.json({ success: true });
+        });
+
+        console.log(`User ${req.user.email} updated music service to ${musicService}`);
+      }
+    );
+  } catch (error) {
+    console.error('Update music service error:', error);
+    res.status(500).json({ error: 'Error updating music service' });
+  }
+});
+
 function getTimeAgo(date) {
   const seconds = Math.floor((new Date() - date) / 1000);
   

--- a/settings-template.js
+++ b/settings-template.js
@@ -327,8 +327,8 @@ const settingsTemplate = (req, options) => {
                 <a href="/auth/spotify" class="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-sm">Connect</a>
               `}
             </div>
-            <div class="flex items-center justify-between">
-              <span class="text-white">Tidal</span>
+              <div class="flex items-center justify-between">
+                <span class="text-white">Tidal</span>
               ${user.tidalAuth ? (
                 tidalValid ? `
                 <span class="text-green-500 text-sm mr-2">Connected</span>
@@ -340,10 +340,21 @@ const settingsTemplate = (req, options) => {
               ) : `
                 <a href="/auth/tidal" class="px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-sm">Connect</a>
               `}
+              </div>
+            </div>
+            <div class="mt-4">
+              <label class="block text-sm font-medium text-gray-400 mb-2">Preferred Service</label>
+              <div class="flex items-center gap-2">
+                <select id="musicServiceSelect" class="bg-gray-800 border border-gray-700 rounded text-white px-3 py-2">
+                  <option value="" ${!user.musicService ? 'selected' : ''}>Ask each time</option>
+                  <option value="spotify" ${user.musicService === 'spotify' ? 'selected' : ''} ${!user.spotifyAuth ? 'disabled' : ''}>Spotify</option>
+                  <option value="tidal" ${user.musicService === 'tidal' ? 'selected' : ''} ${!user.tidalAuth ? 'disabled' : ''}>Tidal</option>
+                </select>
+                <button onclick="updateMusicService(document.getElementById('musicServiceSelect').value)" class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded transition duration-200">Save</button>
+              </div>
             </div>
           </div>
-        </div>
-        </div>
+          </div>
 
         <!-- Statistics & Admin Section -->
         <div class="space-y-6">
@@ -866,6 +877,29 @@ const settingsTemplate = (req, options) => {
       } catch (error) {
         console.error('Error updating date format:', error);
         showToast('Error updating date format', 'error');
+      }
+    }
+
+    async function updateMusicService(service) {
+      try {
+        const response = await fetch('/settings/update-music-service', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ musicService: service }),
+          credentials: 'same-origin'
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+          showToast('Music service updated!');
+          setTimeout(() => location.reload(), 500);
+        } else {
+          showToast(data.error || 'Error updating music service', 'error');
+        }
+      } catch (error) {
+        console.error('Error updating music service:', error);
+        showToast('Error updating music service', 'error');
       }
     }
     

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -966,8 +966,15 @@ function playAlbum(index) {
 
   const hasSpotify = window.currentUser?.spotifyAuth;
   const hasTidal = window.currentUser?.tidalAuth;
+  const preferred = window.currentUser?.musicService;
 
   const chooseService = () => {
+    if (preferred === 'spotify' && hasSpotify) {
+      return Promise.resolve('spotify');
+    }
+    if (preferred === 'tidal' && hasTidal) {
+      return Promise.resolve('tidal');
+    }
     if (hasSpotify && hasTidal) {
       return showServicePicker(true, true);
     } else if (hasSpotify) {


### PR DESCRIPTION
## Summary
- allow a preferred music service per user
- handle new column in postgres and migrations
- expose new property in sanitized user object
- provide UI + API to choose a default service
- play albums automatically using the preferred service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852bb86a594832f8e82cd8dff754ad9