### PR TITLE
Retire context-menu split album getter wiring

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -455,7 +455,7 @@ const getContextMenusModule = createLazyModule(() =>
     playAlbum,
     playAlbumSafe: (albumId) => window.playAlbumSafe(albumId),
     loadLists,
-    getContextAlbumId: () => getContextAlbumState().albumId,
+    getContextAlbum: () => getContextAlbumState(),
     setContextAlbum: (index, albumId) => {
       setContextAlbumState(index, albumId);
     },

--- a/src/js/modules/context-menus.js
+++ b/src/js/modules/context-menus.js
@@ -39,7 +39,7 @@ import { getDeviceIcon } from '../utils/device-icons.js';
  * @param {Function} deps.playAlbum - Play album
  * @param {Function} deps.playAlbumSafe - Play album safely by ID
  * @param {Function} deps.loadLists - Reload lists
- * @param {Function} deps.getContextAlbumId - Get context menu album ID
+ * @param {Function} deps.getContextAlbum - Get context menu album state
  * @param {Function} deps.setContextAlbum - Set context menu album state
  * @param {Function} deps.getContextList - Get context menu list state
  * @param {Function} deps.setContextList - Set context menu list state
@@ -72,7 +72,7 @@ export function createContextMenus(deps = {}) {
     playAlbum: _playAlbum,
     playAlbumSafe: _playAlbumSafe,
     loadLists: _loadLists,
-    getContextAlbumId,
+    getContextAlbum = () => ({ index: null, albumId: null }),
     setContextAlbum,
     getContextList,
     setContextList,
@@ -85,6 +85,14 @@ export function createContextMenus(deps = {}) {
 
   // Track loading performance optimization
   let trackAbortController = null;
+
+  function getContextAlbumId() {
+    const context = getContextAlbum();
+    if (!context || typeof context !== 'object') {
+      return null;
+    }
+    return context.albumId || null;
+  }
 
   /**
    * Hide all context menus and perform module-specific cleanup.

--- a/test/context-menus.test.js
+++ b/test/context-menus.test.js
@@ -38,7 +38,7 @@ describe('context-menus module', () => {
         playAlbum: mock.fn(),
         playAlbumSafe: mock.fn(),
         loadLists: mock.fn(),
-        getContextAlbumId: mock.fn(() => null),
+        getContextAlbum: mock.fn(() => ({ index: null, albumId: null })),
         setContextAlbum: mock.fn(),
         getContextList: mock.fn(() => null),
         setContextList: mock.fn(),


### PR DESCRIPTION
## Summary
- remove remaining split `getContextAlbumId` dependency wiring from context-menus by reading album identity from canonical context state object
- update app-level DI wiring to pass canonical context object accessor directly into context-menus
- adjust context-menus factory test dependency shape to match the canonical contract

## Validation
- `npm run lint:strict`
- `node --test test/context-menus.test.js test/album-context-menu-submenu.test.js test/playback-submenu.test.js`
- `npm run lint:structure:baseline`