### PR TITLE
Standardize frontend track-pick handling on canonical fields

### DIFF
--- a/src/js/modules/album-display-shared.js
+++ b/src/js/modules/album-display-shared.js
@@ -157,7 +157,7 @@ export function createAlbumDisplayShared(deps = {}) {
     const fingerprint = albums
       .map(
         (album) =>
-          `${album._id || ''}|${album.track_pick || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}`
+          `${album._id || ''}|${album.primary_track || album.track_picks?.primary || album.track_pick || ''}|${album.secondary_track || album.track_picks?.secondary || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}`
       )
       .join('::');
 
@@ -176,7 +176,7 @@ export function createAlbumDisplayShared(deps = {}) {
 
     return albums.map(
       (album) =>
-        `${album._id || ''}|${album.artist || ''}|${album.album || ''}|${album.release_date || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}|${album.track_pick || ''}`
+        `${album._id || ''}|${album.artist || ''}|${album.album || ''}|${album.release_date || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}|${album.primary_track || album.track_picks?.primary || album.track_pick || ''}|${album.secondary_track || album.track_picks?.secondary || ''}`
     );
   }
 

--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -174,7 +174,7 @@ export function createAlbumDisplay(deps = {}) {
     let comment2 = album.comments_2 || '';
     if (comment2 === 'Comment 2') comment2 = '';
 
-    // Support both URL-based images (new) and base64 (fallback/legacy)
+    // Support both URL-based images and stored base64 data.
     const coverImageUrl = album.cover_image_url || '';
     const coverImage = album.cover_image || '';
     const imageFormat = album.cover_image_format || 'PNG';
@@ -233,21 +233,17 @@ export function createAlbumDisplay(deps = {}) {
       }
     }
 
-    // Process primary track pick (new normalized field or legacy)
-    const primaryTrack = album.primary_track || album.track_pick || '';
+    // Process primary and secondary track picks.
+    const primaryTrack =
+      album.primary_track ||
+      album.track_picks?.primary ||
+      album.track_pick ||
+      '';
     const primaryData = processTrackPick(primaryTrack, album.tracks);
 
-    // Process secondary track pick (new normalized field)
-    const secondaryTrack = album.secondary_track || '';
+    const secondaryTrack =
+      album.secondary_track || album.track_picks?.secondary || '';
     const secondaryData = processTrackPick(secondaryTrack, album.tracks);
-
-    // Legacy compatibility: keep old fields
-    const trackPick = primaryTrack;
-    const trackPickDisplay = primaryData.display || 'Select Track';
-    const trackPickClass = primaryData.display
-      ? primaryData.class
-      : 'text-gray-800 italic';
-    const trackPickDuration = primaryData.duration;
 
     // Album summary (from Claude AI)
     const summary = album.summary || '';
@@ -287,12 +283,6 @@ export function createAlbumDisplay(deps = {}) {
       coverImageUrl,
       coverImage,
       imageFormat,
-      // Legacy track pick fields (for backward compatibility)
-      trackPick,
-      trackPickDisplay,
-      trackPickClass,
-      trackPickDuration,
-      // New dual track pick fields
       primaryTrack,
       primaryTrackDisplay: primaryData.display,
       primaryTrackClass: primaryData.display
@@ -390,16 +380,19 @@ export function createAlbumDisplay(deps = {}) {
     let comment2 = album.comments_2 || '';
     if (comment2 === 'Comment 2') comment2 = '';
 
-    const primaryTrack = album.primary_track || album.track_pick || '';
-    const trackPick = primaryTrack;
+    const primaryTrack =
+      album.primary_track ||
+      album.track_picks?.primary ||
+      album.track_pick ||
+      '';
 
     // Inline track display logic (avoids processTrackPick closure allocation)
-    let trackPickDisplay = 'Select Track';
-    let trackPickClass = 'text-gray-800 italic';
-    let trackPickDuration = '';
+    let primaryTrackDisplay = 'Select Track';
+    let primaryTrackClass = 'text-gray-800 italic';
+    let primaryTrackDuration = '';
 
     if (primaryTrack) {
-      trackPickClass = 'text-gray-300';
+      primaryTrackClass = 'text-gray-300';
       if (album.tracks && Array.isArray(album.tracks)) {
         const trackMatch = album.tracks.find(
           (t) => getTrackName(t) === primaryTrack
@@ -407,21 +400,21 @@ export function createAlbumDisplay(deps = {}) {
         if (trackMatch) {
           const trackName = getTrackName(trackMatch);
           const match = trackName.match(/^(\d+)[.\s-]?\s*(.*)$/);
-          trackPickDisplay = match
+          primaryTrackDisplay = match
             ? match[2]
               ? `${match[1]}. ${match[2]}`
               : `Track ${match[1]}`
             : trackName;
-          trackPickDuration = formatTrackTime(getTrackLength(trackMatch));
+          primaryTrackDuration = formatTrackTime(getTrackLength(trackMatch));
         } else if (primaryTrack.match(/^\d+$/)) {
-          trackPickDisplay = `Track ${primaryTrack}`;
+          primaryTrackDisplay = `Track ${primaryTrack}`;
         } else {
-          trackPickDisplay = primaryTrack;
+          primaryTrackDisplay = primaryTrack;
         }
       } else if (primaryTrack.match(/^\d+$/)) {
-        trackPickDisplay = `Track ${primaryTrack}`;
+        primaryTrackDisplay = `Track ${primaryTrack}`;
       } else {
-        trackPickDisplay = primaryTrack;
+        primaryTrackDisplay = primaryTrack;
       }
     }
 
@@ -443,10 +436,10 @@ export function createAlbumDisplay(deps = {}) {
       genre2Class: genre2 ? 'text-gray-300' : 'text-gray-800 italic',
       comment,
       comment2,
-      trackPick,
-      trackPickDisplay,
-      trackPickClass,
-      trackPickDuration,
+      primaryTrack,
+      primaryTrackDisplay,
+      primaryTrackClass,
+      primaryTrackDuration,
     };
   }
 
@@ -1672,21 +1665,22 @@ export function createAlbumDisplay(deps = {}) {
 
           // Update track pick using cached span
           if (cache.trackSpan) {
-            cache.trackSpan.textContent = data.trackPickDisplay;
-            cache.trackSpan.className = `text-sm ${data.trackPickClass} truncate cursor-pointer hover:text-gray-100`;
-            cache.trackSpan.title = data.trackPick || 'Click to select track';
+            cache.trackSpan.textContent = data.primaryTrackDisplay;
+            cache.trackSpan.className = `text-sm ${data.primaryTrackClass} truncate cursor-pointer hover:text-gray-100`;
+            cache.trackSpan.title =
+              data.primaryTrack || 'Click to select track';
             // Update duration span (sibling of trackSpan)
             const trackCell = cache.trackSpan.parentElement;
             if (trackCell) {
               const existingDuration = trackCell.querySelector('.shrink-0');
-              if (data.trackPickDuration) {
+              if (data.primaryTrackDuration) {
                 if (existingDuration) {
-                  existingDuration.textContent = data.trackPickDuration;
+                  existingDuration.textContent = data.primaryTrackDuration;
                 } else {
                   const durationSpan = document.createElement('span');
                   durationSpan.className =
                     'text-xs text-gray-500 shrink-0 ml-2';
-                  durationSpan.textContent = data.trackPickDuration;
+                  durationSpan.textContent = data.primaryTrackDuration;
                   trackCell.appendChild(durationSpan);
                 }
               } else if (existingDuration) {
@@ -1711,15 +1705,16 @@ export function createAlbumDisplay(deps = {}) {
           const trackMobile = cache.trackText;
           if (trackMobile) {
             const trackDisplay =
-              data.trackPick && data.trackPickDisplay !== 'Select Track'
-                ? data.trackPickDisplay
+              data.primaryTrack && data.primaryTrackDisplay !== 'Select Track'
+                ? data.primaryTrackDisplay
                 : '';
             trackMobile.textContent = trackDisplay;
 
             const trackPlayBtn = trackMobile.closest('[data-track-play-btn]');
             if (trackPlayBtn) {
               const hasTrack =
-                data.trackPick && data.trackPickDisplay !== 'Select Track';
+                data.primaryTrack &&
+                data.primaryTrackDisplay !== 'Select Track';
               trackPlayBtn.setAttribute(
                 'data-track-play-btn',
                 hasTrack ? 'true' : ''
@@ -1932,11 +1927,6 @@ export function createAlbumDisplay(deps = {}) {
       badge.addEventListener('mouseenter', handleRecommendationBadgeMouseEnter);
       badge.addEventListener('mouseleave', handleBadgeMouseLeave);
     });
-  }
-
-  // Backwards compatibility alias
-  function initLastfmTooltips(container) {
-    initSummaryTooltips(container);
   }
 
   /**
@@ -2738,7 +2728,7 @@ export function createAlbumDisplay(deps = {}) {
 
     // Initialize Last.fm summary tooltips (desktop only)
     if (!isMobile) {
-      initLastfmTooltips(container);
+      initSummaryTooltips(container);
     }
 
     // Update lightweight state instead of expensive deep clone

--- a/src/js/modules/mobile-ui.js
+++ b/src/js/modules/mobile-ui.js
@@ -1096,9 +1096,15 @@ export function createMobileUI(deps = {}) {
                     const trackLength = formatTrackTime(getTrackLength(t));
                     const isPrimary =
                       trackName ===
-                      (album.primary_track || album.track_pick || '');
+                      (album.primary_track ||
+                        album.track_picks?.primary ||
+                        album.track_pick ||
+                        '');
                     const isSecondary =
-                      trackName === (album.secondary_track || '');
+                      trackName ===
+                      (album.secondary_track ||
+                        album.track_picks?.secondary ||
+                        '');
                     const indicator = isPrimary
                       ? '<span class="text-yellow-400 mr-1">★</span>'
                       : isSecondary
@@ -1126,7 +1132,7 @@ export function createMobileUI(deps = {}) {
               </ul>
             `
                 : `
-              <input type="number" id="editTrackPickNumber" value="${album.primary_track || album.track_pick || ''}"
+              <input type="number" id="editTrackPickNumber" value="${album.primary_track || album.track_picks?.primary || album.track_pick || ''}"
                      class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:border-gray-500 transition duration-200"
                      placeholder="Enter track number (primary)">
             `
@@ -1268,8 +1274,13 @@ export function createMobileUI(deps = {}) {
     const trackPickContainer = document.getElementById('trackPickContainer');
 
     // Track current selections (will be synced with server)
-    let currentPrimaryTrack = album.primary_track || album.track_pick || '';
-    let currentSecondaryTrack = album.secondary_track || '';
+    let currentPrimaryTrack =
+      album.primary_track ||
+      album.track_picks?.primary ||
+      album.track_pick ||
+      '';
+    let currentSecondaryTrack =
+      album.secondary_track || album.track_picks?.secondary || '';
 
     function updateTrackPickUI() {
       if (!trackPickContainer) return;
@@ -1377,7 +1388,11 @@ export function createMobileUI(deps = {}) {
             // Update local album data for save
             album.primary_track = currentPrimaryTrack;
             album.secondary_track = currentSecondaryTrack;
-            album.track_pick = currentPrimaryTrack; // Legacy field
+            album.track_pick = currentPrimaryTrack;
+            album.track_picks = {
+              primary: currentPrimaryTrack || null,
+              secondary: currentSecondaryTrack || null,
+            };
           } catch (err) {
             console.error('Track pick error:', err);
             showToast('Error updating track selection', 'error');
@@ -1488,6 +1503,10 @@ export function createMobileUI(deps = {}) {
         // Keep the current values which were updated by the track pick handlers
         primary_track: currentPrimaryTrack,
         secondary_track: currentSecondaryTrack,
+        track_picks: {
+          primary: currentPrimaryTrack || null,
+          secondary: currentSecondaryTrack || null,
+        },
         track_pick:
           currentPrimaryTrack ||
           (() => {

--- a/src/js/modules/playback.js
+++ b/src/js/modules/playback.js
@@ -360,7 +360,8 @@ export function createPlayback(deps = {}) {
     const album = albums && albums[index];
     if (!album) return;
 
-    const trackPick = album.track_pick;
+    const trackPick =
+      album.primary_track || album.track_picks?.primary || album.track_pick;
     if (!trackPick) {
       showToast('No track selected', 'error');
       return;

--- a/src/js/modules/track-selection.js
+++ b/src/js/modules/track-selection.js
@@ -249,8 +249,10 @@ export function createTrackSelection(deps = {}) {
     });
 
     // Get current picks
-    const currentPrimary = album.track_picks?.primary || album.track_pick;
-    const currentSecondary = album.track_picks?.secondary || null;
+    const currentPrimary =
+      album.primary_track || album.track_picks?.primary || album.track_pick;
+    const currentSecondary =
+      album.secondary_track || album.track_picks?.secondary || null;
     const currentPrimaryName = getTrackName(currentPrimary);
     const currentSecondaryName = getTrackName(currentSecondary);
 

--- a/test/album-display.test.js
+++ b/test/album-display.test.js
@@ -244,7 +244,7 @@ describe('album-display module', () => {
       assert.strictEqual(data.countryDisplay, 'Country');
       assert.strictEqual(data.genre1Display, 'Genre 1');
       assert.strictEqual(data.genre2Display, 'Genre 2');
-      assert.strictEqual(data.trackPickDisplay, 'Select Track');
+      assert.strictEqual(data.primaryTrackDisplay, '');
     });
 
     it('should handle genre_2 placeholder values', () => {
@@ -294,8 +294,8 @@ describe('album-display module', () => {
         tracks: ['1. First', '2. Second', '3. Favorite Song'],
       };
       let data = module.processAlbumData(album, 0);
-      assert.strictEqual(data.trackPickDisplay, '3. Favorite Song');
-      assert.strictEqual(data.trackPickClass, 'text-gray-300');
+      assert.strictEqual(data.primaryTrackDisplay, '3. Favorite Song');
+      assert.strictEqual(data.primaryTrackClass, 'text-gray-300');
 
       // Test with just track number
       album = {
@@ -303,7 +303,7 @@ describe('album-display module', () => {
         tracks: [],
       };
       data = module.processAlbumData(album, 0);
-      assert.strictEqual(data.trackPickDisplay, 'Track 5');
+      assert.strictEqual(data.primaryTrackDisplay, 'Track 5');
     });
 
     it('should set position only for main lists', () => {


### PR DESCRIPTION
## Summary
- standardize album/mobile playback/edit/render paths around canonical track-pick fields (`primary_track`, `secondary_track`, `track_picks`) while keeping safe read fallbacks for existing list data
- remove internal album-display compatibility aliases and update incremental DOM refresh paths to use canonical primary-track fields directly
- align supporting modules (`album-display-shared`, `playback`, `track-selection`) so local state changes remain consistent without relying on legacy alias-only paths

## Validation
- npm run lint:strict
- npm run build
- node --test test/album-display.test.js test/album-display-shared.test.js test/mobile-ui.test.js test/playback-submenu.test.js
- npm run lint:structure:baseline
- npm run report:maintainability -- --top 10