### PR TITLE
Prune obsolete playlist trackPick compatibility path

### DIFF
--- a/services/playlist/playlist-helpers.js
+++ b/services/playlist/playlist-helpers.js
@@ -8,18 +8,14 @@
 /**
  * Resolve primary and secondary track picks from an item.
  * Handles both normalized field names (primaryTrack/secondaryTrack)
- * and legacy field names (primary_track/secondary_track, trackPick/track_pick).
+ * and legacy field names (primary_track/secondary_track, track_pick).
  *
  * @param {Object} item - Album/list item
  * @returns {{ primaryTrack: string|null, secondaryTrack: string|null }}
  */
 function resolveTrackPicks(item) {
   const primaryTrack =
-    item.primaryTrack ||
-    item.primary_track ||
-    item.trackPick ||
-    item.track_pick ||
-    null;
+    item.primaryTrack || item.primary_track || item.track_pick || null;
   const secondaryTrack = item.secondaryTrack || item.secondary_track || null;
   return { primaryTrack, secondaryTrack };
 }

--- a/test/playlist-helpers.test.js
+++ b/test/playlist-helpers.test.js
@@ -24,12 +24,6 @@ describe('resolveTrackPicks', () => {
     assert.strictEqual(result.secondaryTrack, 'Track B');
   });
 
-  it('should resolve legacy trackPick field', () => {
-    const result = resolveTrackPicks({ trackPick: 'Legacy Track' });
-    assert.strictEqual(result.primaryTrack, 'Legacy Track');
-    assert.strictEqual(result.secondaryTrack, null);
-  });
-
   it('should resolve legacy track_pick field', () => {
     const result = resolveTrackPicks({ track_pick: 'Legacy Track' });
     assert.strictEqual(result.primaryTrack, 'Legacy Track');
@@ -39,8 +33,7 @@ describe('resolveTrackPicks', () => {
   it('should prefer primaryTrack over legacy fields', () => {
     const result = resolveTrackPicks({
       primaryTrack: 'Primary',
-      trackPick: 'Legacy',
-      track_pick: 'Legacy2',
+      track_pick: 'Legacy',
     });
     assert.strictEqual(result.primaryTrack, 'Primary');
   });


### PR DESCRIPTION
## Summary
- remove obsolete `trackPick` playlist input compatibility handling and keep canonical primary-track resolution paths (`primaryTrack`, `primary_track`, `track_pick`)
- simplify playlist helper resolution logic and keep behavior unchanged for current server/frontend payloads
- update playlist helper tests to reflect the reduced compatibility surface

## Validation
- `npm run lint:strict`
- `node --test test/playlist-helpers.test.js test/mobile-ui.test.js test/album-display.test.js`
- `npm run build`
- `npm run lint:structure:baseline`