### PR TITLE
Extract list normalization boundaries from app-state

### DIFF
--- a/src/js/modules/app-state.js
+++ b/src/js/modules/app-state.js
@@ -8,108 +8,16 @@
  * State is module-private; access is through exported functions.
  */
 
+import {
+  createDefaultListEntry,
+  normalizeAlbumRecords,
+  normalizeListsMap,
+} from './list-data-normalization.js';
+
 // ============ CORE STATE VARIABLES ============
 
 /** Lists keyed by _id. Structure: { _id, name, year, isMain, count, groupId, sortOrder, _data, updatedAt, createdAt } */
 let lists = {};
-
-function normalizeAlbumRecord(album) {
-  if (!album || typeof album !== 'object') {
-    return { album, changed: false };
-  }
-
-  let changed = false;
-  const normalized = { ...album };
-
-  if (!normalized.album_id && normalized.albumId) {
-    normalized.album_id = normalized.albumId;
-    changed = true;
-  }
-
-  if (normalized.comments == null && normalized.comment != null) {
-    normalized.comments = normalized.comment;
-    changed = true;
-  }
-
-  if (!normalized.genre_1 && normalized.genre) {
-    normalized.genre_1 = normalized.genre;
-    changed = true;
-  }
-
-  const legacyPrimary =
-    normalized.track_picks?.primary || normalized.track_pick || null;
-  if (!normalized.primary_track && legacyPrimary) {
-    normalized.primary_track = legacyPrimary;
-    changed = true;
-  }
-
-  const legacySecondary = normalized.track_picks?.secondary || null;
-  if (!normalized.secondary_track && legacySecondary) {
-    normalized.secondary_track = legacySecondary;
-    changed = true;
-  }
-
-  return { album: changed ? normalized : album, changed };
-}
-
-function normalizeAlbumRecords(albums = []) {
-  if (!Array.isArray(albums)) {
-    return [];
-  }
-
-  let changed = false;
-  const normalized = albums.map((album) => {
-    const result = normalizeAlbumRecord(album);
-    changed = changed || result.changed;
-    return result.album;
-  });
-
-  return changed ? normalized : albums;
-}
-
-function createDefaultListEntry(listId, albums = []) {
-  const data = normalizeAlbumRecords(albums);
-
-  return {
-    _id: listId,
-    name: 'Unknown',
-    year: null,
-    isMain: false,
-    count: data.length,
-    _data: data,
-    updatedAt: new Date().toISOString(),
-    createdAt: new Date().toISOString(),
-  };
-}
-
-function normalizeListsMap(newLists = {}) {
-  const normalized = {};
-
-  Object.keys(newLists).forEach((listId) => {
-    const entry = newLists[listId];
-
-    if (Array.isArray(entry)) {
-      normalized[listId] = createDefaultListEntry(listId, entry);
-      return;
-    }
-
-    if (entry && typeof entry === 'object' && Array.isArray(entry._data)) {
-      const normalizedData = normalizeAlbumRecords(entry._data);
-      normalized[listId] =
-        normalizedData === entry._data
-          ? entry
-          : {
-              ...entry,
-              _data: normalizedData,
-            };
-      return;
-    }
-
-    normalized[listId] = entry;
-  });
-
-  return normalized;
-}
 
 /** Groups keyed by _id. Structure: { _id, name, year, sortOrder, listCount, isYearGroup, createdAt, updatedAt } */
 let groups = {};

--- a/src/js/modules/list-data-normalization.js
+++ b/src/js/modules/list-data-normalization.js
@@ -1,0 +1,97 @@
+export function normalizeAlbumRecord(album) {
+  if (!album || typeof album !== 'object') {
+    return { album, changed: false };
+  }
+
+  let changed = false;
+  const normalized = { ...album };
+
+  if (!normalized.album_id && normalized.albumId) {
+    normalized.album_id = normalized.albumId;
+    changed = true;
+  }
+
+  if (normalized.comments == null && normalized.comment != null) {
+    normalized.comments = normalized.comment;
+    changed = true;
+  }
+
+  if (!normalized.genre_1 && normalized.genre) {
+    normalized.genre_1 = normalized.genre;
+    changed = true;
+  }
+
+  const legacyPrimary =
+    normalized.track_picks?.primary || normalized.track_pick || null;
+  if (!normalized.primary_track && legacyPrimary) {
+    normalized.primary_track = legacyPrimary;
+    changed = true;
+  }
+
+  const legacySecondary = normalized.track_picks?.secondary || null;
+  if (!normalized.secondary_track && legacySecondary) {
+    normalized.secondary_track = legacySecondary;
+    changed = true;
+  }
+
+  return { album: changed ? normalized : album, changed };
+}
+
+export function normalizeAlbumRecords(albums = []) {
+  if (!Array.isArray(albums)) {
+    return [];
+  }
+
+  let changed = false;
+  const normalized = albums.map((album) => {
+    const result = normalizeAlbumRecord(album);
+    changed = changed || result.changed;
+    return result.album;
+  });
+
+  return changed ? normalized : albums;
+}
+
+export function createDefaultListEntry(listId, albums = []) {
+  const data = normalizeAlbumRecords(albums);
+
+  return {
+    _id: listId,
+    name: 'Unknown',
+    year: null,
+    isMain: false,
+    count: data.length,
+    _data: data,
+    updatedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function normalizeListsMap(newLists = {}) {
+  const normalized = {};
+
+  Object.keys(newLists).forEach((listId) => {
+    const entry = newLists[listId];
+
+    if (Array.isArray(entry)) {
+      normalized[listId] = createDefaultListEntry(listId, entry);
+      return;
+    }
+
+    if (entry && typeof entry === 'object' && Array.isArray(entry._data)) {
+      const normalizedData = normalizeAlbumRecords(entry._data);
+      normalized[listId] =
+        normalizedData === entry._data
+          ? entry
+          : {
+              ...entry,
+              _data: normalizedData,
+            };
+      return;
+    }
+
+    normalized[listId] = entry;
+  });
+
+  return normalized;
+}

--- a/test/list-data-normalization.test.js
+++ b/test/list-data-normalization.test.js
@@ -1,0 +1,81 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('list-data-normalization module', () => {
+  let normalizeAlbumRecord;
+  let normalizeAlbumRecords;
+  let createDefaultListEntry;
+  let normalizeListsMap;
+
+  beforeEach(async () => {
+    const module = await import('../src/js/modules/list-data-normalization.js');
+    normalizeAlbumRecord = module.normalizeAlbumRecord;
+    normalizeAlbumRecords = module.normalizeAlbumRecords;
+    createDefaultListEntry = module.createDefaultListEntry;
+    normalizeListsMap = module.normalizeListsMap;
+  });
+
+  it('normalizes legacy album fields into canonical keys', () => {
+    const legacyAlbum = {
+      albumId: 'abc',
+      comment: 'legacy comment',
+      genre: 'Rock',
+      track_pick: 'Song 1',
+      track_picks: { secondary: 'Song 2' },
+    };
+
+    const result = normalizeAlbumRecord(legacyAlbum);
+
+    assert.strictEqual(result.changed, true);
+    assert.deepStrictEqual(result.album, {
+      albumId: 'abc',
+      album_id: 'abc',
+      comment: 'legacy comment',
+      comments: 'legacy comment',
+      genre: 'Rock',
+      genre_1: 'Rock',
+      track_pick: 'Song 1',
+      track_picks: { secondary: 'Song 2' },
+      primary_track: 'Song 1',
+      secondary_track: 'Song 2',
+    });
+  });
+
+  it('returns original album array reference when no normalization is needed', () => {
+    const albums = [{ album_id: 'a1', comments: 'ok', primary_track: 'p1' }];
+
+    const normalized = normalizeAlbumRecords(albums);
+
+    assert.strictEqual(normalized, albums);
+  });
+
+  it('creates default list entry with normalized data', () => {
+    const entry = createDefaultListEntry('list-1', [
+      { albumId: 'a1', comment: 'x', genre: 'Jazz' },
+    ]);
+
+    assert.strictEqual(entry._id, 'list-1');
+    assert.strictEqual(entry.name, 'Unknown');
+    assert.strictEqual(entry.count, 1);
+    assert.strictEqual(entry._data[0].album_id, 'a1');
+    assert.strictEqual(entry._data[0].comments, 'x');
+    assert.strictEqual(entry._data[0].genre_1, 'Jazz');
+  });
+
+  it('normalizes mixed list map entries', () => {
+    const input = {
+      'list-1': [{ albumId: 'a1' }],
+      'list-2': {
+        _id: 'list-2',
+        _data: [{ albumId: 'a2', comment: 'hello' }],
+      },
+    };
+
+    const normalized = normalizeListsMap(input);
+
+    assert.strictEqual(Array.isArray(normalized['list-1']._data), true);
+    assert.strictEqual(normalized['list-1']._data[0].album_id, 'a1');
+    assert.strictEqual(normalized['list-2']._data[0].album_id, 'a2');
+    assert.strictEqual(normalized['list-2']._data[0].comments, 'hello');
+  });
+});


### PR DESCRIPTION
## Summary
- Move album/list normalization logic out of src/js/modules/app-state.js into src/js/modules/list-data-normalization.js so state management focuses on state mutation/access concerns.
- Keep existing normalization behavior intact while introducing explicit normalization boundaries for list ingress paths.
- Add dedicated tests in 	est/list-data-normalization.test.js and run existing pp-state tests to guard behavior parity.

## Testing
- 
ode --test test/list-data-normalization.test.js`n- 
ode --test test/app-state.test.js`n- 
pm run lint:strict`n- 
pm test (fails on this host: /bin/bash not available)`n- docker compose -f docker-compose.local.yml exec app npm test (fails: Docker engine unavailable)