### PR TITLE
Retire split context reset compatibility paths

### DIFF
--- a/routes/api/_helpers.js
+++ b/routes/api/_helpers.js
@@ -55,6 +55,13 @@ function createHelpers(deps) {
     }
   }
 
+  function stripLegacyCoverFields(album) {
+    const cleaned = { ...album };
+    delete cleaned.cover_image;
+    delete cleaned.cover_image_format;
+    return cleaned;
+  }
+
   /**
    * Upsert an album record with canonical deduplication.
    *
@@ -67,11 +74,8 @@ function createHelpers(deps) {
    * @returns {Promise<string>} - The canonical album_id to use
    */
   async function upsertAlbumRecord(album, timestamp, client = null) {
-    // Remove cover_image for backward compatibility (extension may still send it)
-    // Cover images are now fetched asynchronously in the background
-    const albumDataWithoutCover = { ...album };
-    delete albumDataWithoutCover.cover_image;
-    delete albumDataWithoutCover.cover_image_format;
+    // Ignore legacy inline cover payloads; covers are fetched asynchronously.
+    const albumDataWithoutCover = stripLegacyCoverFields(album);
 
     const result = await albumCanonical.upsertCanonical(
       albumDataWithoutCover,
@@ -131,13 +135,7 @@ function createHelpers(deps) {
   async function batchUpsertAlbumRecords(albums, timestamp, client = null) {
     if (!albums || albums.length === 0) return new Map();
 
-    // Remove cover_image from all albums (backward compatibility)
-    const albumsWithoutCovers = albums.map((album) => {
-      const cleaned = { ...album };
-      delete cleaned.cover_image;
-      delete cleaned.cover_image_format;
-      return cleaned;
-    });
+    const albumsWithoutCovers = albums.map(stripLegacyCoverFields);
 
     const results = await albumCanonical.batchUpsertCanonical(
       albumsWithoutCovers,

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -135,10 +135,6 @@ function setContextAlbumIndex(index) {
   setContextAlbumState(index, getContextAlbumIdentity());
 }
 
-function setContextAlbumIdentity(albumId) {
-  setContextAlbumState(getContextAlbumIndex(), albumId);
-}
-
 function setPendingImportData(data) {
   const pending = getPendingImportState();
   setPendingImportState(data, pending.filename);
@@ -358,11 +354,8 @@ const getAlbumContextMenuModule = createLazyModule(() =>
     getCurrentRecommendationsYear,
     getContextAlbum: () => getContextAlbumIndex(),
     getContextAlbumId: () => getContextAlbumIdentity(),
-    setContextAlbum: (val) => {
-      setContextAlbumIndex(val);
-    },
-    setContextAlbumId: (val) => {
-      setContextAlbumIdentity(val);
+    setContextAlbum: (index, albumId) => {
+      setContextAlbumState(index, albumId);
     },
     getTrackAbortController: () => getTrackAbortControllerState(),
     setTrackAbortController: (val) => {
@@ -379,7 +372,6 @@ const getAlbumContextMenuModule = createLazyModule(() =>
     loadLists,
     getRecommendationsModule: () => getRecommendationsModule(),
     getMobileUIModule: () => getMobileUIModule(),
-    getListMetadata,
     createContextSubmenuController,
   })
 );

--- a/src/js/modules/album-context-menu.js
+++ b/src/js/modules/album-context-menu.js
@@ -32,7 +32,6 @@ export function createAlbumContextMenu(deps = {}) {
     getContextAlbum,
     getContextAlbumId,
     setContextAlbum,
-    setContextAlbumId,
     getTrackAbortController,
     setTrackAbortController,
     findAlbumByIdentity,
@@ -47,7 +46,6 @@ export function createAlbumContextMenu(deps = {}) {
     loadLists,
     getRecommendationsModule,
     getMobileUIModule,
-    getListMetadata: _getListMetadata,
     createContextSubmenuController:
       makeContextSubmenuController = createContextSubmenuController,
   } = deps;
@@ -100,6 +98,10 @@ export function createAlbumContextMenu(deps = {}) {
     hideAlbumPlaySubmenu();
     hideMoveSubmenus();
     hideCopySubmenu();
+  }
+
+  function clearContextAlbumSelection() {
+    setContextAlbum(null, null);
   }
 
   function initializeAlbumSubmenuController() {
@@ -156,8 +158,7 @@ export function createAlbumContextMenu(deps = {}) {
     }
 
     // Module-specific cleanup: clear context album and cancel track fetches
-    setContextAlbum(null);
-    setContextAlbumId(null);
+    clearContextAlbumSelection();
 
     const trackAbortController = getTrackAbortController();
     if (trackAbortController) {
@@ -268,8 +269,7 @@ export function createAlbumContextMenu(deps = {}) {
             selectList(getCurrentListId());
           }
 
-          setContextAlbum(null);
-          setContextAlbumId(null);
+          clearContextAlbumSelection();
         }
       );
     };
@@ -292,8 +292,7 @@ export function createAlbumContextMenu(deps = {}) {
 
         if (!album || !album.artist || !album.album) {
           showToast('Could not find album data', 'error');
-          setContextAlbum(null);
-          setContextAlbumId(null);
+          clearContextAlbumSelection();
           return;
         }
 
@@ -303,15 +302,13 @@ export function createAlbumContextMenu(deps = {}) {
 
         if (!year) {
           showToast('Cannot recommend from a list without a year', 'error');
-          setContextAlbum(null);
-          setContextAlbumId(null);
+          clearContextAlbumSelection();
           return;
         }
 
         await getRecommendationsModule().recommendAlbum(album, year);
 
-        setContextAlbum(null);
-        setContextAlbumId(null);
+        clearContextAlbumSelection();
       };
     }
 
@@ -344,8 +341,7 @@ export function createAlbumContextMenu(deps = {}) {
           showToast('Could not find album artist', 'error');
         }
 
-        setContextAlbum(null);
-        setContextAlbumId(null);
+        clearContextAlbumSelection();
       };
     }
 
@@ -368,16 +364,14 @@ export function createAlbumContextMenu(deps = {}) {
 
         if (!album || !album.artist || !album.album) {
           showToast('Could not find album data', 'error');
-          setContextAlbum(null);
-          setContextAlbumId(null);
+          clearContextAlbumSelection();
           return;
         }
 
         // Show release selection modal
         showReleaseSelectionModal(album);
 
-        setContextAlbum(null);
-        setContextAlbumId(null);
+        clearContextAlbumSelection();
       };
     }
   }

--- a/src/js/modules/realtime-sync.js
+++ b/src/js/modules/realtime-sync.js
@@ -21,7 +21,7 @@ export function createRealtimeSync(deps = {}) {
     getCurrentList = () => null,
     getListData = () => null,
     refreshListData = async () => {},
-    refreshListDataSilent = async () => {},
+    refreshListDataSilent = refreshListData,
     refreshListNav = () => {},
     showToast = () => {},
     apiCall = async () => {},
@@ -329,14 +329,8 @@ export function createRealtimeSync(deps = {}) {
     });
 
     try {
-      // Use silent refresh if available, otherwise use regular refresh
-      if (refreshListDataSilent) {
-        await refreshListDataSilent(currentList);
-        console.log('[RealtimeSync] List refreshed silently');
-      } else {
-        await refreshListData(currentList);
-        console.log('[RealtimeSync] List refreshed (regular)');
-      }
+      await refreshListDataSilent(currentList);
+      console.log('[RealtimeSync] List refreshed after summary update');
     } catch (error) {
       console.error(
         '[RealtimeSync] Failed to refresh list after summary update:',

--- a/test/album-context-menu-submenu.test.js
+++ b/test/album-context-menu-submenu.test.js
@@ -60,7 +60,6 @@ describe('album context menu submenu controller wiring', async () => {
       getContextAlbum: () => null,
       getContextAlbumId: () => null,
       setContextAlbum: () => {},
-      setContextAlbumId: () => {},
       getTrackAbortController: () => null,
       setTrackAbortController: () => {},
       findAlbumByIdentity: () => null,
@@ -77,7 +76,6 @@ describe('album context menu submenu controller wiring', async () => {
         showMoveConfirmation: () => {},
         showCopyConfirmation: () => {},
       }),
-      getListMetadata: () => ({}),
       createContextSubmenuController,
     });
 
@@ -107,7 +105,6 @@ describe('album context menu submenu controller wiring', async () => {
 
     const hideAll = mock.fn();
     const setContextAlbum = mock.fn();
-    const setContextAlbumId = mock.fn();
     const setTrackAbortController = mock.fn();
     const abort = mock.fn();
 
@@ -119,7 +116,6 @@ describe('album context menu submenu controller wiring', async () => {
       getContextAlbum: () => null,
       getContextAlbumId: () => null,
       setContextAlbum,
-      setContextAlbumId,
       getTrackAbortController: () => ({ abort }),
       setTrackAbortController,
       findAlbumByIdentity: () => null,
@@ -136,7 +132,6 @@ describe('album context menu submenu controller wiring', async () => {
         showMoveConfirmation: () => {},
         showCopyConfirmation: () => {},
       }),
-      getListMetadata: () => ({}),
       createContextSubmenuController: () => ({
         initialize: () => {},
         hideAll,
@@ -149,7 +144,10 @@ describe('album context menu submenu controller wiring', async () => {
 
     assert.strictEqual(hideAll.mock.calls.length, 1);
     assert.strictEqual(setContextAlbum.mock.calls.length, 1);
-    assert.strictEqual(setContextAlbumId.mock.calls.length, 1);
+    assert.deepStrictEqual(setContextAlbum.mock.calls[0].arguments, [
+      null,
+      null,
+    ]);
     assert.strictEqual(abort.mock.calls.length, 1);
     assert.strictEqual(setTrackAbortController.mock.calls.length, 1);
   });


### PR DESCRIPTION
## Summary
- remove split album context clearing (`setContextAlbum` + `setContextAlbumId`) and use the canonical atomic context setter in `album-context-menu`
- simplify realtime summary refresh by defaulting silent refresh to canonical list refresh and removing the dead conditional fallback branch
- centralize legacy inline cover-field stripping in API helpers so the transitional compatibility behavior remains explicit and non-duplicated

## Validation
- `npm run lint:strict`
- `node --test test/album-context-menu-submenu.test.js`
- `npm run lint:structure:baseline`