### PR TITLE
Remove obsolete context object shape guard paths

### DIFF
--- a/src/js/modules/album-context-menu.js
+++ b/src/js/modules/album-context-menu.js
@@ -105,9 +105,6 @@ export function createAlbumContextMenu(deps = {}) {
 
   function getContextAlbumSelection() {
     const context = getContextAlbum();
-    if (!context || typeof context !== 'object') {
-      return { index: null, albumId: null };
-    }
     return {
       index: context.index ?? null,
       albumId: context.albumId ?? null,

--- a/src/js/modules/context-menus.js
+++ b/src/js/modules/context-menus.js
@@ -87,11 +87,7 @@ export function createContextMenus(deps = {}) {
   let trackAbortController = null;
 
   function getContextAlbumId() {
-    const context = getContextAlbum();
-    if (!context || typeof context !== 'object') {
-      return null;
-    }
-    return context.albumId || null;
+    return getContextAlbum().albumId || null;
   }
 
   /**

--- a/src/js/modules/playback.js
+++ b/src/js/modules/playback.js
@@ -36,9 +36,6 @@ export function createPlayback(deps = {}) {
 
   function getContextAlbumSelection() {
     const context = getContextAlbum();
-    if (!context || typeof context !== 'object') {
-      return { index: null, albumId: null };
-    }
     return {
       index: context.index ?? null,
       albumId: context.albumId ?? null,


### PR DESCRIPTION
## Summary
- remove obsolete context-object shape guard branches from `album-context-menu`, `playback`, and `context-menus`
- keep context album reads on canonical object access now that DI standardization is complete (`{ index, albumId }`)
- preserve current context action behavior while trimming residual compatibility scaffolding

## Validation
- `npm run lint:strict`
- `node --test test/context-menus.test.js test/album-context-menu-submenu.test.js test/playback-submenu.test.js`
- `npm run lint:structure:baseline`