### PR TITLE
Standardize recommendation playback album identity shape

### DIFF
--- a/src/js/modules/playback.js
+++ b/src/js/modules/playback.js
@@ -216,16 +216,16 @@ export function createPlayback(deps = {}) {
       ...menuOptions,
       onOpenApp: () =>
         playAlbumByMetadata(album.artist, album.album, {
-          albumId: album.albumId,
-          releaseDate: album.releaseDate,
+          albumId: album.album_id,
+          releaseDate: album.release_date,
         }),
       onSpotifyDevice: (deviceId) =>
         playOnSpotifyDevice(
           {
             artist: album.artist,
             album: album.album,
-            album_id: album.albumId,
-            release_date: album.releaseDate,
+            album_id: album.album_id,
+            release_date: album.release_date,
           },
           deviceId,
           showToast

--- a/src/js/modules/recommendations.js
+++ b/src/js/modules/recommendations.js
@@ -408,8 +408,8 @@ export function createRecommendations(deps = {}) {
               {
                 artist: rec.artist,
                 album: rec.album,
-                albumId: rec.album_id,
-                releaseDate: rec.release_date,
+                album_id: rec.album_id,
+                release_date: rec.release_date,
               },
               {
                 playOptionId: 'playRecommendationOption',


### PR DESCRIPTION
## Summary
- standardize recommendation context playback handoff on canonical album identity fields (`album_id`, `release_date`) instead of mixed alias shape
- remove redundant alias bridging inside playback submenu handlers while preserving existing play/open behavior
- keep recommendation playback and submenu flows unchanged with targeted test coverage

## Validation
- `npm run lint:strict`
- `node --test test/playback-submenu.test.js test/recommendations-playback.test.js test/recommendations-context-menu.test.js`
- `npm run build`
- `npm run lint:structure:baseline`