### PR TITLE
Retire stale mobile track selector compatibility path

### DIFF
--- a/src/js/modules/track-selection.js
+++ b/src/js/modules/track-selection.js
@@ -165,60 +165,50 @@ export function createTrackSelection(deps = {}) {
       cellHtml = primaryHtml + secondaryHtml;
     }
 
+    let trackCell = null;
+
     if (isMobile) {
       const cards = document.querySelectorAll('.album-card');
       const card = cards[albumIndex];
       if (!card) return;
 
-      const trackCell = card.querySelector('[data-field="track_pick"]');
-      if (trackCell) {
-        trackCell.innerHTML = cellHtml;
-        trackCell.onclick = async (e) => {
-          e.stopPropagation();
-          const listData = getListData(getCurrentListId());
-          if (!listData) return;
-          const album = listData[albumIndex];
-          if (!album) return;
-          if (!album.tracks) {
-            try {
-              await fetchTracksForAlbum(album);
-            } catch (_err) {
-              showToast('Could not load tracks', 'error');
-              return;
-            }
-          }
-          const rect = trackCell.getBoundingClientRect();
-          showTrackSelectionMenu(album, albumIndex, rect.left, rect.bottom);
-        };
+      trackCell = card
+        .querySelector('[data-field="track-mobile-text"]')
+        ?.closest('div[data-track-play-btn]');
+      const secondaryRow = card
+        .querySelector('[data-field="secondary-track-mobile-text"]')
+        ?.closest('div[data-track-play-btn]');
+      if (secondaryRow && secondaryRow !== trackCell) {
+        secondaryRow.remove();
       }
     } else {
       const rows = document.querySelectorAll('.album-row');
       const row = rows[albumIndex];
       if (!row) return;
-
-      const trackCell = row.querySelector('.track-cell');
-      if (trackCell) {
-        trackCell.innerHTML = cellHtml;
-        trackCell.style.cursor = 'pointer';
-        trackCell.onclick = async (e) => {
-          e.stopPropagation();
-          const listData = getListData(getCurrentListId());
-          if (!listData) return;
-          const album = listData[albumIndex];
-          if (!album) return;
-          if (!album.tracks) {
-            try {
-              await fetchTracksForAlbum(album);
-            } catch (_err) {
-              showToast('Could not load tracks', 'error');
-              return;
-            }
-          }
-          const rect = trackCell.getBoundingClientRect();
-          showTrackSelectionMenu(album, albumIndex, rect.left, rect.bottom);
-        };
-      }
+      trackCell = row.querySelector('.track-cell');
     }
+
+    if (!trackCell) return;
+
+    trackCell.innerHTML = cellHtml;
+    trackCell.style.cursor = 'pointer';
+    trackCell.onclick = async (e) => {
+      e.stopPropagation();
+      const listData = getListData(getCurrentListId());
+      if (!listData) return;
+      const album = listData[albumIndex];
+      if (!album) return;
+      if (!album.tracks) {
+        try {
+          await fetchTracksForAlbum(album);
+        } catch (_err) {
+          showToast('Could not load tracks', 'error');
+          return;
+        }
+      }
+      const rect = trackCell.getBoundingClientRect();
+      showTrackSelectionMenu(album, albumIndex, rect.left, rect.bottom);
+    };
   }
 
   // ============ TRACK SELECTION MENU ============


### PR DESCRIPTION
## Summary
- remove stale mobile track-selection selector coupling to `data-field=track_pick` and switch to canonical mobile track field targeting
- collapse duplicated mobile/desktop track-cell click wiring in `track-selection` into one shared interaction path
- keep quick track menu behavior unchanged while reducing branching and legacy selector usage

## Validation
- `npm run lint:strict`
- `npm run build`
- `npm run lint:structure:baseline`
- `node --test test/mobile-ui.test.js test/album-display.test.js`