### PR TITLE
Retire context-state compatibility object API

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -81,9 +81,8 @@ import {
   setCurrentRecommendationsYear,
   getContextAlbum as getContextAlbumState,
   setContextAlbum as setContextAlbumState,
+  getContextList as getContextListState,
   setContextList as setContextListState,
-  getContextState as getContextStateFromStore,
-  setContextState as setContextStateInStore,
   getContextGroup as getContextGroupState,
   setContextGroup as setContextGroupState,
   getPendingImport as getPendingImportState,
@@ -478,9 +477,13 @@ const getContextMenusModule = createLazyModule(() =>
     playAlbum,
     playAlbumSafe: (albumId) => window.playAlbumSafe(albumId),
     loadLists,
-    getContextState: () => getContextStateFromStore(),
-    setContextState: (state) => {
-      setContextStateInStore(state);
+    getContextAlbumId: () => getContextAlbumIdentity(),
+    setContextAlbum: (index, albumId) => {
+      setContextAlbumState(index, albumId);
+    },
+    getContextList: () => getContextListState(),
+    setContextList: (listId) => {
+      setContextListState(listId);
     },
     setCurrentList: (listName) => {
       setCurrentListId(listName);

--- a/src/js/modules/app-state.js
+++ b/src/js/modules/app-state.js
@@ -455,28 +455,6 @@ export function setContextList(listId) {
 }
 
 /**
- * Get full context state (for DI compat)
- * @returns {{ album: number|null, albumId: string|null, list: string|null }}
- */
-export function getContextState() {
-  return {
-    album: currentContextAlbum,
-    albumId: currentContextAlbumId,
-    list: currentContextList,
-  };
-}
-
-/**
- * Set context state from object (for DI compat)
- * @param {Object} state
- */
-export function setContextState(state) {
-  if ('album' in state) currentContextAlbum = state.album;
-  if ('albumId' in state) currentContextAlbumId = state.albumId;
-  if ('list' in state) currentContextList = state.list;
-}
-
-/**
  * Get context group
  * @returns {Object|null}
  */

--- a/src/js/modules/context-menus.js
+++ b/src/js/modules/context-menus.js
@@ -39,8 +39,10 @@ import { getDeviceIcon } from '../utils/device-icons.js';
  * @param {Function} deps.playAlbum - Play album
  * @param {Function} deps.playAlbumSafe - Play album safely by ID
  * @param {Function} deps.loadLists - Reload lists
- * @param {Function} deps.getContextState - Get context menu state
- * @param {Function} deps.setContextState - Set context menu state
+ * @param {Function} deps.getContextAlbumId - Get context menu album ID
+ * @param {Function} deps.setContextAlbum - Set context menu album state
+ * @param {Function} deps.getContextList - Get context menu list state
+ * @param {Function} deps.setContextList - Set context menu list state
  * @param {Function} deps.setCurrentList - Set current list (for delete)
  * @param {Function} deps.refreshMobileBarVisibility - Refresh mobile bar visibility
  * @param {Function} deps.getSortedGroups - Get groups sorted by sort_order
@@ -70,8 +72,10 @@ export function createContextMenus(deps = {}) {
     playAlbum: _playAlbum,
     playAlbumSafe: _playAlbumSafe,
     loadLists: _loadLists,
-    getContextState,
-    setContextState,
+    getContextAlbumId,
+    setContextAlbum,
+    getContextList,
+    setContextList,
     setCurrentList,
     refreshMobileBarVisibility,
     getSortedGroups,
@@ -90,7 +94,7 @@ export function createContextMenus(deps = {}) {
     hideAllMenusBase();
 
     // Module-specific cleanup: clear context state and cancel track fetches
-    setContextState({ album: null, albumId: null });
+    setContextAlbum(null, null);
     if (trackAbortController) {
       trackAbortController.abort();
       trackAbortController = null;
@@ -170,7 +174,7 @@ export function createContextMenus(deps = {}) {
   function showMoveToListSubmenu() {
     const currentList = getCurrentList();
     const lists = getLists();
-    const { albumId } = getContextState();
+    const albumId = getContextAlbumId();
 
     const submenu = document.getElementById('albumMoveSubmenu');
     const moveOption = document.getElementById('moveAlbumOption');
@@ -247,7 +251,7 @@ export function createContextMenus(deps = {}) {
   function showCopyToListSubmenu() {
     const currentList = getCurrentList();
     const lists = getLists();
-    const { albumId } = getContextState();
+    const albumId = getContextAlbumId();
 
     const submenu = document.getElementById('albumCopySubmenu');
     const copyOption = document.getElementById('copyAlbumOption');
@@ -322,7 +326,7 @@ export function createContextMenus(deps = {}) {
    * Show download list submenu for desktop
    */
   function showDownloadListSubmenu() {
-    const { list: currentContextList } = getContextState();
+    const currentContextList = getContextList();
     const submenu = document.getElementById('downloadListSubmenu');
     const downloadOption = document.getElementById('downloadListOption');
 
@@ -358,7 +362,7 @@ export function createContextMenus(deps = {}) {
 
         // Download the list
         downloadListAsJSON(currentContextList);
-        setContextState({ list: null });
+        setContextList(null);
       });
     }
 
@@ -376,7 +380,7 @@ export function createContextMenus(deps = {}) {
 
         // Download the list
         downloadListAsPDF(currentContextList);
-        setContextState({ list: null });
+        setContextList(null);
       });
     }
 
@@ -394,7 +398,7 @@ export function createContextMenus(deps = {}) {
 
         // Download the list
         downloadListAsCSV(currentContextList);
-        setContextState({ list: null });
+        setContextList(null);
       });
     }
 
@@ -560,7 +564,7 @@ export function createContextMenus(deps = {}) {
 
     // Handle rename option click
     renameOption.onclick = () => {
-      const { list: currentContextList } = getContextState();
+      const currentContextList = getContextList();
       contextMenu.classList.add('hidden');
 
       if (!currentContextList) return;
@@ -570,9 +574,9 @@ export function createContextMenus(deps = {}) {
 
     // Handle toggle main option click
     toggleMainOption.onclick = () => {
-      const { list: currentContextList } = getContextState();
+      const currentContextList = getContextList();
       contextMenu.classList.add('hidden');
-      setContextState({ list: null });
+      setContextList(null);
 
       if (currentContextList) {
         toggleMainStatus(currentContextList);
@@ -581,7 +585,7 @@ export function createContextMenus(deps = {}) {
 
     // Handle update playlist option click
     updatePlaylistOption.onclick = async () => {
-      const { list: currentContextList } = getContextState();
+      const currentContextList = getContextList();
       contextMenu.classList.add('hidden');
 
       if (!currentContextList) return;
@@ -594,12 +598,12 @@ export function createContextMenus(deps = {}) {
         console.error('Update playlist failed', err);
       }
 
-      setContextState({ list: null });
+      setContextList(null);
     };
 
     // Handle delete option click
     deleteOption.onclick = async () => {
-      const { list: currentContextList } = getContextState();
+      const currentContextList = getContextList();
       const currentList = getCurrentList();
       contextMenu.classList.add('hidden');
 
@@ -674,7 +678,7 @@ export function createContextMenus(deps = {}) {
         }
       }
 
-      setContextState({ list: null });
+      setContextList(null);
     };
 
     // Get submenu elements
@@ -730,7 +734,7 @@ export function createContextMenus(deps = {}) {
         cancelHideMoveListSubmenu();
         // Also hide download submenu when entering move option
         hideDownloadSubmenu();
-        const { list: currentContextList } = getContextState();
+        const currentContextList = getContextList();
         if (currentContextList) {
           showMoveListSubmenu();
         }
@@ -759,7 +763,7 @@ export function createContextMenus(deps = {}) {
         cancelHideDownloadSubmenu();
         // Also hide move list submenu when entering download option
         hideMoveListSubmenu();
-        const { list: currentContextList } = getContextState();
+        const currentContextList = getContextList();
         if (currentContextList) {
           showDownloadListSubmenu();
         }
@@ -807,7 +811,7 @@ export function createContextMenus(deps = {}) {
   function showMoveListSubmenu() {
     const moveListOption = document.getElementById('moveListOption');
     const moveListSubmenu = document.getElementById('moveListSubmenu');
-    const { list: currentContextList } = getContextState();
+    const currentContextList = getContextList();
 
     if (!moveListSubmenu || !moveListOption || !currentContextList) return;
 
@@ -918,7 +922,7 @@ export function createContextMenus(deps = {}) {
       showToast('Failed to move list', 'error');
     }
 
-    setContextState({ list: null });
+    setContextList(null);
   }
 
   // Return public API

--- a/test/app-state.test.js
+++ b/test/app-state.test.js
@@ -427,23 +427,12 @@ describe('app-state', async () => {
       assert.strictEqual(mod.getContextList(), null);
     });
 
-    it('getContextState returns combined context', () => {
-      mod.setContextAlbum(3, 'album-abc');
-      mod.setContextList('list-1');
-      const state = mod.getContextState();
-      assert.strictEqual(state.album, 3);
-      assert.strictEqual(state.albumId, 'album-abc');
-      assert.strictEqual(state.list, 'list-1');
-    });
-
-    it('setContextState applies partial updates', () => {
+    it('setContextAlbum replaces both index and album ID together', () => {
       mod.setContextAlbum(1, 'old');
-      mod.setContextList('old-list');
-      mod.setContextState({ album: 10, albumId: 'new' });
-      const state = mod.getContextState();
-      assert.strictEqual(state.album, 10);
+      mod.setContextAlbum(10, 'new');
+      const state = mod.getContextAlbum();
+      assert.strictEqual(state.index, 10);
       assert.strictEqual(state.albumId, 'new');
-      assert.strictEqual(state.list, 'old-list'); // unchanged
     });
 
     it('getContextGroup / setContextGroup', () => {

--- a/test/context-menus.test.js
+++ b/test/context-menus.test.js
@@ -38,8 +38,10 @@ describe('context-menus module', () => {
         playAlbum: mock.fn(),
         playAlbumSafe: mock.fn(),
         loadLists: mock.fn(),
-        getContextState: mock.fn(() => ({})),
-        setContextState: mock.fn(),
+        getContextAlbumId: mock.fn(() => null),
+        setContextAlbum: mock.fn(),
+        getContextList: mock.fn(() => null),
+        setContextList: mock.fn(),
         toggleMainStatus: mock.fn(),
       };
 


### PR DESCRIPTION
## Summary
- Remove the transitional getContextState / setContextState object API from app-state and switch remaining context-menu consumers to dedicated getters/setters for album and list context.
- Update app wiring so context-menu DI uses canonical context accessors instead of compatibility bridge wrappers.
- Keep menu behavior unchanged while tightening state contracts with updated unit tests.

## Validation
- npm run lint:strict
- node --test test/app-state.test.js test/context-menus.test.js test/album-context-menu-submenu.test.js test/mobile-ui.test.js test/list-nav.test.js
- npm run build
- npm run lint:structure:baseline
- npm run report:maintainability -- --top 10