### PR TITLE
Prune obsolete playback utils compatibility exports

### DIFF
--- a/src/js/modules/now-playing.js
+++ b/src/js/modules/now-playing.js
@@ -8,10 +8,8 @@
  * @module now-playing
  */
 
-import {
-  normalizeForMatch,
-  isAlbumMatchingPlayback,
-} from './playback-utils.js';
+import { isAlbumMatchingPlayback } from './playback-utils.js';
+import { normalizeForMatch } from './normalization.js';
 
 /**
  * Factory function to create the now-playing module with injected dependencies

--- a/src/js/modules/playback-utils.js
+++ b/src/js/modules/playback-utils.js
@@ -6,12 +6,6 @@
 // Import normalizeForMatch from centralized normalization module
 import { normalizeForMatch } from './normalization.js';
 
-// Re-export for backward compatibility
-export { normalizeForMatch };
-
-// Re-export getDeviceIcon from standalone util (no @utils alias dependency)
-export { getDeviceIcon } from '../utils/device-icons.js';
-
 /**
  * Check if a list album matches the currently playing Spotify track
  * @param {Object} listAlbum - Album from the list with .album and .artist properties


### PR DESCRIPTION
## Summary
- remove obsolete compatibility re-exports from `playback-utils` that no active modules consume
- import `normalizeForMatch` directly from `normalization` in `now-playing` and keep playback matching behavior unchanged
- shrink legacy compatibility surface and reduce unused export plumbing

## Validation
- `npm run lint:strict`
- `node --test test/playback-utils.test.js`
- `npm run build`
- `npm run lint:structure:baseline`