### PR TITLE
Centralize legacy field normalization boundaries

### DIFF
--- a/src/js/modules/album-display-shared.js
+++ b/src/js/modules/album-display-shared.js
@@ -157,7 +157,7 @@ export function createAlbumDisplayShared(deps = {}) {
     const fingerprint = albums
       .map(
         (album) =>
-          `${album._id || ''}|${album.primary_track || album.track_picks?.primary || album.track_pick || ''}|${album.secondary_track || album.track_picks?.secondary || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}`
+          `${album._id || ''}|${album.primary_track || ''}|${album.secondary_track || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}`
       )
       .join('::');
 
@@ -176,7 +176,7 @@ export function createAlbumDisplayShared(deps = {}) {
 
     return albums.map(
       (album) =>
-        `${album._id || ''}|${album.artist || ''}|${album.album || ''}|${album.release_date || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}|${album.primary_track || album.track_picks?.primary || album.track_pick || ''}|${album.secondary_track || album.track_picks?.secondary || ''}`
+        `${album._id || ''}|${album.artist || ''}|${album.album || ''}|${album.release_date || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}|${album.primary_track || ''}|${album.secondary_track || ''}`
     );
   }
 

--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -159,7 +159,7 @@ export function createAlbumDisplay(deps = {}) {
     const countryDisplay = country || 'Country';
     const countryClass = country ? 'text-gray-300' : 'text-gray-800 italic';
 
-    const genre1 = album.genre_1 || album.genre || '';
+    const genre1 = album.genre_1 || '';
     const genre1Display = genre1 || 'Genre 1';
     const genre1Class = genre1 ? 'text-gray-300' : 'text-gray-800 italic';
 
@@ -168,7 +168,7 @@ export function createAlbumDisplay(deps = {}) {
     const genre2Display = genre2 || 'Genre 2';
     const genre2Class = genre2 ? 'text-gray-300' : 'text-gray-800 italic';
 
-    let comment = album.comments || album.comment || '';
+    let comment = album.comments || '';
     if (comment === 'Comment') comment = '';
 
     let comment2 = album.comments_2 || '';
@@ -234,15 +234,10 @@ export function createAlbumDisplay(deps = {}) {
     }
 
     // Process primary and secondary track picks.
-    const primaryTrack =
-      album.primary_track ||
-      album.track_picks?.primary ||
-      album.track_pick ||
-      '';
+    const primaryTrack = album.primary_track || '';
     const primaryData = processTrackPick(primaryTrack, album.tracks);
 
-    const secondaryTrack =
-      album.secondary_track || album.track_picks?.secondary || '';
+    const secondaryTrack = album.secondary_track || '';
     const secondaryData = processTrackPick(secondaryTrack, album.tracks);
 
     // Album summary (from Claude AI)
@@ -372,19 +367,15 @@ export function createAlbumDisplay(deps = {}) {
     const artist = album.artist || 'Unknown Artist';
     const albumName = album.album || 'Unknown Album';
     const country = album.country || '';
-    const genre1 = album.genre_1 || album.genre || '';
+    const genre1 = album.genre_1 || '';
     let genre2 = album.genre_2 || '';
     if (genre2 === 'Genre 2' || genre2 === '-') genre2 = '';
-    let comment = album.comments || album.comment || '';
+    let comment = album.comments || '';
     if (comment === 'Comment') comment = '';
     let comment2 = album.comments_2 || '';
     if (comment2 === 'Comment 2') comment2 = '';
 
-    const primaryTrack =
-      album.primary_track ||
-      album.track_picks?.primary ||
-      album.track_pick ||
-      '';
+    const primaryTrack = album.primary_track || '';
 
     // Inline track display logic (avoids processTrackPick closure allocation)
     let primaryTrackDisplay = 'Select Track';
@@ -713,7 +704,7 @@ export function createAlbumDisplay(deps = {}) {
     // Attach link preview
     const albumsForPreview = getListData(currentList);
     const album = albumsForPreview && albumsForPreview[index];
-    const comment = album ? album.comments || album.comment || '' : '';
+    const comment = album ? album.comments || '' : '';
     if (commentCell) {
       attachLinkPreview(commentCell, comment);
     }
@@ -1101,7 +1092,7 @@ export function createAlbumDisplay(deps = {}) {
     // Attach link preview to content area
     const albumsForMobile = getListData(currentList);
     const album = albumsForMobile && albumsForMobile[index];
-    const comment = album ? album.comments || album.comment || '' : '';
+    const comment = album ? album.comments || '' : '';
     const contentDiv = card.querySelector('.flex-1.min-w-0');
     if (contentDiv) attachLinkPreview(contentDiv, comment);
 
@@ -1424,7 +1415,7 @@ export function createAlbumDisplay(deps = {}) {
         // Build new fingerprint inline and compare as string -- cheaper than
         // comparing 8+ object properties individually, and avoids allocating objects.
         const newAlbum = newAlbums[i];
-        const newFp = `${newAlbum._id || ''}|${newAlbum.artist || ''}|${newAlbum.album || ''}|${newAlbum.release_date || ''}|${newAlbum.country || ''}|${newAlbum.genre_1 || ''}|${newAlbum.genre_2 || ''}|${newAlbum.comments || ''}|${newAlbum.comments_2 || ''}|${newAlbum.track_pick || ''}`;
+        const newFp = `${newAlbum._id || ''}|${newAlbum.artist || ''}|${newAlbum.album || ''}|${newAlbum.release_date || ''}|${newAlbum.country || ''}|${newAlbum.genre_1 || ''}|${newAlbum.genre_2 || ''}|${newAlbum.comments || ''}|${newAlbum.comments_2 || ''}|${newAlbum.primary_track || ''}`;
         if (oldFingerprints[i] !== newFp) {
           fieldChanges++;
         }

--- a/src/js/modules/app-state.js
+++ b/src/js/modules/app-state.js
@@ -13,34 +13,62 @@
 /** Lists keyed by _id. Structure: { _id, name, year, isMain, count, groupId, sortOrder, _data, updatedAt, createdAt } */
 let lists = {};
 
-function normalizeAlbumIdentifiers(albums = []) {
+function normalizeAlbumRecord(album) {
+  if (!album || typeof album !== 'object') {
+    return { album, changed: false };
+  }
+
+  let changed = false;
+  const normalized = { ...album };
+
+  if (!normalized.album_id && normalized.albumId) {
+    normalized.album_id = normalized.albumId;
+    changed = true;
+  }
+
+  if (normalized.comments == null && normalized.comment != null) {
+    normalized.comments = normalized.comment;
+    changed = true;
+  }
+
+  if (!normalized.genre_1 && normalized.genre) {
+    normalized.genre_1 = normalized.genre;
+    changed = true;
+  }
+
+  const legacyPrimary =
+    normalized.track_picks?.primary || normalized.track_pick || null;
+  if (!normalized.primary_track && legacyPrimary) {
+    normalized.primary_track = legacyPrimary;
+    changed = true;
+  }
+
+  const legacySecondary = normalized.track_picks?.secondary || null;
+  if (!normalized.secondary_track && legacySecondary) {
+    normalized.secondary_track = legacySecondary;
+    changed = true;
+  }
+
+  return { album: changed ? normalized : album, changed };
+}
+
+function normalizeAlbumRecords(albums = []) {
   if (!Array.isArray(albums)) {
     return [];
   }
 
   let changed = false;
   const normalized = albums.map((album) => {
-    if (
-      album &&
-      typeof album === 'object' &&
-      !album.album_id &&
-      album.albumId
-    ) {
-      changed = true;
-      return {
-        ...album,
-        album_id: album.albumId,
-      };
-    }
-
-    return album;
+    const result = normalizeAlbumRecord(album);
+    changed = changed || result.changed;
+    return result.album;
   });
 
   return changed ? normalized : albums;
 }
 
 function createDefaultListEntry(listId, albums = []) {
-  const data = normalizeAlbumIdentifiers(albums);
+  const data = normalizeAlbumRecords(albums);
 
   return {
     _id: listId,
@@ -66,7 +94,7 @@ function normalizeListsMap(newLists = {}) {
     }
 
     if (entry && typeof entry === 'object' && Array.isArray(entry._data)) {
-      const normalizedData = normalizeAlbumIdentifiers(entry._data);
+      const normalizedData = normalizeAlbumRecords(entry._data);
       normalized[listId] =
         normalizedData === entry._data
           ? entry
@@ -215,7 +243,7 @@ export function getListData(listId) {
 export function setListData(listId, albums, updateSnapshot = true) {
   if (!listId) return;
 
-  const normalizedAlbums = normalizeAlbumIdentifiers(albums || []);
+  const normalizedAlbums = normalizeAlbumRecords(albums || []);
 
   if (!lists[listId]) {
     lists[listId] = createDefaultListEntry(listId, normalizedAlbums);

--- a/src/js/modules/editable-fields.js
+++ b/src/js/modules/editable-fields.js
@@ -710,10 +710,7 @@ export function createEditableFields(deps = {}) {
     const albumsForComment = getListData(currentList);
     if (!albumsForComment || !albumsForComment[albumIndex]) return;
 
-    const currentComment =
-      albumsForComment[albumIndex].comments ||
-      albumsForComment[albumIndex].comment ||
-      '';
+    const currentComment = albumsForComment[albumIndex].comments || '';
 
     // Create textarea
     const textarea = document.createElement('textarea');
@@ -756,7 +753,6 @@ export function createEditableFields(deps = {}) {
 
         // Update local state
         albumsToUpdate[albumIndex].comments = newComment;
-        albumsToUpdate[albumIndex].comment = newComment;
 
         // Update display without re-rendering everything
         let displayComment = newComment;

--- a/src/js/modules/import-export.js
+++ b/src/js/modules/import-export.js
@@ -328,7 +328,7 @@ export async function downloadListAsCSV(listId) {
         album.country || '',
         album.genre_1 || '',
         album.genre_2 || '',
-        album.primary_track || album.track_pick || '',
+        album.primary_track || '',
         album.secondary_track || '',
         album.comments || '',
         album.comments_2 || '',

--- a/src/js/modules/mobile-ui.js
+++ b/src/js/modules/mobile-ui.js
@@ -1047,7 +1047,7 @@ export function createMobileUI(deps = {}) {
           <!-- Genre 1 - Searchable Select -->
           <div class="w-full">
             <label class="block text-gray-400 text-sm mb-2">Primary Genre</label>
-            <div id="editGenre1Container" class="searchable-genre-select" data-value="${album.genre_1 || album.genre || ''}" data-placeholder="Select a genre..."></div>
+            <div id="editGenre1Container" class="searchable-genre-select" data-value="${album.genre_1 || ''}" data-placeholder="Select a genre..."></div>
           </div>
           
           <!-- Genre 2 - Searchable Select -->
@@ -1064,7 +1064,7 @@ export function createMobileUI(deps = {}) {
               rows="3"
               class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:border-gray-500 transition duration-200 resize-none"
               placeholder="Add your notes..."
-            >${album.comments || album.comment || ''}</textarea>
+            >${album.comments || ''}</textarea>
           </div>
 
           <!-- Comments 2 -->
@@ -1094,17 +1094,9 @@ export function createMobileUI(deps = {}) {
                   .map((t) => {
                     const trackName = getTrackName(t);
                     const trackLength = formatTrackTime(getTrackLength(t));
-                    const isPrimary =
-                      trackName ===
-                      (album.primary_track ||
-                        album.track_picks?.primary ||
-                        album.track_pick ||
-                        '');
+                    const isPrimary = trackName === (album.primary_track || '');
                     const isSecondary =
-                      trackName ===
-                      (album.secondary_track ||
-                        album.track_picks?.secondary ||
-                        '');
+                      trackName === (album.secondary_track || '');
                     const indicator = isPrimary
                       ? '<span class="text-yellow-400 mr-1">★</span>'
                       : isSecondary
@@ -1132,7 +1124,7 @@ export function createMobileUI(deps = {}) {
               </ul>
             `
                 : `
-              <input type="number" id="editTrackPickNumber" value="${album.primary_track || album.track_picks?.primary || album.track_pick || ''}"
+              <input type="number" id="editTrackPickNumber" value="${album.primary_track || ''}"
                      class="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:border-gray-500 transition duration-200"
                      placeholder="Enter track number (primary)">
             `
@@ -1259,7 +1251,7 @@ export function createMobileUI(deps = {}) {
     initSearchableGenreSelect(
       'editGenre1Container',
       availableGenres,
-      album.genre_1 || album.genre || '',
+      album.genre_1 || '',
       'Select a genre...'
     );
     initSearchableGenreSelect(
@@ -1274,13 +1266,8 @@ export function createMobileUI(deps = {}) {
     const trackPickContainer = document.getElementById('trackPickContainer');
 
     // Track current selections (will be synced with server)
-    let currentPrimaryTrack =
-      album.primary_track ||
-      album.track_picks?.primary ||
-      album.track_pick ||
-      '';
-    let currentSecondaryTrack =
-      album.secondary_track || album.track_picks?.secondary || '';
+    let currentPrimaryTrack = album.primary_track || '';
+    let currentSecondaryTrack = album.secondary_track || '';
 
     function updateTrackPickUI() {
       if (!trackPickContainer) return;
@@ -1388,11 +1375,6 @@ export function createMobileUI(deps = {}) {
             // Update local album data for save
             album.primary_track = currentPrimaryTrack;
             album.secondary_track = currentSecondaryTrack;
-            album.track_pick = currentPrimaryTrack;
-            album.track_picks = {
-              primary: currentPrimaryTrack || null,
-              secondary: currentSecondaryTrack || null,
-            };
           } catch (err) {
             console.error('Track pick error:', err);
             showToast('Error updating track selection', 'error');
@@ -1489,6 +1471,13 @@ export function createMobileUI(deps = {}) {
           ? originalReleaseDate
           : formatDateForStorage(newDateValue);
 
+      const primaryTrackForSave =
+        currentPrimaryTrack ||
+        (() => {
+          const numInput = document.getElementById('editTrackPickNumber');
+          return numInput ? numInput.value.trim() : '';
+        })();
+
       const updatedAlbum = {
         ...album,
         artist: document.getElementById('editArtist').value.trim(),
@@ -1496,26 +1485,11 @@ export function createMobileUI(deps = {}) {
         release_date: finalReleaseDate,
         country: document.getElementById('editCountry').value,
         genre_1: document.getElementById('editGenre1').value,
-        genre: document.getElementById('editGenre1').value,
         genre_2: document.getElementById('editGenre2').value,
         tracks: Array.isArray(album.tracks) ? album.tracks : undefined,
-        // Track picks are now managed via API and stored in track_picks table
-        // Keep the current values which were updated by the track pick handlers
-        primary_track: currentPrimaryTrack,
+        primary_track: primaryTrackForSave,
         secondary_track: currentSecondaryTrack,
-        track_picks: {
-          primary: currentPrimaryTrack || null,
-          secondary: currentSecondaryTrack || null,
-        },
-        track_pick:
-          currentPrimaryTrack ||
-          (() => {
-            // Fallback for albums without album_id (can't use API)
-            const numInput = document.getElementById('editTrackPickNumber');
-            return numInput ? numInput.value.trim() : '';
-          })(),
         comments: document.getElementById('editComments').value.trim(),
-        comment: document.getElementById('editComments').value.trim(),
         comments_2: document.getElementById('editComments2').value.trim(),
       };
 

--- a/src/js/modules/music-services.js
+++ b/src/js/modules/music-services.js
@@ -3,14 +3,13 @@ import { showToast, apiCall, showConfirmation } from './utils.js';
 export async function updatePlaylist(listName, listData = []) {
   try {
     // Validate track selection before proceeding
-    // Check for new normalized fields (primary_track) or legacy field (track_pick)
     const totalAlbums = listData.length;
     const albumsWithTracks = listData.filter((album) => {
-      const primary = album.primary_track || album.track_pick;
+      const primary = album.primary_track;
       return primary && primary.trim() !== '';
     }).length;
     const albumsWithBothTracks = listData.filter((album) => {
-      const primary = album.primary_track || album.track_pick;
+      const primary = album.primary_track;
       const secondary = album.secondary_track;
       return (
         primary && primary.trim() !== '' && secondary && secondary.trim() !== ''

--- a/src/js/modules/playback.js
+++ b/src/js/modules/playback.js
@@ -369,8 +369,7 @@ export function createPlayback(deps = {}) {
     const album = albums && albums[index];
     if (!album) return;
 
-    const trackPick =
-      album.primary_track || album.track_picks?.primary || album.track_pick;
+    const trackPick = album.primary_track;
     if (!trackPick) {
       showToast('No track selected', 'error');
       return;

--- a/src/js/modules/track-selection.js
+++ b/src/js/modules/track-selection.js
@@ -249,10 +249,8 @@ export function createTrackSelection(deps = {}) {
     });
 
     // Get current picks
-    const currentPrimary =
-      album.primary_track || album.track_picks?.primary || album.track_pick;
-    const currentSecondary =
-      album.secondary_track || album.track_picks?.secondary || null;
+    const currentPrimary = album.primary_track;
+    const currentSecondary = album.secondary_track || null;
     const currentPrimaryName = getTrackName(currentPrimary);
     const currentSecondaryName = getTrackName(currentSecondary);
 
@@ -291,16 +289,14 @@ export function createTrackSelection(deps = {}) {
           method: 'DELETE',
         });
 
-        currentAlbum.track_pick = null;
         currentAlbum.primary_track = null;
         currentAlbum.secondary_track = null;
-        currentAlbum.track_picks = { primary: null, secondary: null };
         selectedPrimary = null;
         selectedSecondary = null;
         updateMenuUI();
         updateTrackCellDisplayDual(
           albumIndex,
-          currentAlbum.track_picks,
+          { primary: null, secondary: null },
           album.tracks
         );
       } catch (err) {
@@ -375,27 +371,19 @@ export function createTrackSelection(deps = {}) {
             selectedPrimary = result.primary_track || null;
             selectedSecondary = result.secondary_track || null;
 
-            const newPicks = {
-              primary: selectedPrimary
-                ? sortedTracks.find(
-                    (t) => getTrackName(t) === selectedPrimary
-                  ) || selectedPrimary
-                : null,
-              secondary: selectedSecondary
-                ? sortedTracks.find(
-                    (t) => getTrackName(t) === selectedSecondary
-                  ) || selectedSecondary
-                : null,
-            };
-
             // Update album data
             currentAlbum.primary_track = selectedPrimary;
             currentAlbum.secondary_track = selectedSecondary;
-            currentAlbum.track_pick = selectedPrimary;
-            currentAlbum.track_picks = newPicks;
 
             updateMenuUI();
-            updateTrackCellDisplayDual(albumIndex, newPicks, album.tracks);
+            updateTrackCellDisplayDual(
+              albumIndex,
+              {
+                primary: selectedPrimary,
+                secondary: selectedSecondary,
+              },
+              album.tracks
+            );
           }
         } catch (err) {
           console.error('Error saving track picks:', err);

--- a/test/album-display-shared.test.js
+++ b/test/album-display-shared.test.js
@@ -163,7 +163,7 @@ describe('album-display-shared module', () => {
         artist: 'A',
         album: 'B',
         release_date: '2024-01-01',
-        track_pick: 'Song',
+        primary_track: 'Song',
       },
     ];
 
@@ -171,7 +171,7 @@ describe('album-display-shared module', () => {
     const second = utils.generateAlbumFingerprint(albums);
     assert.strictEqual(first, second);
 
-    albums[0].track_pick = 'New';
+    albums[0].primary_track = 'New';
     const stale = utils.generateAlbumFingerprint(albums);
     assert.strictEqual(stale, first);
 

--- a/test/album-display.test.js
+++ b/test/album-display.test.js
@@ -202,7 +202,7 @@ describe('album-display module', () => {
         genre_1: 'Rock',
         genre_2: 'Alternative',
         comments: 'Great album',
-        track_pick: '1. First Track',
+        primary_track: '1. First Track',
         tracks: ['1. First Track', '2. Second Track'],
       };
 
@@ -290,7 +290,7 @@ describe('album-display module', () => {
 
       // Test with full track info
       let album = {
-        track_pick: '3. Favorite Song',
+        primary_track: '3. Favorite Song',
         tracks: ['1. First', '2. Second', '3. Favorite Song'],
       };
       let data = module.processAlbumData(album, 0);
@@ -299,7 +299,7 @@ describe('album-display module', () => {
 
       // Test with just track number
       album = {
-        track_pick: '5',
+        primary_track: '5',
         tracks: [],
       };
       data = module.processAlbumData(album, 0);

--- a/test/app-state.test.js
+++ b/test/app-state.test.js
@@ -82,6 +82,37 @@ describe('app-state', async () => {
       assert.strictEqual(album.albumId, 'legacy-1');
     });
 
+    it('setLists normalizes legacy comment and track-pick aliases', () => {
+      mod.setLists({
+        id1: {
+          _id: 'id1',
+          name: 'Test',
+          _data: [{ comment: 'Legacy note', track_pick: '5' }],
+          count: 1,
+        },
+      });
+
+      const album = mod.getListData('id1')[0];
+      assert.strictEqual(album.comments, 'Legacy note');
+      assert.strictEqual(album.primary_track, '5');
+      assert.strictEqual(album.track_pick, '5');
+    });
+
+    it('setLists normalizes legacy genre alias to genre_1', () => {
+      mod.setLists({
+        id1: {
+          _id: 'id1',
+          name: 'Test',
+          _data: [{ genre: 'Post-rock' }],
+          count: 1,
+        },
+      });
+
+      const album = mod.getListData('id1')[0];
+      assert.strictEqual(album.genre_1, 'Post-rock');
+      assert.strictEqual(album.genre, 'Post-rock');
+    });
+
     it('getListData returns null for nonexistent list', () => {
       assert.strictEqual(mod.getListData('nonexistent'), null);
     });
@@ -157,6 +188,19 @@ describe('app-state', async () => {
       const album = mod.getListData('id1')[0];
       assert.strictEqual(album.album_id, 'legacy-2');
       assert.strictEqual(album.albumId, 'legacy-2');
+    });
+
+    it('setListData normalizes track_picks to canonical track fields', () => {
+      mod.setLists({ id1: { _id: 'id1', _data: [], count: 0 } });
+      mod.setListData(
+        'id1',
+        [{ track_picks: { primary: 'Track A', secondary: 'Track B' } }],
+        false
+      );
+
+      const album = mod.getListData('id1')[0];
+      assert.strictEqual(album.primary_track, 'Track A');
+      assert.strictEqual(album.secondary_track, 'Track B');
     });
 
     it('setListData does nothing when listId is falsy', () => {


### PR DESCRIPTION
## Summary
- centralize remaining legacy list-item field compatibility at the app-state boundary (album/comment/genre/track-pick aliases) so downstream modules can read canonical fields only
- remove duplicated read-time fallback branches across album display/edit/play/track-selection/import-export/music-service flows and keep behavior unchanged
- reduce source complexity in touched modules (net source module reduction: 115 deletions vs 90 insertions) while preserving compatibility via boundary normalization

## Validation
- `npm run lint:strict`
- `node --test test/app-state.test.js test/album-display.test.js test/album-display-shared.test.js test/mobile-ui.test.js test/playback-submenu.test.js test/context-menus.test.js`
- `npm run lint:structure:baseline`
- `npm run build`