### PR TITLE
Unify track-pick interaction flow across editors

### DIFF
--- a/src/js/modules/mobile-ui.js
+++ b/src/js/modules/mobile-ui.js
@@ -13,6 +13,7 @@ import { createActionSheet } from './ui-factories.js';
 import { createTransferHelpers } from './album-transfer.js';
 import { fetchSpotifyDevices } from '../utils/playback-service.js';
 import { createMobileAlbumActions } from './mobile-ui/album-actions.js';
+import { createTrackPickService } from './track-pick-service.js';
 
 /**
  * Factory function to create the mobile UI module with injected dependencies
@@ -92,6 +93,7 @@ export function createMobileUI(deps = {}) {
     isViewingRecommendations,
     recommendAlbum,
   } = deps;
+  const trackPickService = createTrackPickService({ apiCall });
 
   /**
    * Find album by identity string instead of index
@@ -1325,8 +1327,6 @@ export function createMobileUI(deps = {}) {
 
           const trackName = item.dataset.track;
           const listItemId = trackPickContainer.dataset.listItemId;
-          const isPrimary = item.dataset.isPrimary === 'true';
-          const isSecondary = item.dataset.isSecondary === 'true';
 
           if (!listItemId) {
             showToast('Cannot save - missing list item ID', 'error');
@@ -1334,37 +1334,16 @@ export function createMobileUI(deps = {}) {
           }
 
           try {
-            if (isPrimary) {
-              // Deselect primary
-              const result = await apiCall(`/api/track-picks/${listItemId}`, {
-                method: 'DELETE',
-                body: JSON.stringify({ trackIdentifier: trackName }),
-              });
-              currentPrimaryTrack = result.primary_track || '';
-              currentSecondaryTrack = result.secondary_track || '';
-            } else if (isSecondary) {
-              // Promote to primary
-              const result = await apiCall(`/api/track-picks/${listItemId}`, {
-                method: 'POST',
-                body: JSON.stringify({
-                  trackIdentifier: trackName,
-                  priority: 1,
-                }),
-              });
-              currentPrimaryTrack = result.primary_track || '';
-              currentSecondaryTrack = result.secondary_track || '';
-            } else {
-              // New selection as secondary
-              const result = await apiCall(`/api/track-picks/${listItemId}`, {
-                method: 'POST',
-                body: JSON.stringify({
-                  trackIdentifier: trackName,
-                  priority: 2,
-                }),
-              });
-              currentPrimaryTrack = result.primary_track || '';
-              currentSecondaryTrack = result.secondary_track || '';
-            }
+            const result = await trackPickService.updateTrackPick(
+              listItemId,
+              trackName,
+              {
+                primaryTrack: currentPrimaryTrack,
+                secondaryTrack: currentSecondaryTrack,
+              }
+            );
+            currentPrimaryTrack = result.primaryTrack;
+            currentSecondaryTrack = result.secondaryTrack;
 
             // Update UI immediately
             updateTrackPickUI();

--- a/src/js/modules/track-pick-service.js
+++ b/src/js/modules/track-pick-service.js
@@ -1,0 +1,54 @@
+export function createTrackPickService(deps = {}) {
+  const { apiCall = async () => {} } = deps;
+
+  function normalizeTrackPicks(result = null) {
+    return {
+      primaryTrack: result?.primary_track || '',
+      secondaryTrack: result?.secondary_track || '',
+    };
+  }
+
+  function buildTrackPickRequest(trackName, currentPicks = {}) {
+    const selectedPrimary = currentPicks.primaryTrack || null;
+    const selectedSecondary = currentPicks.secondaryTrack || null;
+
+    if (trackName === selectedPrimary) {
+      return {
+        method: 'DELETE',
+        body: JSON.stringify({ trackIdentifier: trackName }),
+      };
+    }
+
+    if (trackName === selectedSecondary) {
+      return {
+        method: 'POST',
+        body: JSON.stringify({ trackIdentifier: trackName, priority: 1 }),
+      };
+    }
+
+    return {
+      method: 'POST',
+      body: JSON.stringify({ trackIdentifier: trackName, priority: 2 }),
+    };
+  }
+
+  async function updateTrackPick(listItemId, trackName, currentPicks = {}) {
+    const request = buildTrackPickRequest(trackName, currentPicks);
+    const result = await apiCall(`/api/track-picks/${listItemId}`, request);
+    return normalizeTrackPicks(result);
+  }
+
+  async function clearTrackPicks(listItemId) {
+    const result = await apiCall(`/api/track-picks/${listItemId}`, {
+      method: 'DELETE',
+    });
+
+    return normalizeTrackPicks(result);
+  }
+
+  return {
+    buildTrackPickRequest,
+    updateTrackPick,
+    clearTrackPicks,
+  };
+}

--- a/src/js/modules/track-selection.js
+++ b/src/js/modules/track-selection.js
@@ -7,6 +7,8 @@
  * @param {Object} deps - External dependencies
  * @returns {Object} Public API
  */
+import { createTrackPickService } from './track-pick-service.js';
+
 export function createTrackSelection(deps = {}) {
   const {
     apiCall,
@@ -16,6 +18,7 @@ export function createTrackSelection(deps = {}) {
     formatTrackTime,
     saveList: _saveList,
   } = deps;
+  const trackPickService = createTrackPickService({ apiCall });
 
   // ============ PURE HELPERS ============
 
@@ -275,14 +278,11 @@ export function createTrackSelection(deps = {}) {
         const currentAlbum = listData[albumIndex];
         if (!currentAlbum?._id) return;
 
-        await apiCall(`/api/track-picks/${currentAlbum._id}`, {
-          method: 'DELETE',
-        });
-
-        currentAlbum.primary_track = null;
-        currentAlbum.secondary_track = null;
-        selectedPrimary = null;
-        selectedSecondary = null;
+        const result = await trackPickService.clearTrackPicks(currentAlbum._id);
+        selectedPrimary = result.primaryTrack || null;
+        selectedSecondary = result.secondaryTrack || null;
+        currentAlbum.primary_track = selectedPrimary;
+        currentAlbum.secondary_track = selectedSecondary;
         updateMenuUI();
         updateTrackCellDisplayDual(
           albumIndex,
@@ -326,55 +326,33 @@ export function createTrackSelection(deps = {}) {
         const currentAlbum = listData[albumIndex];
         if (!currentAlbum?._id) return;
 
-        // Determine the API action BEFORE updating local state
-        // The backend handles swap logic internally, so send one call per click
-        let apiAction;
-        if (trackName === selectedPrimary) {
-          // Clicking primary = deselect it
-          apiAction = {
-            method: 'DELETE',
-            body: JSON.stringify({ trackIdentifier: trackName }),
-          };
-        } else if (trackName === selectedSecondary) {
-          // Clicking secondary = promote to primary
-          apiAction = {
-            method: 'POST',
-            body: JSON.stringify({ trackIdentifier: trackName, priority: 1 }),
-          };
-        } else {
-          // New track = add as secondary (backend handles demotion)
-          apiAction = {
-            method: 'POST',
-            body: JSON.stringify({ trackIdentifier: trackName, priority: 2 }),
-          };
-        }
-
         // Persist via API - backend is the source of truth
         try {
-          const result = await apiCall(
-            `/api/track-picks/${currentAlbum._id}`,
-            apiAction
+          const result = await trackPickService.updateTrackPick(
+            currentAlbum._id,
+            trackName,
+            {
+              primaryTrack: selectedPrimary,
+              secondaryTrack: selectedSecondary,
+            }
           );
 
-          if (result) {
-            // Sync local state with backend response (authoritative)
-            selectedPrimary = result.primary_track || null;
-            selectedSecondary = result.secondary_track || null;
+          selectedPrimary = result.primaryTrack || null;
+          selectedSecondary = result.secondaryTrack || null;
 
-            // Update album data
-            currentAlbum.primary_track = selectedPrimary;
-            currentAlbum.secondary_track = selectedSecondary;
+          // Update album data
+          currentAlbum.primary_track = selectedPrimary;
+          currentAlbum.secondary_track = selectedSecondary;
 
-            updateMenuUI();
-            updateTrackCellDisplayDual(
-              albumIndex,
-              {
-                primary: selectedPrimary,
-                secondary: selectedSecondary,
-              },
-              album.tracks
-            );
-          }
+          updateMenuUI();
+          updateTrackCellDisplayDual(
+            albumIndex,
+            {
+              primary: selectedPrimary,
+              secondary: selectedSecondary,
+            },
+            album.tracks
+          );
         } catch (err) {
           console.error('Error saving track picks:', err);
           showToast('Error saving track pick', 'error');

--- a/test/track-pick-service.test.js
+++ b/test/track-pick-service.test.js
@@ -1,0 +1,105 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('track-pick-service module', () => {
+  let createTrackPickService;
+
+  beforeEach(async () => {
+    const module = await import('../src/js/modules/track-pick-service.js');
+    createTrackPickService = module.createTrackPickService;
+  });
+
+  it('builds DELETE request when clicking the current primary track', () => {
+    const service = createTrackPickService({ apiCall: async () => ({}) });
+
+    const request = service.buildTrackPickRequest('Track A', {
+      primaryTrack: 'Track A',
+      secondaryTrack: 'Track B',
+    });
+
+    assert.deepStrictEqual(request, {
+      method: 'DELETE',
+      body: JSON.stringify({ trackIdentifier: 'Track A' }),
+    });
+  });
+
+  it('builds promote request when clicking the current secondary track', () => {
+    const service = createTrackPickService({ apiCall: async () => ({}) });
+
+    const request = service.buildTrackPickRequest('Track B', {
+      primaryTrack: 'Track A',
+      secondaryTrack: 'Track B',
+    });
+
+    assert.deepStrictEqual(request, {
+      method: 'POST',
+      body: JSON.stringify({ trackIdentifier: 'Track B', priority: 1 }),
+    });
+  });
+
+  it('builds add-secondary request for a newly selected track', () => {
+    const service = createTrackPickService({ apiCall: async () => ({}) });
+
+    const request = service.buildTrackPickRequest('Track C', {
+      primaryTrack: 'Track A',
+      secondaryTrack: 'Track B',
+    });
+
+    assert.deepStrictEqual(request, {
+      method: 'POST',
+      body: JSON.stringify({ trackIdentifier: 'Track C', priority: 2 }),
+    });
+  });
+
+  it('persists track picks via API and normalizes response fields', async () => {
+    const calls = [];
+    const service = createTrackPickService({
+      apiCall: async (url, options) => {
+        calls.push([url, options]);
+        return {
+          primary_track: 'Track B',
+          secondary_track: 'Track A',
+        };
+      },
+    });
+
+    const result = await service.updateTrackPick('item-1', 'Track B', {
+      primaryTrack: 'Track A',
+      secondaryTrack: 'Track B',
+    });
+
+    assert.deepStrictEqual(calls, [
+      [
+        '/api/track-picks/item-1',
+        {
+          method: 'POST',
+          body: JSON.stringify({ trackIdentifier: 'Track B', priority: 1 }),
+        },
+      ],
+    ]);
+    assert.deepStrictEqual(result, {
+      primaryTrack: 'Track B',
+      secondaryTrack: 'Track A',
+    });
+  });
+
+  it('clears track picks via API and returns normalized empty picks', async () => {
+    const calls = [];
+    const service = createTrackPickService({
+      apiCall: async (url, options) => {
+        calls.push([url, options]);
+        return null;
+      },
+    });
+
+    const result = await service.clearTrackPicks('item-2');
+
+    assert.deepStrictEqual(calls, [
+      ['/api/track-picks/item-2', { method: 'DELETE' }],
+    ]);
+    assert.deepStrictEqual(result, {
+      primaryTrack: '',
+      secondaryTrack: '',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract shared track-pick request/action logic into src/js/modules/track-pick-service.js so desktop quick-pick and mobile edit modal use the same API semantics.
- Route both src/js/modules/track-selection.js and src/js/modules/mobile-ui.js through the shared service to remove duplicated promote/deselect/add-secondary branching.
- Add unit coverage for the shared service in 	est/track-pick-service.test.js to lock request shape and normalized response behavior.

## Testing
- 
ode --test test/track-pick-service.test.js`n- 
ode --test test/mobile-ui.test.js`n- 
pm run lint:strict`n- 
pm test (fails on this host: /bin/bash not available)`n- docker compose -f docker-compose.local.yml exec app npm test (fails: Docker engine unavailable)