### PR TITLE
Standardize list realtime contracts on listId

### DIFF
--- a/routes/api/lists.js
+++ b/routes/api/lists.js
@@ -203,7 +203,12 @@ module.exports = (app, deps) => {
       // Broadcast rename event if name changed
       const broadcast = req.app.locals.broadcast;
       if (broadcast && newName && newName.trim() !== result.list.name) {
-        broadcast.listRenamed(req.user._id, result.list.name, newName.trim());
+        broadcast.listRenamed(
+          req.user._id,
+          id,
+          result.list.name,
+          newName.trim()
+        );
       }
 
       res.json({ success: true });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -809,33 +809,29 @@ function getRealtimeSyncModule() {
       apiCall,
       updateAlbumSummaryInPlace: (albumId, summaryData) =>
         getAlbumDisplayModule().updateAlbumSummaryInPlace(albumId, summaryData),
-      refreshListData: async (listName) => {
+      refreshListData: async (listId) => {
         // Check if this was our own save - skip refresh and notification
-        if (wasRecentLocalSave(listName)) {
+        if (wasRecentLocalSave(listId)) {
           console.log(
             '[RealtimeSync] Skipping refresh for local save:',
-            listName
+            listId
           );
           return { wasLocalSave: true };
         }
 
         // Fetch fresh data and update the display
-        const data = await apiCall(
-          `/api/lists/${encodeURIComponent(listName)}`
-        );
-        setListData(listName, data);
-        if (getCurrentListId() === listName) {
+        const data = await apiCall(`/api/lists/${encodeURIComponent(listId)}`);
+        setListData(listId, data);
+        if (getCurrentListId() === listId) {
           displayAlbums(data, { forceFullRebuild: true });
         }
         return { wasLocalSave: false };
       },
-      refreshListDataSilent: async (listName) => {
+      refreshListDataSilent: async (listId) => {
         // Silent refresh without notifications (for summary updates)
-        const data = await apiCall(
-          `/api/lists/${encodeURIComponent(listName)}`
-        );
-        setListData(listName, data);
-        if (getCurrentListId() === listName) {
+        const data = await apiCall(`/api/lists/${encodeURIComponent(listId)}`);
+        setListData(listId, data);
+        if (getCurrentListId() === listId) {
           displayAlbums(data, { forceFullRebuild: true });
         }
       },

--- a/src/js/modules/realtime-sync.js
+++ b/src/js/modules/realtime-sync.js
@@ -10,7 +10,7 @@ import { io } from 'socket.io-client';
  * @param {Object} deps - Dependencies
  * @param {Function} deps.getListData - Get data for a list
  * @param {Function} deps.setListData - Set data for a list
- * @param {Function} deps.getCurrentList - Get the currently selected list name
+ * @param {Function} deps.getCurrentList - Get the currently selected list ID
  * @param {Function} deps.refreshListData - Refresh list data from server
  * @param {Function} deps.refreshListNav - Refresh the sidebar list navigation
  * @param {Function} deps.showToast - Show toast notification
@@ -27,6 +27,7 @@ export function createRealtimeSync(deps = {}) {
     apiCall = async () => {},
     updateAlbumSummaryInPlace = async () => {},
     displayAlbums = () => {},
+    ioFactory = io,
   } = deps;
 
   let socket = null;
@@ -43,7 +44,7 @@ export function createRealtimeSync(deps = {}) {
     }
 
     // Connect to the same origin (works for both dev and production)
-    socket = io({
+    socket = ioFactory({
       // Use the same path as the HTTP server
       path: '/socket.io',
       // Reconnection settings
@@ -125,40 +126,54 @@ export function createRealtimeSync(deps = {}) {
 
   /**
    * Subscribe to updates for a specific list
-   * @param {string} listName - Name of the list to subscribe to
+   * @param {string} listId - ID of the list to subscribe to
    */
-  function subscribeToList(listName) {
+  function subscribeToList(listId) {
     if (socket && isConnected) {
-      socket.emit('subscribe:list', listName);
-      console.log('[RealtimeSync] Subscribed to list:', listName);
+      socket.emit('subscribe:list', listId);
+      console.log('[RealtimeSync] Subscribed to list:', listId);
     }
   }
 
   /**
    * Unsubscribe from updates for a specific list
-   * @param {string} listName - Name of the list to unsubscribe from
+   * @param {string} listId - ID of the list to unsubscribe from
    */
-  function unsubscribeFromList(listName) {
+  function unsubscribeFromList(listId) {
     if (socket && isConnected) {
-      socket.emit('unsubscribe:list', listName);
-      console.log('[RealtimeSync] Unsubscribed from list:', listName);
+      socket.emit('unsubscribe:list', listId);
+      console.log('[RealtimeSync] Unsubscribed from list:', listId);
     }
+  }
+
+  function getEventListId(data, eventName) {
+    if (typeof data?.listId !== 'string' || data.listId.length === 0) {
+      console.warn('[RealtimeSync] Ignoring event without listId', {
+        eventName,
+        data,
+      });
+      return null;
+    }
+    return data.listId;
   }
 
   /**
    * Handle list updated event
    * @param {Object} data - Event payload
-   * @param {string} data.listName - Name of the updated list
+   * @param {string} data.listId - ID of the updated list
    * @param {string} data.updatedAt - Timestamp of the update
    */
   async function handleListUpdated(data) {
     console.log('[RealtimeSync] List updated:', data);
 
+    const listId = getEventListId(data, 'list:updated');
+    if (!listId) return;
+
     const currentList = getCurrentList();
-    if (data.listName === currentList) {
+    if (listId === currentList) {
       // Refresh the current list data
       try {
-        const result = await refreshListData(data.listName);
+        const result = await refreshListData(listId);
         // Only show notification if this wasn't our own save
         if (!result?.wasLocalSave) {
           showToast('List updated from another device', 'info');
@@ -181,12 +196,14 @@ export function createRealtimeSync(deps = {}) {
   async function handleListReordered(data) {
     console.log('[RealtimeSync] List reordered:', data);
 
+    const listId = getEventListId(data, 'list:reordered');
+    if (!listId) return;
+
     const currentList = getCurrentList();
-    const targetListId = data.listId || data.listName;
-    if (targetListId === currentList) {
+    if (listId === currentList) {
       // Refresh the current list to get new order
       try {
-        await refreshListData(targetListId);
+        await refreshListData(listId);
         // Optionally show notification (can be commented out if too noisy)
         // showToast('List order updated', 'info');
       } catch (error) {
@@ -216,18 +233,18 @@ export function createRealtimeSync(deps = {}) {
   /**
    * Handle list deleted event
    * @param {Object} data - Event payload
-   * @param {string} data.listName - Name of the deleted list
+   * @param {string} data.listId - ID of the deleted list
    */
   function handleListDeleted(data) {
     console.log('[RealtimeSync] List deleted:', data);
 
+    const listId = getEventListId(data, 'list:deleted');
+    if (!listId) return;
+
     const currentList = getCurrentList();
-    if (data.listName === currentList) {
+    if (listId === currentList) {
       // Current list was deleted, show notification
-      showToast(
-        `List "${data.listName}" was deleted on another device`,
-        'warning'
-      );
+      showToast('Current list was deleted on another device', 'warning');
     }
 
     // Refresh sidebar to remove the deleted list
@@ -237,14 +254,18 @@ export function createRealtimeSync(deps = {}) {
   /**
    * Handle list renamed event
    * @param {Object} data - Event payload
+   * @param {string} data.listId - ID of the renamed list
    * @param {string} data.oldName - Previous name of the list
    * @param {string} data.newName - New name of the list
    */
   function handleListRenamed(data) {
     console.log('[RealtimeSync] List renamed:', data);
 
+    const listId = getEventListId(data, 'list:renamed');
+    if (!listId) return;
+
     const currentList = getCurrentList();
-    if (data.oldName === currentList) {
+    if (listId === currentList) {
       showToast(`List renamed to "${data.newName}" on another device`, 'info');
     }
 
@@ -255,11 +276,14 @@ export function createRealtimeSync(deps = {}) {
   /**
    * Handle list main status changed event
    * @param {Object} data - Event payload
-   * @param {string} data.listName - Name of the list
+   * @param {string} data.listId - ID of the list
    * @param {boolean} data.isMain - Whether the list is now the main list
    */
   function handleListMainChanged(data) {
     console.log('[RealtimeSync] List main status changed:', data);
+
+    const listId = getEventListId(data, 'list:main-changed');
+    if (!listId) return;
 
     // Refresh sidebar to update the main indicator
     refreshListNav();
@@ -267,7 +291,7 @@ export function createRealtimeSync(deps = {}) {
     // If this is the currently displayed list, re-render to show/hide position numbers
     // Position numbers only appear on main lists (they have semantic meaning for rankings)
     const currentList = getCurrentList();
-    if (data.listName === currentList) {
+    if (listId === currentList) {
       const albums = getListData(currentList);
       if (albums) {
         // Force full rebuild to add/remove position elements

--- a/test/realtime-sync.test.js
+++ b/test/realtime-sync.test.js
@@ -1,0 +1,147 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+function createFakeSocket() {
+  const handlers = new Map();
+
+  return {
+    id: 'socket-test-1',
+    io: {
+      engine: {
+        transport: {
+          name: 'websocket',
+        },
+      },
+    },
+    emitted: [],
+    on(event, handler) {
+      const current = handlers.get(event) || [];
+      current.push(handler);
+      handlers.set(event, current);
+      return this;
+    },
+    emit(event, payload) {
+      this.emitted.push({ event, payload });
+    },
+    disconnect() {},
+    connect() {},
+    async trigger(event, payload) {
+      const listeners = handlers.get(event) || [];
+      for (const listener of listeners) {
+        await listener(payload);
+      }
+    },
+  };
+}
+
+describe('realtime-sync module', () => {
+  let createRealtimeSync;
+
+  beforeEach(async () => {
+    const module = await import('../src/js/modules/realtime-sync.js');
+    createRealtimeSync = module.createRealtimeSync;
+  });
+
+  it('refreshes current list on list:updated when listId matches', async () => {
+    const fakeSocket = createFakeSocket();
+    const refreshCalls = [];
+    const navCalls = [];
+    const toasts = [];
+
+    const sync = createRealtimeSync({
+      ioFactory: () => fakeSocket,
+      getCurrentList: () => 'list-1',
+      refreshListData: async (listId) => {
+        refreshCalls.push(listId);
+        return { wasLocalSave: false };
+      },
+      refreshListNav: () => navCalls.push('called'),
+      showToast: (...args) => toasts.push(args),
+    });
+
+    sync.connect();
+    await fakeSocket.trigger('list:updated', {
+      listId: 'list-1',
+      updatedAt: new Date().toISOString(),
+    });
+
+    assert.deepStrictEqual(refreshCalls, ['list-1']);
+    assert.deepStrictEqual(navCalls, []);
+    assert.deepStrictEqual(toasts, [
+      ['List updated from another device', 'info'],
+    ]);
+  });
+
+  it('refreshes sidebar for list:updated when another list changes', async () => {
+    const fakeSocket = createFakeSocket();
+    const refreshCalls = [];
+    const navCalls = [];
+
+    const sync = createRealtimeSync({
+      ioFactory: () => fakeSocket,
+      getCurrentList: () => 'list-1',
+      refreshListData: async (listId) => {
+        refreshCalls.push(listId);
+      },
+      refreshListNav: () => navCalls.push('called'),
+      showToast: () => {},
+    });
+
+    sync.connect();
+    await fakeSocket.trigger('list:updated', {
+      listId: 'list-2',
+      updatedAt: new Date().toISOString(),
+    });
+
+    assert.deepStrictEqual(refreshCalls, []);
+    assert.deepStrictEqual(navCalls, ['called']);
+  });
+
+  it('ignores list:reordered payloads that do not include listId', async () => {
+    const fakeSocket = createFakeSocket();
+    const refreshCalls = [];
+
+    const sync = createRealtimeSync({
+      ioFactory: () => fakeSocket,
+      getCurrentList: () => 'list-1',
+      refreshListData: async (listId) => {
+        refreshCalls.push(listId);
+      },
+    });
+
+    sync.connect();
+    await fakeSocket.trigger('list:reordered', {
+      listName: 'list-1',
+      order: ['a', 'b'],
+    });
+
+    assert.deepStrictEqual(refreshCalls, []);
+  });
+
+  it('rebuilds current list display on list:main-changed using listId', async () => {
+    const fakeSocket = createFakeSocket();
+    const displayCalls = [];
+    const navCalls = [];
+    const albums = [{ album_id: 'album-1' }];
+
+    const sync = createRealtimeSync({
+      ioFactory: () => fakeSocket,
+      getCurrentList: () => 'list-1',
+      getListData: () => albums,
+      refreshListNav: () => navCalls.push('called'),
+      displayAlbums: (data, options) => displayCalls.push([data, options]),
+    });
+
+    sync.connect();
+    await fakeSocket.trigger('list:main-changed', {
+      listId: 'list-1',
+      isMain: true,
+      changedAt: new Date().toISOString(),
+    });
+
+    assert.deepStrictEqual(navCalls, ['called']);
+    assert.deepStrictEqual(displayCalls, [
+      [albums, { forceFullRebuild: true }],
+    ]);
+  });
+});

--- a/utils/websocket.js
+++ b/utils/websocket.js
@@ -193,23 +193,41 @@ function createWebSocketService(deps = {}) {
       });
 
       // Handle client subscribing to a specific list
-      socket.on('subscribe:list', (listName) => {
-        const listRoom = `list:${userId}:${listName}`;
+      socket.on('subscribe:list', (listId) => {
+        if (typeof listId !== 'string' || listId.length === 0) {
+          logger.warn('Client subscribe:list payload missing listId', {
+            socketId: socket.id,
+            userId,
+            listId,
+          });
+          return;
+        }
+
+        const listRoom = `list:${userId}:${listId}`;
         socket.join(listRoom);
         logger.debug('Client subscribed to list', {
           socketId: socket.id,
-          listName,
+          listId,
           listRoom,
         });
       });
 
       // Handle client unsubscribing from a list
-      socket.on('unsubscribe:list', (listName) => {
-        const listRoom = `list:${userId}:${listName}`;
+      socket.on('unsubscribe:list', (listId) => {
+        if (typeof listId !== 'string' || listId.length === 0) {
+          logger.warn('Client unsubscribe:list payload missing listId', {
+            socketId: socket.id,
+            userId,
+            listId,
+          });
+          return;
+        }
+
+        const listRoom = `list:${userId}:${listId}`;
         socket.leave(listRoom);
         logger.debug('Client unsubscribed from list', {
           socketId: socket.id,
-          listName,
+          listId,
         });
       });
 


### PR DESCRIPTION
## Summary
- Standardize list realtime event handling on canonical listId fields in the client sync module, and ignore malformed list events that do not include listId.
- Align list rename broadcasts with the websocket payload contract by passing listId from the lists route.
- Add targeted realtime-sync contract tests covering list:updated, list:reordered, and list:main-changed listId behavior.

## Testing
- 
ode --test test/realtime-sync.test.js`n- 
ode --test test/websocket.test.js`n- 
pm run lint:strict`n- 
pm test (fails on this host: /bin/bash not available)`n- docker compose -f docker-compose.local.yml exec app npm test (fails: Docker engine unavailable)