### PR TITLE
Continue module decomposition: extract list write operations

### DIFF
--- a/services/list-service.js
+++ b/services/list-service.js
@@ -8,6 +8,7 @@ const {
   createListManagementOperations,
 } = require('./list/management-operations');
 const { createSetupStatus } = require('./list/setup-status');
+const { createListWriteOperations } = require('./list/write-operations');
 const {
   validateYearNotLocked,
   validateMainListNotLocked,
@@ -135,6 +136,18 @@ function createListService(deps = {}) {
     deleteGroupIfEmptyAutoGroup,
   });
   const setupStatus = createSetupStatus({ pool });
+  const writeOperations = createListWriteOperations({
+    pool,
+    withTransaction,
+    TransactionAbort,
+    crypto,
+    managementOperations,
+    itemOperations,
+    findListByIdOrThrow,
+    findOrCreateYearGroup,
+    findOrCreateUncategorizedGroup,
+    logger: log,
+  });
 
   async function getAllLists(userId, { full = false } = {}) {
     return listFetchers.getAllLists(userId, { full });
@@ -165,90 +178,12 @@ function createListService(deps = {}) {
     userId,
     { name, groupId: requestGroupId, year, albums: rawAlbums }
   ) {
-    if (!name || typeof name !== 'string' || name.trim().length === 0) {
-      throw new TransactionAbort(400, { error: 'List name is required' });
-    }
-
-    const trimmedName = name.trim();
-    const listId = crypto.randomBytes(12).toString('hex');
-    const timestamp = new Date();
-
-    const listYear = await withTransaction(pool, async (client) => {
-      let resultYear = null;
-      let groupIdInternal;
-
-      if (requestGroupId) {
-        const groupResult = await client.query(
-          `SELECT id, year FROM list_groups WHERE _id = $1 AND user_id = $2`,
-          [requestGroupId, userId]
-        );
-        if (groupResult.rows.length === 0) {
-          throw new TransactionAbort(400, { error: 'Invalid group' });
-        }
-        groupIdInternal = groupResult.rows[0].id;
-        resultYear = groupResult.rows[0].year;
-      } else if (year !== undefined && year !== null) {
-        const yearGroup = await findOrCreateYearGroup(client, userId, year);
-        groupIdInternal = yearGroup.groupId;
-        resultYear = yearGroup.year;
-      } else {
-        groupIdInternal = await findOrCreateUncategorizedGroup(client, userId);
-      }
-
-      await managementOperations.checkDuplicateListName(
-        client,
-        userId,
-        trimmedName,
-        groupIdInternal
-      );
-
-      const maxListOrder = await client.query(
-        `SELECT COALESCE(MAX(sort_order), -1) + 1 as next_order FROM lists WHERE group_id = $1`,
-        [groupIdInternal]
-      );
-
-      await client.query(
-        `INSERT INTO lists (_id, user_id, name, year, group_id, is_main, sort_order, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, FALSE, $6, $7, $8)`,
-        [
-          listId,
-          userId,
-          trimmedName,
-          resultYear,
-          groupIdInternal,
-          maxListOrder.rows[0].next_order,
-          timestamp,
-          timestamp,
-        ]
-      );
-
-      if (rawAlbums && Array.isArray(rawAlbums)) {
-        await itemOperations.insertListItems(
-          client,
-          listId,
-          rawAlbums,
-          timestamp
-        );
-      }
-
-      return resultYear;
+    return writeOperations.createList(userId, {
+      name,
+      groupId: requestGroupId,
+      year,
+      albums: rawAlbums,
     });
-
-    log.info('List created', {
-      userId,
-      listId,
-      listName: trimmedName,
-      year: listYear,
-      albumCount: rawAlbums?.length || 0,
-    });
-
-    return {
-      listId,
-      name: trimmedName,
-      year: listYear,
-      groupId: requestGroupId || null,
-      count: rawAlbums?.length || 0,
-    };
   }
 
   async function updateListMetadata(
@@ -264,138 +199,11 @@ function createListService(deps = {}) {
   }
 
   async function replaceListItems(listId, userId, rawAlbums) {
-    const list = await findListByIdOrThrow(listId, userId, 'modify list items');
-    const timestamp = new Date();
-
-    await withTransaction(pool, async (client) => {
-      await client.query('DELETE FROM list_items WHERE list_id = $1', [
-        list._id,
-      ]);
-
-      await itemOperations.insertListItems(
-        client,
-        list._id,
-        rawAlbums,
-        timestamp
-      );
-
-      await client.query('UPDATE lists SET updated_at = $1 WHERE _id = $2', [
-        timestamp,
-        list._id,
-      ]);
-    });
-
-    log.info('List items replaced', {
-      userId,
-      listId,
-      listName: list.name,
-      albumCount: rawAlbums.length,
-    });
-
-    return { list, count: rawAlbums.length };
+    return writeOperations.replaceListItems(listId, userId, rawAlbums);
   }
 
   async function reorderItems(listId, userId, order) {
-    if (!Array.isArray(order)) {
-      throw new TransactionAbort(400, { error: 'Invalid order array' });
-    }
-
-    const list = await findListByIdOrThrow(
-      listId,
-      userId,
-      'reorder list items'
-    );
-
-    let effectivePos = 0;
-
-    await withTransaction(pool, async (client) => {
-      const now = new Date();
-
-      const listItemsResult = await client.query(
-        'SELECT _id, album_id FROM list_items WHERE list_id = $1',
-        [list._id]
-      );
-      const listItems = listItemsResult.rows;
-
-      if (listItems.length === 0) {
-        if (order.length > 0) {
-          throw new TransactionAbort(400, {
-            error: 'Order must be empty for a list with no items',
-          });
-        }
-        effectivePos = 0;
-        return;
-      }
-
-      const itemIdsByAlbumId = new Map();
-      const validItemIds = new Set();
-      for (const item of listItems) {
-        validItemIds.add(item._id);
-        if (item.album_id) {
-          itemIdsByAlbumId.set(item.album_id, item._id);
-        }
-      }
-
-      const orderedItemIds = [];
-      for (const entry of order) {
-        if (typeof entry === 'string') {
-          const resolvedItemId = itemIdsByAlbumId.get(entry);
-          if (!resolvedItemId) {
-            throw new TransactionAbort(400, {
-              error: `Album '${entry}' is not in this list`,
-            });
-          }
-          orderedItemIds.push(resolvedItemId);
-          continue;
-        }
-
-        if (entry && typeof entry === 'object' && entry._id) {
-          if (!validItemIds.has(entry._id)) {
-            throw new TransactionAbort(400, {
-              error: `Item '${entry._id}' is not in this list`,
-            });
-          }
-          orderedItemIds.push(entry._id);
-          continue;
-        }
-
-        throw new TransactionAbort(400, {
-          error: 'Order contains invalid entries',
-        });
-      }
-
-      if (new Set(orderedItemIds).size !== orderedItemIds.length) {
-        throw new TransactionAbort(400, {
-          error: 'Order cannot contain duplicate entries',
-        });
-      }
-
-      if (orderedItemIds.length !== listItems.length) {
-        throw new TransactionAbort(400, {
-          error: 'Order must include all list items exactly once',
-        });
-      }
-
-      const positionValues = orderedItemIds.map((_, index) => index + 1);
-      await client.query(
-        `UPDATE list_items
-         SET position = t.position, updated_at = $1
-         FROM UNNEST($2::text[], $3::int[]) AS t(item_id, position)
-         WHERE list_items._id = t.item_id AND list_items.list_id = $4`,
-        [now, orderedItemIds, positionValues, list._id]
-      );
-
-      effectivePos = orderedItemIds.length;
-    });
-
-    log.info('List reordered', {
-      userId,
-      listId,
-      listName: list.name,
-      itemCount: effectivePos,
-    });
-
-    return { list, itemCount: effectivePos };
+    return writeOperations.reorderItems(listId, userId, order);
   }
 
   async function updateItemComment(listId, userId, identifier, comment) {
@@ -424,58 +232,12 @@ function createListService(deps = {}) {
     { added, removed, updated },
     user
   ) {
-    const list = await findListByIdOrThrow(listId, userId, 'modify list items');
-
-    const timestamp = new Date();
-    let changeCount = 0;
-    const addedItems = [];
-    const duplicateAlbums = [];
-
-    await withTransaction(pool, async (client) => {
-      changeCount += await itemOperations.processRemovals(
-        client,
-        list._id,
-        removed
-      );
-
-      const addResult = await itemOperations.processAdditions(
-        client,
-        list,
-        added,
-        timestamp
-      );
-      addedItems.push(...addResult.addedItems);
-      duplicateAlbums.push(...addResult.duplicateAlbums);
-      changeCount += addResult.changeCount;
-
-      changeCount += await itemOperations.processPositionUpdates(
-        client,
-        list._id,
-        updated,
-        timestamp
-      );
-
-      await client.query('UPDATE lists SET updated_at = $1 WHERE _id = $2', [
-        timestamp,
-        list._id,
-      ]);
-    });
-
-    log.info('List incrementally updated', {
-      userId,
+    return writeOperations.incrementalUpdate(
       listId,
-      listName: list.name,
-      added: added?.length || 0,
-      removed: removed?.length || 0,
-      updated: updated?.length || 0,
-      totalChanges: changeCount,
-      duplicates: duplicateAlbums?.length || 0,
-    });
-
-    // Trigger async playcount refresh for newly added albums
-    itemOperations.triggerPlaycountRefresh(user, addedItems);
-
-    return { list, changeCount, addedItems, duplicateAlbums };
+      userId,
+      { added, removed, updated },
+      user
+    );
   }
 
   async function toggleMainStatus(listId, userId, isMain) {

--- a/services/list/write-operations.js
+++ b/services/list/write-operations.js
@@ -1,0 +1,239 @@
+const { reorderItems } = require('./write/reorder-items');
+
+function createListWriteOperations(deps = {}) {
+  const {
+    pool,
+    withTransaction,
+    TransactionAbort,
+    crypto,
+    managementOperations,
+    itemOperations,
+    findListByIdOrThrow,
+    findOrCreateYearGroup,
+    findOrCreateUncategorizedGroup,
+    logger,
+  } = deps;
+
+  if (!pool) throw new Error('pool is required');
+  if (typeof withTransaction !== 'function') {
+    throw new Error('withTransaction is required');
+  }
+  if (!TransactionAbort) throw new Error('TransactionAbort is required');
+  if (!crypto) throw new Error('crypto is required');
+  if (!managementOperations)
+    throw new Error('managementOperations is required');
+  if (!itemOperations) throw new Error('itemOperations is required');
+  if (typeof findListByIdOrThrow !== 'function') {
+    throw new Error('findListByIdOrThrow is required');
+  }
+  if (typeof findOrCreateYearGroup !== 'function') {
+    throw new Error('findOrCreateYearGroup is required');
+  }
+  if (typeof findOrCreateUncategorizedGroup !== 'function') {
+    throw new Error('findOrCreateUncategorizedGroup is required');
+  }
+
+  async function createList(
+    userId,
+    { name, groupId: requestGroupId, year, albums: rawAlbums }
+  ) {
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw new TransactionAbort(400, { error: 'List name is required' });
+    }
+
+    const trimmedName = name.trim();
+    const listId = crypto.randomBytes(12).toString('hex');
+    const timestamp = new Date();
+
+    const listYear = await withTransaction(pool, async (client) => {
+      let resultYear = null;
+      let groupIdInternal;
+
+      if (requestGroupId) {
+        const groupResult = await client.query(
+          `SELECT id, year FROM list_groups WHERE _id = $1 AND user_id = $2`,
+          [requestGroupId, userId]
+        );
+        if (groupResult.rows.length === 0) {
+          throw new TransactionAbort(400, { error: 'Invalid group' });
+        }
+        groupIdInternal = groupResult.rows[0].id;
+        resultYear = groupResult.rows[0].year;
+      } else if (year !== undefined && year !== null) {
+        const yearGroup = await findOrCreateYearGroup(client, userId, year);
+        groupIdInternal = yearGroup.groupId;
+        resultYear = yearGroup.year;
+      } else {
+        groupIdInternal = await findOrCreateUncategorizedGroup(client, userId);
+      }
+
+      await managementOperations.checkDuplicateListName(
+        client,
+        userId,
+        trimmedName,
+        groupIdInternal
+      );
+
+      const maxListOrder = await client.query(
+        `SELECT COALESCE(MAX(sort_order), -1) + 1 as next_order FROM lists WHERE group_id = $1`,
+        [groupIdInternal]
+      );
+
+      await client.query(
+        `INSERT INTO lists (_id, user_id, name, year, group_id, is_main, sort_order, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, FALSE, $6, $7, $8)`,
+        [
+          listId,
+          userId,
+          trimmedName,
+          resultYear,
+          groupIdInternal,
+          maxListOrder.rows[0].next_order,
+          timestamp,
+          timestamp,
+        ]
+      );
+
+      if (rawAlbums && Array.isArray(rawAlbums)) {
+        await itemOperations.insertListItems(
+          client,
+          listId,
+          rawAlbums,
+          timestamp
+        );
+      }
+
+      return resultYear;
+    });
+
+    logger?.info('List created', {
+      userId,
+      listId,
+      listName: trimmedName,
+      year: listYear,
+      albumCount: rawAlbums?.length || 0,
+    });
+
+    return {
+      listId,
+      name: trimmedName,
+      year: listYear,
+      groupId: requestGroupId || null,
+      count: rawAlbums?.length || 0,
+    };
+  }
+
+  async function replaceListItems(listId, userId, rawAlbums) {
+    const list = await findListByIdOrThrow(listId, userId, 'modify list items');
+    const timestamp = new Date();
+
+    await withTransaction(pool, async (client) => {
+      await client.query('DELETE FROM list_items WHERE list_id = $1', [
+        list._id,
+      ]);
+
+      await itemOperations.insertListItems(
+        client,
+        list._id,
+        rawAlbums,
+        timestamp
+      );
+
+      await client.query('UPDATE lists SET updated_at = $1 WHERE _id = $2', [
+        timestamp,
+        list._id,
+      ]);
+    });
+
+    logger?.info('List items replaced', {
+      userId,
+      listId,
+      listName: list.name,
+      albumCount: rawAlbums.length,
+    });
+
+    return { list, count: rawAlbums.length };
+  }
+
+  async function incrementalUpdate(
+    listId,
+    userId,
+    { added, removed, updated },
+    user
+  ) {
+    const list = await findListByIdOrThrow(listId, userId, 'modify list items');
+
+    const timestamp = new Date();
+    let changeCount = 0;
+    const addedItems = [];
+    const duplicateAlbums = [];
+
+    await withTransaction(pool, async (client) => {
+      changeCount += await itemOperations.processRemovals(
+        client,
+        list._id,
+        removed
+      );
+
+      const addResult = await itemOperations.processAdditions(
+        client,
+        list,
+        added,
+        timestamp
+      );
+      addedItems.push(...addResult.addedItems);
+      duplicateAlbums.push(...addResult.duplicateAlbums);
+      changeCount += addResult.changeCount;
+
+      changeCount += await itemOperations.processPositionUpdates(
+        client,
+        list._id,
+        updated,
+        timestamp
+      );
+
+      await client.query('UPDATE lists SET updated_at = $1 WHERE _id = $2', [
+        timestamp,
+        list._id,
+      ]);
+    });
+
+    logger?.info('List incrementally updated', {
+      userId,
+      listId,
+      listName: list.name,
+      added: added?.length || 0,
+      removed: removed?.length || 0,
+      updated: updated?.length || 0,
+      totalChanges: changeCount,
+      duplicates: duplicateAlbums?.length || 0,
+    });
+
+    itemOperations.triggerPlaycountRefresh(user, addedItems);
+
+    return { list, changeCount, addedItems, duplicateAlbums };
+  }
+
+  return {
+    createList,
+    replaceListItems,
+    reorderItems: (listId, userId, order) =>
+      reorderItems(
+        {
+          pool,
+          withTransaction,
+          TransactionAbort,
+          findListByIdOrThrow,
+          logger,
+        },
+        listId,
+        userId,
+        order
+      ),
+    incrementalUpdate,
+  };
+}
+
+module.exports = {
+  createListWriteOperations,
+};

--- a/services/list/write/reorder-items.js
+++ b/services/list/write/reorder-items.js
@@ -1,0 +1,106 @@
+async function reorderItems(ctx, listId, userId, order) {
+  if (!Array.isArray(order)) {
+    throw new ctx.TransactionAbort(400, { error: 'Invalid order array' });
+  }
+
+  const list = await ctx.findListByIdOrThrow(
+    listId,
+    userId,
+    'reorder list items'
+  );
+
+  let effectivePos = 0;
+
+  await ctx.withTransaction(ctx.pool, async (client) => {
+    const now = new Date();
+
+    const listItemsResult = await client.query(
+      'SELECT _id, album_id FROM list_items WHERE list_id = $1',
+      [list._id]
+    );
+    const listItems = listItemsResult.rows;
+
+    if (listItems.length === 0) {
+      if (order.length > 0) {
+        throw new ctx.TransactionAbort(400, {
+          error: 'Order must be empty for a list with no items',
+        });
+      }
+      effectivePos = 0;
+      return;
+    }
+
+    const itemIdsByAlbumId = new Map();
+    const validItemIds = new Set();
+    for (const item of listItems) {
+      validItemIds.add(item._id);
+      if (item.album_id) {
+        itemIdsByAlbumId.set(item.album_id, item._id);
+      }
+    }
+
+    const orderedItemIds = [];
+    for (const entry of order) {
+      if (typeof entry === 'string') {
+        const resolvedItemId = itemIdsByAlbumId.get(entry);
+        if (!resolvedItemId) {
+          throw new ctx.TransactionAbort(400, {
+            error: `Album '${entry}' is not in this list`,
+          });
+        }
+        orderedItemIds.push(resolvedItemId);
+        continue;
+      }
+
+      if (entry && typeof entry === 'object' && entry._id) {
+        if (!validItemIds.has(entry._id)) {
+          throw new ctx.TransactionAbort(400, {
+            error: `Item '${entry._id}' is not in this list`,
+          });
+        }
+        orderedItemIds.push(entry._id);
+        continue;
+      }
+
+      throw new ctx.TransactionAbort(400, {
+        error: 'Order contains invalid entries',
+      });
+    }
+
+    if (new Set(orderedItemIds).size !== orderedItemIds.length) {
+      throw new ctx.TransactionAbort(400, {
+        error: 'Order cannot contain duplicate entries',
+      });
+    }
+
+    if (orderedItemIds.length !== listItems.length) {
+      throw new ctx.TransactionAbort(400, {
+        error: 'Order must include all list items exactly once',
+      });
+    }
+
+    const positionValues = orderedItemIds.map((_, index) => index + 1);
+    await client.query(
+      `UPDATE list_items
+       SET position = t.position, updated_at = $1
+       FROM UNNEST($2::text[], $3::int[]) AS t(item_id, position)
+       WHERE list_items._id = t.item_id AND list_items.list_id = $4`,
+      [now, orderedItemIds, positionValues, list._id]
+    );
+
+    effectivePos = orderedItemIds.length;
+  });
+
+  ctx.logger?.info('List reordered', {
+    userId,
+    listId,
+    listName: list.name,
+    itemCount: effectivePos,
+  });
+
+  return { list, itemCount: effectivePos };
+}
+
+module.exports = {
+  reorderItems,
+};

--- a/test/list-service.test.js
+++ b/test/list-service.test.js
@@ -581,3 +581,95 @@ describe('list-service management operations', () => {
     );
   });
 });
+
+describe('list-service write operations', () => {
+  it('createList should create an uncategorized list without albums', async () => {
+    const client = {
+      query: mock.fn(async (sql) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.startsWith('SELECT 1 FROM lists WHERE user_id = $1')) {
+          return { rows: [] };
+        }
+
+        if (sql.includes('SELECT COALESCE(MAX(sort_order), -1) + 1')) {
+          return { rows: [{ next_order: 3 }] };
+        }
+
+        if (sql.startsWith('INSERT INTO lists')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        throw new Error(`Unexpected query: ${sql}`);
+      }),
+      release: mock.fn(),
+    };
+
+    const pool = {
+      query: mock.fn(async (sql) => {
+        throw new Error(`Unexpected pool query: ${sql}`);
+      }),
+      connect: mock.fn(async () => client),
+    };
+
+    const deps = createServiceDeps(pool);
+    deps.helpers.findOrCreateUncategorizedGroup = mock.fn(async () => 42);
+
+    const service = createListService(deps);
+    const result = await service.createList('user1', { name: 'New List' });
+
+    assert.strictEqual(result.name, 'New List');
+    assert.strictEqual(result.year, null);
+    assert.strictEqual(result.count, 0);
+    assert.strictEqual(result.groupId, null);
+    assert.strictEqual(
+      deps.helpers.findOrCreateUncategorizedGroup.mock.calls.length,
+      1
+    );
+  });
+
+  it('incrementalUpdate should handle empty changes with zero updates', async () => {
+    const client = {
+      query: mock.fn(async (sql) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.startsWith('UPDATE lists SET updated_at = $1 WHERE _id = $2')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        throw new Error(`Unexpected query: ${sql}`);
+      }),
+      release: mock.fn(),
+    };
+
+    const pool = {
+      query: mock.fn(async (sql) => {
+        if (sql.includes('FROM lists l') && sql.includes('WHERE l._id = $1')) {
+          return { rows: [createOwnedListRow()] };
+        }
+
+        throw new Error(`Unexpected pool query: ${sql}`);
+      }),
+      connect: mock.fn(async () => client),
+    };
+
+    const deps = createServiceDeps(pool);
+    const service = createListService(deps);
+
+    const result = await service.incrementalUpdate(
+      'list1',
+      'user1',
+      { added: [], removed: [], updated: [] },
+      { _id: 'user1', lastfmUsername: 'listener' }
+    );
+
+    assert.strictEqual(result.changeCount, 0);
+    assert.deepStrictEqual(result.addedItems, []);
+    assert.deepStrictEqual(result.duplicateAlbums, []);
+    assert.strictEqual(result.list._id, 'list1');
+  });
+});


### PR DESCRIPTION
## Summary
- continue `list-service` decomposition by extracting write-focused orchestration into `services/list/write-operations.js` and reorder logic into `services/list/write/reorder-items.js`.
- reduce `services/list-service.js` to a thinner composition/delegation layer while preserving external behavior and service contracts.
- add targeted regression coverage for write paths in `test/list-service.test.js` (`createList` uncategorized flow and empty `incrementalUpdate` path).

## Validation
- `npm run lint:strict`
- `node --test test/list-service.test.js test/list-item-mapper.test.js`
- full non-integration unit suite via Node test runner
- `npm run lint:structure:baseline`
- `npm run report:maintainability`

## Structural Impact
- `services/list-service.js`: `508 -> 271` lines
- Added focused write modules:
  - `services/list/write-operations.js` (`240` lines)
  - `services/list/write/reorder-items.js` (`107` lines)
- `App JS files >300`: `83 -> 82`
- `App JS files >700`: remains `22`