### PR TITLE
Prune playcount albumId compatibility plumbing

### DIFF
--- a/services/playcount-service.js
+++ b/services/playcount-service.js
@@ -86,7 +86,7 @@ function matchAndFindStale(listItems, statsMap, normalizeAlbumKey) {
         itemId: item._id,
         artist: item.artist,
         album: item.album,
-        albumId: item.album_id,
+        album_id: item.album_id,
       });
     }
   }
@@ -137,7 +137,7 @@ function createPlaycountService(deps = {}) {
    * Refresh playcounts for albums in background
    * @param {string} userId - User ID
    * @param {string} lastfmUsername - User's Last.fm username
-   * @param {Array} albums - Array of album objects with itemId, artist, album, albumId
+   * @param {Array} albums - Array of album objects with itemId, artist, album, album_id
    * @param {Object} pool - Database connection pool
    * @param {Object} logger - Logger instance
    * @returns {Promise<Object>} - Map of itemId -> { playcount, status }

--- a/services/playcount-sync-service.js
+++ b/services/playcount-sync-service.js
@@ -118,7 +118,7 @@ async function upsertPlaycount(pool, userId, album, playcount, status) {
   const canonicalArtist = normalizeForLastfm(album.artist).toLowerCase().trim();
   const canonicalAlbum = normalizeForLastfm(album.album).toLowerCase().trim();
   const normalizedKey = normalizeAlbumKey(canonicalArtist, canonicalAlbum);
-  const albumId = album.album_id || album.albumId || null;
+  const albumId = album.album_id || null;
 
   await pool.query(
     `INSERT INTO user_album_stats (user_id, album_id, artist, album_name, normalized_key, lastfm_playcount, lastfm_status, lastfm_updated_at, updated_at)
@@ -145,7 +145,7 @@ async function upsertPlaycount(pool, userId, album, playcount, status) {
 
 async function getLastfmArtistCandidates(pool, log, album) {
   const canonicalArtist = album?.artist;
-  const albumId = album?.album_id || album?.albumId || null;
+  const albumId = album?.album_id || null;
 
   if (!canonicalArtist) {
     return [];
@@ -204,7 +204,7 @@ async function getLastfmArtistCandidates(pool, log, album) {
  */
 async function refreshAlbumPlaycount(pool, log, userId, lastfmUsername, album) {
   try {
-    const albumId = album.album_id || album.albumId || null;
+    const albumId = album.album_id || null;
     const artistCandidates = await getLastfmArtistCandidates(pool, log, album);
 
     let info = null;

--- a/test/playcount-service.test.js
+++ b/test/playcount-service.test.js
@@ -12,7 +12,7 @@ const { createPlaycountService } = require('../services/playcount-service');
 
 // Helper to create a mock album object
 function createAlbum(id, artist = 'Artist', album = 'Album') {
-  return { itemId: id, artist, album, albumId: `album-${id}` };
+  return { itemId: id, artist, album, album_id: `album-${id}` };
 }
 
 describe('playcount-service', () => {


### PR DESCRIPTION
## Summary
- remove `album.albumId` compatibility reads from playcount sync internals and standardize on canonical `album.album_id`
- align playcount-service stale-refresh payload shape with canonical `album_id` to eliminate internal alias bridging
- update playcount-service tests to reflect canonical payload shape

## Validation
- `npm run lint:strict`
- `node --test test/playcount-service.test.js test/playcount-sync-service.test.js`
- `npm run lint:structure:baseline`