### PR TITLE
Tighten structural baseline guardrails

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "optimize:icons": "bash scripts/optimize-icons.sh",
     "report:maintainability": "node scripts/maintainability-report.js",
     "report:maintainability:json": "node scripts/maintainability-report.js --json",
-    "lint:structure:baseline": "node scripts/maintainability-report.js --max-js-files-over-300=83 --max-js-files-over-700=23 --max-legacy-markers=154"
+    "lint:structure:baseline": "node scripts/maintainability-report.js --max-js-files-over-300=83 --max-js-files-over-700=20 --max-legacy-markers=120"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",

--- a/test/realtime-sync.test.js
+++ b/test/realtime-sync.test.js
@@ -118,6 +118,28 @@ describe('realtime-sync module', () => {
     assert.deepStrictEqual(refreshCalls, []);
   });
 
+  it('refreshes current list on list:reordered when listId matches', async () => {
+    const fakeSocket = createFakeSocket();
+    const refreshCalls = [];
+
+    const sync = createRealtimeSync({
+      ioFactory: () => fakeSocket,
+      getCurrentList: () => 'list-1',
+      refreshListData: async (listId) => {
+        refreshCalls.push(listId);
+      },
+    });
+
+    sync.connect();
+    await fakeSocket.trigger('list:reordered', {
+      listId: 'list-1',
+      order: ['a', 'b'],
+      reorderedAt: new Date().toISOString(),
+    });
+
+    assert.deepStrictEqual(refreshCalls, ['list-1']);
+  });
+
   it('rebuilds current list display on list:main-changed using listId', async () => {
     const fakeSocket = createFakeSocket();
     const displayCalls = [];


### PR DESCRIPTION
## Summary
- Tighten lint:structure:baseline thresholds by reducing allowed oversized app JS files over 700 lines and reducing allowed legacy marker count.
- Add a positive realtime reorder test to ensure list:reordered with canonical listId refreshes the active list, covering a high-risk cross-device sync path.
- Keep existing baseline limits for >300-line files unchanged while ratcheting the stricter dimensions.

## Testing
- 
ode --test test/realtime-sync.test.js`n- 
pm run lint:structure:baseline`n- 
pm run lint:strict`n- 
pm test (fails on this host: /bin/bash not available)`n- docker compose -f docker-compose.local.yml exec app npm test (fails: Docker engine unavailable)