### PR TITLE
Fix spotify page inline script escaping regression

### DIFF
--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -689,6 +689,18 @@ describe('templates utilities', () => {
       assert.ok(result.includes('/styles/output.css'));
       assert.ok(result.includes('/styles/app.css'));
     });
+
+    it('should render viewport height script with valid template literal syntax', () => {
+      const user = { username: 'test' };
+      const result = templates.spotifyTemplate(user);
+
+      assert.ok(
+        result.includes(
+          "document.documentElement.style.setProperty('--vh', `${vh}px`);"
+        )
+      );
+      assert.ok(!result.includes("setProperty('--vh', \\`\\${vh}px\\`);"));
+    });
   });
 
   describe('headerComponent', () => {

--- a/views/spotify-page.ejs
+++ b/views/spotify-page.ejs
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta property="og:title" content="SuShe Online">
@@ -480,7 +481,7 @@
 
     function updateViewportHeight() {
       const vh = window.innerHeight * 0.01;
-      document.documentElement.style.setProperty('--vh', \`\${vh}px\`);
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
     }
 
     updateViewportHeight();


### PR DESCRIPTION
## Summary
- fix a syntax regression in `views/spotify-page.ejs` where the viewport-height line was emitted with escaped backticks (`\`\${...}\``), causing `Invalid or unexpected token` in the browser
- add a regression assertion in `test/templates.test.js` to ensure the rendered output contains valid template-literal syntax for that line
- add `mobile-web-app-capable` meta tag alongside existing Apple tag to satisfy modern browser expectations

## Validation
- npm run lint:strict
- node --test test/templates.test.js