### PR TITLE
Continue module decomposition: extract auth route handlers

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,10 +2,6 @@
  * Authentication & User Settings Routes
  *
  * Thin route layer — delegates business logic to authService and userService.
- * Handles only HTTP concerns: request parsing, response formatting,
- * session management, flash messages, and redirects.
- *
- * @module routes/auth
  */
 module.exports = (app, deps) => {
   const logger = require('../utils/logger');
@@ -25,6 +21,12 @@ module.exports = (app, deps) => {
     validateExtensionToken,
     cleanupExpiredTokens,
   } = require('../utils/auth-utils');
+  const { createResponseHelpers } = require('./auth/response-helpers');
+  const { createSettingsHandlers } = require('./auth/settings-handlers');
+  const { createSecurityHandlers } = require('./auth/security-handlers');
+  const {
+    createExtensionTokenHandlers,
+  } = require('./auth/extension-token-handlers');
 
   const {
     htmlTemplate,
@@ -50,95 +52,37 @@ module.exports = (app, deps) => {
   } = deps;
 
   const asyncHandler = createAsyncHandler(logger);
+  const { respondWithError, respondWithSuccess } = createResponseHelpers();
+  const settingsHandlers = createSettingsHandlers({
+    asyncHandler,
+    userService,
+    saveSessionSafe,
+  });
+  const securityHandlers = createSecurityHandlers({
+    authService,
+    usersAsync,
+    invalidateUserCache,
+    saveSessionSafe,
+    adminCodeState,
+    logger,
+    respondWithError,
+    respondWithSuccess,
+    isValidPassword,
+  });
+  const extensionTokenHandlers = createExtensionTokenHandlers({
+    asyncHandler,
+    authService,
+    pool,
+    generateExtensionToken,
+    validateExtensionToken,
+    cleanupExpiredTokens,
+    usersAsync,
+    sanitizeUser,
+    saveSessionAsync,
+    extensionAuthTemplate,
+    logger,
+  });
 
-  // ── Helper: respond with JSON or flash+redirect ────────────────────────
-
-  function respondWithError(req, res, statusCode, message, redirectPath) {
-    if (req.accepts('json')) {
-      return res.status(statusCode).json({ error: message });
-    }
-    req.flash('error', message);
-    return res.redirect(redirectPath);
-  }
-
-  function respondWithSuccess(req, res, message, redirectPath) {
-    if (req.accepts('json')) {
-      return res.json({ success: true, message });
-    }
-    req.flash('success', message);
-    return res.redirect(redirectPath);
-  }
-
-  // ── Settings update helper (DRY: eliminates 4 identical handlers) ──────
-
-  /**
-   * Create a route handler for a simple user setting update.
-   * Validates via userService.validateSetting, updates via userService.updateSetting,
-   * then syncs the session.
-   */
-  function settingsHandler(field) {
-    return asyncHandler(async (req, res) => {
-      const value = req.body[field];
-      const validation = userService.validateSetting(field, value);
-
-      if (!validation.valid) {
-        return res.status(400).json({ error: validation.error });
-      }
-
-      await userService.updateSetting(req.user._id, field, validation.value);
-
-      // Sync session
-      req.user[field] = validation.value;
-      saveSessionSafe(req, `${field} update`);
-      res.json({ success: true });
-    }, `updating ${field}`);
-  }
-
-  // ── Unique field update helper (DRY: eliminates 2 identical handlers) ──
-
-  /**
-   * Create a route handler for a unique-constrained field update (email/username).
-   * Validates format, checks uniqueness via userService, updates, syncs session.
-   */
-  function uniqueFieldHandler(field, validator, validationError) {
-    return asyncHandler(async (req, res) => {
-      const value = req.body[field];
-
-      if (!value || !value.trim()) {
-        return res
-          .status(400)
-          .json({ error: `${capitalize(field)} is required` });
-      }
-
-      if (!validator(value)) {
-        return res.status(400).json({ error: validationError });
-      }
-
-      const result = await userService.updateUniqueField(
-        req.user._id,
-        field,
-        value
-      );
-
-      if (!result.success) {
-        return res.status(400).json({ error: result.error });
-      }
-
-      // Sync session
-      req.user[field] = value.trim();
-      saveSessionSafe(req, `${field} update`);
-      req.flash('success', `${capitalize(field)} updated successfully`);
-      res.json({ success: true });
-    }, `updating ${field}`);
-  }
-
-  function capitalize(str) {
-    return str.charAt(0).toUpperCase() + str.slice(1);
-  }
-
-  // ============ PAGE ROUTES ============
-
-  // Registration page
   app.get('/register', csrfProtection, (req, res) => {
     res.send(
       htmlTemplate(
@@ -148,7 +92,6 @@ module.exports = (app, deps) => {
     );
   });
 
-  // Registration handler
   app.post('/register', registerRateLimit, csrfProtection, async (req, res) => {
     try {
       const { email, username, password, confirmPassword } = req.body;
@@ -164,7 +107,6 @@ module.exports = (app, deps) => {
         return res.redirect('/register');
       }
 
-      // Fire-and-forget admin approval event
       await authService.createApprovalEvent(app.locals.adminEventService, user);
 
       recordAuthAttempt('register', 'success');
@@ -181,7 +123,6 @@ module.exports = (app, deps) => {
     }
   });
 
-  // Login page
   app.get('/login', csrfProtection, (req, res) => {
     if (req.isAuthenticated()) {
       return res.redirect('/');
@@ -199,7 +140,6 @@ module.exports = (app, deps) => {
     );
   });
 
-  // Login handler
   app.post('/login', loginRateLimit, csrfProtection, async (req, res, next) => {
     logger.debug('Login POST request received', {
       email: req.body.email,
@@ -212,9 +152,9 @@ module.exports = (app, deps) => {
 
     try {
       const { user, info } = await new Promise((resolve, reject) => {
-        passport.authenticate('local', (err, user, info) => {
+        passport.authenticate('local', (err, authUser, authInfo) => {
           if (err) return reject(err);
-          resolve({ user, info });
+          resolve({ user: authUser, info: authInfo });
         })(req, res, next);
       });
 
@@ -249,12 +189,10 @@ module.exports = (app, deps) => {
       logger.info('User logged in successfully', { email: user.email });
       recordAuthAttempt('login', 'success');
 
-      // "Remember me" — extend or use default session lifetime
       req.session.cookie.maxAge = authService.getSessionMaxAge(
         req.body.remember
       );
 
-      // Record last activity
       const timestamp = new Date();
       req.user.lastActivity = timestamp;
       req.session.lastActivityUpdatedAt = Date.now();
@@ -269,7 +207,6 @@ module.exports = (app, deps) => {
         logger.error('Session save error', { error: err.message });
       }
 
-      // Check if this login was for extension authorization
       if (req.session.extensionAuth) {
         delete req.session.extensionAuth;
         return res.redirect('/extension/auth');
@@ -283,312 +220,107 @@ module.exports = (app, deps) => {
     }
   });
 
-  // Logout
   app.get('/logout', (req, res) => {
     recordAuthAttempt('logout', 'success');
     req.logout(() => res.redirect('/login'));
   });
 
-  // Home (protected)
   app.get('/', ensureAuth, csrfProtection, (req, res) => {
     res.send(spotifyTemplate(sanitizeUser(req.user), req.csrfToken()));
   });
 
-  // ============ USER SETTINGS ============
-
-  // Simple settings — all use the same DRY handler
   app.post(
     '/settings/update-accent-color',
     ensureAuth,
-    settingsHandler('accentColor')
+    settingsHandlers.settingsHandler('accentColor')
   );
   app.post(
     '/settings/update-time-format',
     ensureAuth,
-    settingsHandler('timeFormat')
+    settingsHandlers.settingsHandler('timeFormat')
   );
   app.post(
     '/settings/update-date-format',
     ensureAuth,
-    settingsHandler('dateFormat')
+    settingsHandlers.settingsHandler('dateFormat')
   );
   app.post(
     '/settings/update-music-service',
     ensureAuth,
-    settingsHandler('musicService')
+    settingsHandlers.settingsHandler('musicService')
   );
   app.post(
     '/settings/update-column-visibility',
     ensureAuth,
-    settingsHandler('columnVisibility')
+    settingsHandlers.settingsHandler('columnVisibility')
   );
 
-  // Unique-field settings
   app.post(
     '/settings/update-email',
     ensureAuth,
-    uniqueFieldHandler('email', isValidEmail, 'Invalid email format')
+    settingsHandlers.uniqueFieldHandler(
+      'email',
+      isValidEmail,
+      'Invalid email format'
+    )
   );
   app.post(
     '/settings/update-username',
     ensureAuth,
-    uniqueFieldHandler(
+    settingsHandlers.uniqueFieldHandler(
       'username',
       isValidUsername,
       'Username can only contain letters, numbers, and underscores and must be 3-30 characters'
     )
   );
 
-  // Update last selected list
   app.post(
     '/api/user/last-list',
     ensureAuthAPI,
-    asyncHandler(async (req, res) => {
-      const listId = req.body.listId || req.body.listName;
-
-      if (!listId) {
-        return res.status(400).json({ error: 'listId is required' });
-      }
-
-      await userService.updateLastSelectedList(req.user._id, listId);
-
-      req.user.lastSelectedList = listId;
-      saveSessionSafe(req, 'lastSelectedList update');
-      res.json({ success: true });
-    }, 'updating last selected list')
+    settingsHandlers.updateLastSelectedList
   );
 
-  // Change password
   app.post(
     '/settings/change-password',
     ensureAuth,
     sensitiveSettingsRateLimit,
     csrfProtection,
-    async (req, res) => {
-      try {
-        const result = await authService.changePassword(
-          req.user._id,
-          req.user.hash,
-          req.body,
-          isValidPassword
-        );
-
-        if (!result.success) {
-          return respondWithError(req, res, 400, result.error, '/');
-        }
-
-        await usersAsync.update(
-          { _id: req.user._id },
-          { $set: { hash: result.newHash, updatedAt: new Date() } }
-        );
-
-        if (invalidateUserCache) {
-          invalidateUserCache(req.user._id);
-        }
-
-        return respondWithSuccess(
-          req,
-          res,
-          'Password updated successfully',
-          '/'
-        );
-      } catch (error) {
-        logger.error('Password change error', {
-          error: error.message,
-          userId: req.user._id,
-        });
-        return respondWithError(req, res, 500, 'Error changing password', '/');
-      }
-    }
+    securityHandlers.changePassword
   );
 
-  // Request admin access
   app.post(
     '/settings/request-admin',
     ensureAuth,
     csrfProtection,
     rateLimitAdminRequest,
-    async (req, res) => {
-      logger.info('Admin request received', {
-        email: req.user.email,
-        userId: req.user._id,
-        requestId: req.id,
-      });
-
-      try {
-        const { code } = req.body;
-        const codeResult = authService.validateAdminCode(
-          code,
-          req.user._id,
-          adminCodeState
-        );
-
-        if (!codeResult.valid) {
-          logger.info('Invalid code attempt');
-
-          // Increment failed attempts
-          const attempts = req.adminAttempts;
-          attempts.count++;
-          adminCodeState.adminCodeAttempts.set(req.user._id, attempts);
-
-          return respondWithError(req, res, 400, codeResult.error, '/');
-        }
-
-        // Clear failed attempts on success
-        adminCodeState.adminCodeAttempts.delete(req.user._id);
-
-        // Grant admin role in DB
-        await usersAsync.update(
-          { _id: req.user._id },
-          { $set: { role: 'admin', adminGrantedAt: new Date() } }
-        );
-
-        if (invalidateUserCache) {
-          invalidateUserCache(req.user._id);
-        }
-
-        logger.info(`Admin access granted to: ${req.user.email}`);
-        authService.finalizeAdminCodeUsage(adminCodeState, req.user.email);
-
-        // Update session
-        req.user.role = 'admin';
-        saveSessionSafe(req, 'admin role update');
-
-        return respondWithSuccess(req, res, 'Admin access granted!', '/');
-      } catch (error) {
-        logger.error('Admin request error', {
-          error: error.message,
-          userId: req.user._id,
-        });
-        return respondWithError(
-          req,
-          res,
-          500,
-          'Error processing admin request',
-          '/'
-        );
-      }
-    }
+    securityHandlers.requestAdmin
   );
 
-  // ============ EXTENSION AUTHENTICATION ============
+  app.get('/extension/auth', extensionTokenHandlers.showExtensionAuthPage);
 
-  // Extension login page — redirects to login, then generates token
-  app.get('/extension/auth', async (req, res) => {
-    if (!req.isAuthenticated()) {
-      req.session.extensionAuth = true;
-      try {
-        await saveSessionAsync(req);
-      } catch (err) {
-        logger.error('Session save error:', err);
-      }
-      return res.redirect('/login');
-    }
-
-    res.send(extensionAuthTemplate());
-  });
-
-  // ============ EXTENSION TOKEN ENDPOINTS ============
-
-  // Generate extension token
   app.post(
     '/api/auth/extension-token',
     ensureAuth,
-    asyncHandler(async (req, res) => {
-      const userAgent = req.get('User-Agent') || 'Unknown';
-      const result = await authService.createExtensionToken(
-        pool,
-        req.user._id,
-        userAgent,
-        generateExtensionToken
-      );
-
-      logger.info('Extension token generated', {
-        userId: req.user._id,
-        email: req.user.email,
-      });
-
-      res.json(result);
-    }, 'generating extension token')
+    extensionTokenHandlers.createExtensionToken
   );
 
-  // Validate extension token
-  app.get(
-    '/api/auth/validate-token',
-    asyncHandler(async (req, res) => {
-      const authHeader = req.get('Authorization');
-      if (!authHeader || !authHeader.startsWith('Bearer ')) {
-        return res.status(401).json({ error: 'No token provided' });
-      }
+  app.get('/api/auth/validate-token', extensionTokenHandlers.validateToken);
 
-      const token = authHeader.substring(7);
-      const userId = await validateExtensionToken(token, pool);
-
-      if (!userId) {
-        return res.status(401).json({ error: 'Invalid or expired token' });
-      }
-
-      const user = await usersAsync.findOne({ _id: userId });
-      if (!user) {
-        return res.status(401).json({ error: 'User not found' });
-      }
-
-      res.json({ valid: true, user: sanitizeUser(user) });
-    }, 'validating extension token')
-  );
-
-  // Revoke extension token
   app.delete(
     '/api/auth/extension-token',
     ensureAuth,
-    asyncHandler(async (req, res) => {
-      const { token } = req.body;
-
-      if (!token) {
-        return res.status(400).json({ error: 'Token required' });
-      }
-
-      const { revoked } = await authService.revokeExtensionToken(
-        pool,
-        token,
-        req.user._id
-      );
-
-      if (!revoked) {
-        return res.status(404).json({ error: 'Token not found' });
-      }
-
-      logger.info('Extension token revoked', {
-        userId: req.user._id,
-        email: req.user.email,
-      });
-
-      res.json({ success: true });
-    }, 'revoking extension token')
+    extensionTokenHandlers.revokeExtensionToken
   );
 
-  // List extension tokens
   app.get(
     '/api/auth/extension-tokens',
     ensureAuth,
-    asyncHandler(async (req, res) => {
-      const tokens = await authService.listExtensionTokens(pool, req.user._id);
-      res.json({ tokens });
-    }, 'listing extension tokens')
+    extensionTokenHandlers.listExtensionTokens
   );
 
-  // Cleanup expired tokens (admin only)
   app.post(
     '/api/auth/cleanup-tokens',
     ensureAuth,
-    asyncHandler(async (req, res) => {
-      if (req.user.role !== 'admin') {
-        return res.status(403).json({ error: 'Admin access required' });
-      }
-
-      const deletedCount = await cleanupExpiredTokens(pool);
-      logger.info('Cleaned up expired tokens', { count: deletedCount });
-      res.json({ deletedCount });
-    }, 'cleaning up expired tokens')
+    extensionTokenHandlers.cleanupTokens
   );
 };

--- a/routes/auth/extension-token-handlers.js
+++ b/routes/auth/extension-token-handlers.js
@@ -1,0 +1,119 @@
+function createExtensionTokenHandlers(deps = {}) {
+  const {
+    asyncHandler,
+    authService,
+    pool,
+    generateExtensionToken,
+    validateExtensionToken,
+    cleanupExpiredTokens,
+    usersAsync,
+    sanitizeUser,
+    saveSessionAsync,
+    logger,
+  } = deps;
+
+  async function showExtensionAuthPage(req, res) {
+    if (!req.isAuthenticated()) {
+      req.session.extensionAuth = true;
+      try {
+        await saveSessionAsync(req);
+      } catch (err) {
+        logger.error('Session save error:', err);
+      }
+      return res.redirect('/login');
+    }
+
+    res.send(deps.extensionAuthTemplate());
+  }
+
+  const createExtensionToken = asyncHandler(async (req, res) => {
+    const userAgent = req.get('User-Agent') || 'Unknown';
+    const result = await authService.createExtensionToken(
+      pool,
+      req.user._id,
+      userAgent,
+      generateExtensionToken
+    );
+
+    logger.info('Extension token generated', {
+      userId: req.user._id,
+      email: req.user.email,
+    });
+
+    res.json(result);
+  }, 'generating extension token');
+
+  const validateToken = asyncHandler(async (req, res) => {
+    const authHeader = req.get('Authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'No token provided' });
+    }
+
+    const token = authHeader.substring(7);
+    const userId = await validateExtensionToken(token, pool);
+
+    if (!userId) {
+      return res.status(401).json({ error: 'Invalid or expired token' });
+    }
+
+    const user = await usersAsync.findOne({ _id: userId });
+    if (!user) {
+      return res.status(401).json({ error: 'User not found' });
+    }
+
+    res.json({ valid: true, user: sanitizeUser(user) });
+  }, 'validating extension token');
+
+  const revokeExtensionToken = asyncHandler(async (req, res) => {
+    const { token } = req.body;
+
+    if (!token) {
+      return res.status(400).json({ error: 'Token required' });
+    }
+
+    const { revoked } = await authService.revokeExtensionToken(
+      pool,
+      token,
+      req.user._id
+    );
+
+    if (!revoked) {
+      return res.status(404).json({ error: 'Token not found' });
+    }
+
+    logger.info('Extension token revoked', {
+      userId: req.user._id,
+      email: req.user.email,
+    });
+
+    res.json({ success: true });
+  }, 'revoking extension token');
+
+  const listExtensionTokens = asyncHandler(async (req, res) => {
+    const tokens = await authService.listExtensionTokens(pool, req.user._id);
+    res.json({ tokens });
+  }, 'listing extension tokens');
+
+  const cleanupTokens = asyncHandler(async (req, res) => {
+    if (req.user.role !== 'admin') {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+
+    const deletedCount = await cleanupExpiredTokens(pool);
+    logger.info('Cleaned up expired tokens', { count: deletedCount });
+    res.json({ deletedCount });
+  }, 'cleaning up expired tokens');
+
+  return {
+    cleanupTokens,
+    createExtensionToken,
+    listExtensionTokens,
+    revokeExtensionToken,
+    showExtensionAuthPage,
+    validateToken,
+  };
+}
+
+module.exports = {
+  createExtensionTokenHandlers,
+};

--- a/routes/auth/response-helpers.js
+++ b/routes/auth/response-helpers.js
@@ -1,0 +1,28 @@
+function createResponseHelpers() {
+  function respondWithError(req, res, statusCode, message, redirectPath) {
+    if (req.accepts('json')) {
+      return res.status(statusCode).json({ error: message });
+    }
+
+    req.flash('error', message);
+    return res.redirect(redirectPath);
+  }
+
+  function respondWithSuccess(req, res, message, redirectPath) {
+    if (req.accepts('json')) {
+      return res.json({ success: true, message });
+    }
+
+    req.flash('success', message);
+    return res.redirect(redirectPath);
+  }
+
+  return {
+    respondWithError,
+    respondWithSuccess,
+  };
+}
+
+module.exports = {
+  createResponseHelpers,
+};

--- a/routes/auth/security-handlers.js
+++ b/routes/auth/security-handlers.js
@@ -1,0 +1,112 @@
+function createSecurityHandlers(deps = {}) {
+  const {
+    authService,
+    usersAsync,
+    invalidateUserCache,
+    saveSessionSafe,
+    adminCodeState,
+    logger,
+    respondWithError,
+    respondWithSuccess,
+    isValidPassword,
+  } = deps;
+
+  async function changePassword(req, res) {
+    try {
+      const result = await authService.changePassword(
+        req.user._id,
+        req.user.hash,
+        req.body,
+        isValidPassword
+      );
+
+      if (!result.success) {
+        return respondWithError(req, res, 400, result.error, '/');
+      }
+
+      await usersAsync.update(
+        { _id: req.user._id },
+        { $set: { hash: result.newHash, updatedAt: new Date() } }
+      );
+
+      if (invalidateUserCache) {
+        invalidateUserCache(req.user._id);
+      }
+
+      return respondWithSuccess(req, res, 'Password updated successfully', '/');
+    } catch (error) {
+      logger.error('Password change error', {
+        error: error.message,
+        userId: req.user._id,
+      });
+      return respondWithError(req, res, 500, 'Error changing password', '/');
+    }
+  }
+
+  async function requestAdmin(req, res) {
+    logger.info('Admin request received', {
+      email: req.user.email,
+      userId: req.user._id,
+      requestId: req.id,
+    });
+
+    try {
+      const { code } = req.body;
+      const codeResult = authService.validateAdminCode(
+        code,
+        req.user._id,
+        adminCodeState
+      );
+
+      if (!codeResult.valid) {
+        logger.info('Invalid code attempt');
+
+        const attempts = req.adminAttempts;
+        attempts.count++;
+        adminCodeState.adminCodeAttempts.set(req.user._id, attempts);
+
+        return respondWithError(req, res, 400, codeResult.error, '/');
+      }
+
+      adminCodeState.adminCodeAttempts.delete(req.user._id);
+
+      await usersAsync.update(
+        { _id: req.user._id },
+        { $set: { role: 'admin', adminGrantedAt: new Date() } }
+      );
+
+      if (invalidateUserCache) {
+        invalidateUserCache(req.user._id);
+      }
+
+      logger.info(`Admin access granted to: ${req.user.email}`);
+      authService.finalizeAdminCodeUsage(adminCodeState, req.user.email);
+
+      req.user.role = 'admin';
+      saveSessionSafe(req, 'admin role update');
+
+      return respondWithSuccess(req, res, 'Admin access granted!', '/');
+    } catch (error) {
+      logger.error('Admin request error', {
+        error: error.message,
+        userId: req.user._id,
+      });
+      return respondWithError(
+        req,
+        res,
+        500,
+        'Error processing admin request',
+        '/'
+      );
+    }
+  }
+
+  return {
+    changePassword,
+    requestAdmin,
+  };
+}
+
+module.exports = {
+  createSecurityHandlers,
+};

--- a/routes/auth/settings-handlers.js
+++ b/routes/auth/settings-handlers.js
@@ -1,0 +1,79 @@
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function createSettingsHandlers(deps = {}) {
+  const { asyncHandler, userService, saveSessionSafe } = deps;
+
+  function settingsHandler(field) {
+    return asyncHandler(async (req, res) => {
+      const value = req.body[field];
+      const validation = userService.validateSetting(field, value);
+
+      if (!validation.valid) {
+        return res.status(400).json({ error: validation.error });
+      }
+
+      await userService.updateSetting(req.user._id, field, validation.value);
+
+      req.user[field] = validation.value;
+      saveSessionSafe(req, `${field} update`);
+      res.json({ success: true });
+    }, `updating ${field}`);
+  }
+
+  function uniqueFieldHandler(field, validator, validationError) {
+    return asyncHandler(async (req, res) => {
+      const value = req.body[field];
+
+      if (!value || !value.trim()) {
+        return res
+          .status(400)
+          .json({ error: `${capitalize(field)} is required` });
+      }
+
+      if (!validator(value)) {
+        return res.status(400).json({ error: validationError });
+      }
+
+      const result = await userService.updateUniqueField(
+        req.user._id,
+        field,
+        value
+      );
+
+      if (!result.success) {
+        return res.status(400).json({ error: result.error });
+      }
+
+      req.user[field] = value.trim();
+      saveSessionSafe(req, `${field} update`);
+      req.flash('success', `${capitalize(field)} updated successfully`);
+      res.json({ success: true });
+    }, `updating ${field}`);
+  }
+
+  const updateLastSelectedList = asyncHandler(async (req, res) => {
+    const listId = req.body.listId || req.body.listName;
+
+    if (!listId) {
+      return res.status(400).json({ error: 'listId is required' });
+    }
+
+    await userService.updateLastSelectedList(req.user._id, listId);
+
+    req.user.lastSelectedList = listId;
+    saveSessionSafe(req, 'lastSelectedList update');
+    res.json({ success: true });
+  }, 'updating last selected list');
+
+  return {
+    settingsHandler,
+    uniqueFieldHandler,
+    updateLastSelectedList,
+  };
+}
+
+module.exports = {
+  createSettingsHandlers,
+};


### PR DESCRIPTION
## Summary
- decompose routes/auth.js by extracting focused modules for response helpers, settings handlers, security handlers, and extension token handlers
- keep all existing auth routes, middleware order, request/response contracts, and session behavior intact while making the route file thinner
- preserve existing login/register/password/admin/extension-token flows without changing user-visible behavior

## Verification
- npm run lint:strict
- node --test test/auth-routes.test.js test/password-change.test.js test/extension-token-routes.test.js
- npm run lint:structure:baseline
- npm run report:maintainability -- --top 12