### PR TITLE
Normalize albumId aliases at list-state boundaries

### DIFF
--- a/src/js/modules/app-state.js
+++ b/src/js/modules/app-state.js
@@ -13,8 +13,34 @@
 /** Lists keyed by _id. Structure: { _id, name, year, isMain, count, groupId, sortOrder, _data, updatedAt, createdAt } */
 let lists = {};
 
+function normalizeAlbumIdentifiers(albums = []) {
+  if (!Array.isArray(albums)) {
+    return [];
+  }
+
+  let changed = false;
+  const normalized = albums.map((album) => {
+    if (
+      album &&
+      typeof album === 'object' &&
+      !album.album_id &&
+      album.albumId
+    ) {
+      changed = true;
+      return {
+        ...album,
+        album_id: album.albumId,
+      };
+    }
+
+    return album;
+  });
+
+  return changed ? normalized : albums;
+}
+
 function createDefaultListEntry(listId, albums = []) {
-  const data = Array.isArray(albums) ? albums : [];
+  const data = normalizeAlbumIdentifiers(albums);
 
   return {
     _id: listId,
@@ -33,9 +59,25 @@ function normalizeListsMap(newLists = {}) {
 
   Object.keys(newLists).forEach((listId) => {
     const entry = newLists[listId];
-    normalized[listId] = Array.isArray(entry)
-      ? createDefaultListEntry(listId, entry)
-      : entry;
+
+    if (Array.isArray(entry)) {
+      normalized[listId] = createDefaultListEntry(listId, entry);
+      return;
+    }
+
+    if (entry && typeof entry === 'object' && Array.isArray(entry._data)) {
+      const normalizedData = normalizeAlbumIdentifiers(entry._data);
+      normalized[listId] =
+        normalizedData === entry._data
+          ? entry
+          : {
+              ...entry,
+              _data: normalizedData,
+            };
+      return;
+    }
+
+    normalized[listId] = entry;
   });
 
   return normalized;
@@ -173,16 +215,18 @@ export function getListData(listId) {
 export function setListData(listId, albums, updateSnapshot = true) {
   if (!listId) return;
 
+  const normalizedAlbums = normalizeAlbumIdentifiers(albums || []);
+
   if (!lists[listId]) {
-    lists[listId] = createDefaultListEntry(listId, albums);
+    lists[listId] = createDefaultListEntry(listId, normalizedAlbums);
   } else {
-    lists[listId]._data = albums || [];
-    lists[listId].count = albums ? albums.length : 0;
+    lists[listId]._data = normalizedAlbums;
+    lists[listId].count = normalizedAlbums.length;
   }
 
   // Update snapshot for diff-based saves (when data is fetched from server)
   if (updateSnapshot && albums) {
-    const snapshot = createListSnapshot(albums);
+    const snapshot = createListSnapshot(normalizedAlbums);
     lastSavedSnapshots.set(listId, snapshot);
     saveSnapshotToStorage(listId, snapshot);
   }
@@ -614,7 +658,7 @@ export function getLastSavedSnapshots() {
  */
 export function createListSnapshot(albums) {
   if (!albums || !Array.isArray(albums)) return [];
-  return albums.map((a) => a.album_id || a.albumId || null).filter(Boolean);
+  return albums.map((a) => a.album_id || null).filter(Boolean);
 }
 
 /**

--- a/src/js/modules/editable-fields.js
+++ b/src/js/modules/editable-fields.js
@@ -219,7 +219,7 @@ export function createEditableFields(deps = {}) {
 
       // Get album_id for canonical update
       const album = albumsToUpdate[albumIndex];
-      const albumId = album.album_id || album.albumId;
+      const albumId = album.album_id;
 
       if (!albumId) {
         showToast('Cannot update - album not linked', 'error');
@@ -412,7 +412,7 @@ export function createEditableFields(deps = {}) {
 
       // Get album_id for canonical update
       const album = albumsToUpdate[albumIndex];
-      const albumId = album.album_id || album.albumId;
+      const albumId = album.album_id;
 
       if (!albumId) {
         showToast('Cannot update - album not linked', 'error');
@@ -737,7 +737,7 @@ export function createEditableFields(deps = {}) {
       const album = albumsToUpdate[albumIndex];
 
       // Get canonical album identifier
-      const identifier = album.album_id || album.albumId;
+      const identifier = album.album_id;
 
       if (!identifier) {
         showToast('Cannot update - album not identified', 'error');
@@ -873,7 +873,7 @@ export function createEditableFields(deps = {}) {
       const album = albumsToUpdate[albumIndex];
 
       // Get canonical album identifier
-      const identifier = album.album_id || album.albumId;
+      const identifier = album.album_id;
 
       if (!identifier) {
         showToast('Cannot update - album not identified', 'error');

--- a/src/js/modules/list-reorder.js
+++ b/src/js/modules/list-reorder.js
@@ -15,9 +15,7 @@ export function createListReorder(deps = {}) {
     }
 
     try {
-      const order = list.map(
-        (album) => album.album_id || album.albumId || null
-      );
+      const order = list.map((album) => album.album_id || null);
 
       await apiCall(`/api/lists/${encodeURIComponent(listName)}/reorder`, {
         method: 'POST',

--- a/src/js/utils/save-optimizer.js
+++ b/src/js/utils/save-optimizer.js
@@ -16,7 +16,7 @@ import { createListSnapshot } from '../modules/app-state.js';
  *  - Too many changes (falls back to full save)
  *
  * @param {Array<string>} oldSnapshot - Previous album_id array
- * @param {Array<Object>} newData - New album array with album_id or albumId fields
+ * @param {Array<Object>} newData - New album array with canonical album_id fields
  * @returns {Object|null} Diff object { added, removed, updated, totalChanges }, or null
  */
 export function computeListDiff(oldSnapshot, newData) {
@@ -34,14 +34,14 @@ export function computeListDiff(oldSnapshot, newData) {
 
   // Find added albums (in new but not in old)
   const added = newData.filter((album) => {
-    const id = album.album_id || album.albumId;
+    const id = album.album_id;
     return id && !oldSet.has(id);
   });
 
   // Find position changes for existing albums
   const updated = [];
   newData.forEach((album, newIndex) => {
-    const id = album.album_id || album.albumId;
+    const id = album.album_id;
     if (id && oldSet.has(id)) {
       const oldIndex = oldSnapshot.indexOf(id);
       if (oldIndex !== newIndex) {
@@ -65,9 +65,7 @@ export function computeListDiff(oldSnapshot, newData) {
 
   // Prepare added items with position
   const addedWithPosition = added.map((album) => {
-    const newIndex = newData.findIndex(
-      (a) => (a.album_id || a.albumId) === (album.album_id || album.albumId)
-    );
+    const newIndex = newData.findIndex((a) => a.album_id === album.album_id);
     return {
       ...album,
       position: newIndex + 1,

--- a/test/app-state.test.js
+++ b/test/app-state.test.js
@@ -67,6 +67,21 @@ describe('app-state', async () => {
       assert.strictEqual(window.lists, mod.getLists());
     });
 
+    it('setLists normalizes albumId aliases inside _data arrays', () => {
+      mod.setLists({
+        id1: {
+          _id: 'id1',
+          name: 'Test',
+          _data: [{ albumId: 'legacy-1' }],
+          count: 1,
+        },
+      });
+
+      const album = mod.getListData('id1')[0];
+      assert.strictEqual(album.album_id, 'legacy-1');
+      assert.strictEqual(album.albumId, 'legacy-1');
+    });
+
     it('getListData returns null for nonexistent list', () => {
       assert.strictEqual(mod.getListData('nonexistent'), null);
     });
@@ -133,6 +148,15 @@ describe('app-state', async () => {
       assert.strictEqual(entry._data, albums);
       assert.strictEqual(entry.count, 2);
       assert.strictEqual(entry._id, 'id1');
+    });
+
+    it('setListData normalizes albumId aliases to album_id', () => {
+      mod.setLists({ id1: { _id: 'id1', _data: [], count: 0 } });
+      mod.setListData('id1', [{ albumId: 'legacy-2' }], false);
+
+      const album = mod.getListData('id1')[0];
+      assert.strictEqual(album.album_id, 'legacy-2');
+      assert.strictEqual(album.albumId, 'legacy-2');
     });
 
     it('setListData does nothing when listId is falsy', () => {
@@ -567,10 +591,10 @@ describe('app-state', async () => {
       assert.deepStrictEqual(snapshot, ['a1', 'a2']);
     });
 
-    it('createListSnapshot handles albumId field', () => {
-      const albums = [{ albumId: 'b1' }, { albumId: 'b2' }];
+    it('createListSnapshot ignores entries without canonical album_id', () => {
+      const albums = [{ albumId: 'b1' }, { album_id: 'b2' }];
       const snapshot = mod.createListSnapshot(albums);
-      assert.deepStrictEqual(snapshot, ['b1', 'b2']);
+      assert.deepStrictEqual(snapshot, ['b2']);
     });
 
     it('createListSnapshot returns empty for null/invalid input', () => {

--- a/test/list-reorder.test.js
+++ b/test/list-reorder.test.js
@@ -50,7 +50,7 @@ describe('list-reorder module', () => {
 
     await saveReorder('My List/2024', [
       { album_id: 'mbid-1' },
-      { albumId: 'spotify-2' },
+      { album_id: 'spotify-2' },
       { album_id: 'mbid-3' },
       { name: 'No ID' },
     ]);

--- a/test/save-optimizer.test.js
+++ b/test/save-optimizer.test.js
@@ -113,11 +113,13 @@ describe('save-optimizer', async () => {
       assert.ok(result.updated.length > 0); // a3 and a1 moved
     });
 
-    it('handles albumId field (alternative naming)', () => {
-      const oldSnapshot = ['b1', 'b2'];
-      const newData = [{ albumId: 'b2' }, { albumId: 'b1' }];
+    it('ignores entries without canonical album_id', () => {
+      const oldSnapshot = ['b1'];
+      const newData = [{ albumId: 'b1' }, { album_id: 'b2' }];
       const result = computeListDiff(oldSnapshot, newData);
-      assert.strictEqual(result.updated.length, 2); // both swapped
+      assert.deepStrictEqual(result.removed, ['b1']);
+      assert.strictEqual(result.added.length, 1);
+      assert.strictEqual(result.added[0].album_id, 'b2');
     });
 
     it('returns null when too many changes exceed threshold', () => {


### PR DESCRIPTION
## Summary
- Normalize legacy lbumId aliases when list data enters app state so downstream save/reorder/edit code can rely on canonical lbum_id consistently.
- Remove repeated lbum_id || albumId compatibility branches from editable fields, reorder payload generation, snapshot creation, and diff-based save logic.
- Expand tests to verify boundary normalization and canonical-only behavior in snapshot and save optimizer paths.

## Validation
- npm run lint:strict
- node --test test/app-state.test.js test/save-optimizer.test.js test/list-reorder.test.js test/list-service.test.js
- npm run build
- npm run lint:structure:baseline
- npm run report:maintainability -- --top 10