### PR TITLE
Retire list-item _id compatibility in reorder/comment paths

### DIFF
--- a/services/list/item-comments.js
+++ b/services/list/item-comments.js
@@ -48,17 +48,10 @@ function createItemComments(deps = {}) {
     const now = new Date();
 
     await withTransaction(pool, async (client) => {
-      let updateResult = await client.query(
+      const updateResult = await client.query(
         `UPDATE list_items SET ${field} = $1, updated_at = $2 WHERE list_id = $3 AND album_id = $4 RETURNING _id`,
         [trimmedComment, now, list._id, identifier]
       );
-
-      if (updateResult.rowCount === 0) {
-        updateResult = await client.query(
-          `UPDATE list_items SET ${field} = $1, updated_at = $2 WHERE _id = $3 AND list_id = $4 RETURNING _id`,
-          [trimmedComment, now, identifier, list._id]
-        );
-      }
 
       if (updateResult.rowCount === 0) {
         throw new TransactionAbort(404, {

--- a/services/list/write/reorder-items.js
+++ b/services/list/write/reorder-items.js
@@ -31,9 +31,7 @@ async function reorderItems(ctx, listId, userId, order) {
     }
 
     const itemIdsByAlbumId = new Map();
-    const validItemIds = new Set();
     for (const item of listItems) {
-      validItemIds.add(item._id);
       if (item.album_id) {
         itemIdsByAlbumId.set(item.album_id, item._id);
       }
@@ -49,16 +47,6 @@ async function reorderItems(ctx, listId, userId, order) {
           });
         }
         orderedItemIds.push(resolvedItemId);
-        continue;
-      }
-
-      if (entry && typeof entry === 'object' && entry._id) {
-        if (!validItemIds.has(entry._id)) {
-          throw new ctx.TransactionAbort(400, {
-            error: `Item '${entry._id}' is not in this list`,
-          });
-        }
-        orderedItemIds.push(entry._id);
         continue;
       }
 

--- a/src/js/modules/editable-fields.js
+++ b/src/js/modules/editable-fields.js
@@ -736,8 +736,8 @@ export function createEditableFields(deps = {}) {
       const newComment = textarea.value.trim();
       const album = albumsToUpdate[albumIndex];
 
-      // Get identifier (prefer album_id, fallback to _id for legacy albums)
-      const identifier = album.album_id || album.albumId || album._id;
+      // Get canonical album identifier
+      const identifier = album.album_id || album.albumId;
 
       if (!identifier) {
         showToast('Cannot update - album not identified', 'error');
@@ -872,8 +872,8 @@ export function createEditableFields(deps = {}) {
       const newComment = textarea.value.trim();
       const album = albumsToUpdate[albumIndex];
 
-      // Get identifier (prefer album_id, fallback to _id for legacy albums)
-      const identifier = album.album_id || album.albumId || album._id;
+      // Get canonical album identifier
+      const identifier = album.album_id || album.albumId;
 
       if (!identifier) {
         showToast('Cannot update - album not identified', 'error');

--- a/src/js/modules/list-reorder.js
+++ b/src/js/modules/list-reorder.js
@@ -1,7 +1,7 @@
 /**
  * List reorder persistence flow.
  *
- * Persists drag/drop ordering with stable item identity fallback.
+ * Persists drag/drop ordering using canonical album identity.
  */
 
 export function createListReorder(deps = {}) {
@@ -15,12 +15,9 @@ export function createListReorder(deps = {}) {
     }
 
     try {
-      const order = list.map((album) => {
-        const id = album.album_id || album.albumId;
-        if (id) return id;
-        if (album._id) return { _id: album._id };
-        return null;
-      });
+      const order = list.map(
+        (album) => album.album_id || album.albumId || null
+      );
 
       await apiCall(`/api/lists/${encodeURIComponent(listName)}/reorder`, {
         method: 'POST',

--- a/test/list-reorder.test.js
+++ b/test/list-reorder.test.js
@@ -34,7 +34,7 @@ describe('list-reorder module', () => {
     ]);
   });
 
-  it('maps ids with fallback and posts reorder payload', async () => {
+  it('maps canonical ids and posts reorder payload', async () => {
     const apiCalls = [];
     const logs = [];
 
@@ -51,7 +51,7 @@ describe('list-reorder module', () => {
     await saveReorder('My List/2024', [
       { album_id: 'mbid-1' },
       { albumId: 'spotify-2' },
-      { _id: 'legacy-3' },
+      { album_id: 'mbid-3' },
       { name: 'No ID' },
     ]);
 
@@ -60,7 +60,7 @@ describe('list-reorder module', () => {
       {
         method: 'POST',
         body: JSON.stringify({
-          order: ['mbid-1', 'spotify-2', { _id: 'legacy-3' }, null],
+          order: ['mbid-1', 'spotify-2', 'mbid-3', null],
         }),
       },
     ]);

--- a/test/list-service.test.js
+++ b/test/list-service.test.js
@@ -161,6 +161,58 @@ describe('list-service reorderItems', () => {
     assert.deepStrictEqual(updateParams[1], ['item2', 'item1']);
     assert.deepStrictEqual(updateParams[2], [1, 2]);
   });
+
+  it('should reject non-string entries in order payload', async () => {
+    const client = {
+      query: mock.fn(async (sql) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (
+          sql.includes(
+            'SELECT _id, album_id FROM list_items WHERE list_id = $1'
+          )
+        ) {
+          return {
+            rows: [
+              { _id: 'item1', album_id: 'album1' },
+              { _id: 'item2', album_id: 'album2' },
+            ],
+          };
+        }
+
+        throw new Error(`Unexpected query: ${sql}`);
+      }),
+      release: mock.fn(),
+    };
+
+    const pool = {
+      query: mock.fn(async (sql) => {
+        if (sql.includes('FROM lists l') && sql.includes('WHERE l._id = $1')) {
+          return {
+            rows: [createOwnedListRow()],
+          };
+        }
+
+        throw new Error(`Unexpected pool query: ${sql}`);
+      }),
+      connect: mock.fn(async () => client),
+    };
+
+    const service = createListService(createServiceDeps(pool));
+
+    await assert.rejects(
+      () =>
+        service.reorderItems('list1', 'user1', [{ _id: 'item1' }, 'album2']),
+      (err) => {
+        assert.ok(err instanceof TransactionAbort);
+        assert.strictEqual(err.statusCode, 400);
+        assert.match(err.body.error, /invalid entries/i);
+        return true;
+      }
+    );
+  });
 });
 
 describe('list-service item comments', () => {
@@ -203,7 +255,7 @@ describe('list-service item comments', () => {
     assert.strictEqual(client.query.mock.calls.length, 3);
   });
 
-  it('should fallback to item id for comment 2 updates', async () => {
+  it('should reject comment 2 updates with non-album identifiers', async () => {
     const updateQueries = [];
 
     const client = {
@@ -214,10 +266,7 @@ describe('list-service item comments', () => {
 
         if (sql.includes('UPDATE list_items SET comments_2 = $1')) {
           updateQueries.push(sql);
-          if (updateQueries.length === 1) {
-            return { rows: [], rowCount: 0 };
-          }
-          return { rows: [{ _id: 'item1' }], rowCount: 1 };
+          return { rows: [], rowCount: 0 };
         }
 
         throw new Error(`Unexpected query: ${sql}`);
@@ -239,14 +288,22 @@ describe('list-service item comments', () => {
     };
 
     const service = createListService(createServiceDeps(pool));
-    await service.updateItemComment2('list1', 'user1', 'item1', 'Second note');
+    await assert.rejects(
+      () =>
+        service.updateItemComment2('list1', 'user1', 'item1', 'Second note'),
+      (err) => {
+        assert.ok(err instanceof TransactionAbort);
+        assert.strictEqual(err.statusCode, 404);
+        assert.strictEqual(err.body.error, 'Album not found in list');
+        return true;
+      }
+    );
 
-    assert.strictEqual(updateQueries.length, 2);
+    assert.strictEqual(updateQueries.length, 1);
     assert.ok(
       updateQueries[0].includes('WHERE list_id = $3 AND album_id = $4')
     );
-    assert.ok(updateQueries[1].includes('WHERE _id = $3 AND list_id = $4'));
-    assert.strictEqual(client.query.mock.calls.length, 4);
+    assert.strictEqual(client.query.mock.calls.length, 3);
   });
 });
 


### PR DESCRIPTION
## Summary
- Standardize list reorder and comment-update flows on canonical album identifiers by removing list-item _id compatibility branches in frontend and backend paths.
- Keep endpoint shapes intact while tightening server validation so reorder payload entries must be canonical album-id strings.
- Update tests to cover the canonical path and verify legacy _id payloads are rejected with existing error semantics.

## Validation
- npm run lint:strict
- node --test test/list-reorder.test.js test/list-service.test.js
- npm run build
- npm run lint:structure:baseline
- npm run report:maintainability -- --top 10