### PR TITLE
Extract helper boundaries from frontend monolith modules

### DIFF
--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -31,6 +31,7 @@ import {
   createAlbumDisplayShared,
   PLACEHOLDER_GIF,
 } from './album-display-shared.js';
+import { detectUpdateType } from './album-display/incremental-update-detector.js';
 
 // Feature flag for incremental updates (can be disabled if issues arise)
 const ENABLE_INCREMENTAL_UPDATES = true;
@@ -1265,179 +1266,6 @@ export function createAlbumDisplay(deps = {}) {
   }
 
   /**
-   * Get album ID for comparison
-   * @param {Object} album - Album object
-   * @returns {string} Album identifier
-   */
-  function getAlbumId(album) {
-    return (
-      album._id ||
-      `${album.artist}::${album.album}::${album.release_date || ''}`
-    );
-  }
-
-  /**
-   * Extract album ID from a mutable fingerprint string.
-   * Fingerprint format: "_id|artist|album|release_date|..."
-   * @param {string} fp - Fingerprint string
-   * @returns {string} Album identifier
-   */
-  function getAlbumIdFromFingerprint(fp) {
-    const pipeIdx = fp.indexOf('|');
-    const id = pipeIdx >= 0 ? fp.substring(0, pipeIdx) : fp;
-    if (id) return id;
-    // Fallback: extract artist::album::release_date for composite ID
-    const parts = fp.split('|');
-    return `${parts[1] || ''}::${parts[2] || ''}::${parts[3] || ''}`;
-  }
-
-  /**
-   * Find single addition in list
-   * @param {Array<string>} oldFingerprints - Previous fingerprint strings
-   * @param {Array} newAlbums - New album array
-   * @returns {Object|null} { album, index } or null
-   */
-  function findSingleAddition(oldFingerprints, newAlbums) {
-    if (newAlbums.length !== oldFingerprints.length + 1) return null;
-
-    const oldIds = new Set(oldFingerprints.map(getAlbumIdFromFingerprint));
-
-    for (let i = 0; i < newAlbums.length; i++) {
-      const newId = getAlbumId(newAlbums[i]);
-      if (!oldIds.has(newId)) {
-        // Found the added album - verify rest of list matches
-        const beforeMatch = newAlbums
-          .slice(0, i)
-          .every(
-            (a, idx) =>
-              getAlbumId(a) === getAlbumIdFromFingerprint(oldFingerprints[idx])
-          );
-        const afterMatch = newAlbums
-          .slice(i + 1)
-          .every(
-            (a, idx) =>
-              getAlbumId(a) ===
-              getAlbumIdFromFingerprint(oldFingerprints[i + idx])
-          );
-
-        if (beforeMatch && afterMatch) {
-          return { album: newAlbums[i], index: i };
-        }
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Find single removal in list
-   * @param {Array<string>} oldFingerprints - Previous fingerprint strings
-   * @param {Array} newAlbums - New album array
-   * @returns {number} Index of removed item or -1
-   */
-  function findSingleRemoval(oldFingerprints, newAlbums) {
-    if (newAlbums.length !== oldFingerprints.length - 1) return -1;
-
-    const newIds = new Set(newAlbums.map(getAlbumId));
-
-    for (let i = 0; i < oldFingerprints.length; i++) {
-      const oldId = getAlbumIdFromFingerprint(oldFingerprints[i]);
-      if (!newIds.has(oldId)) {
-        // Found the removed album - verify rest of list matches
-        const beforeMatch = newAlbums
-          .slice(0, i)
-          .every(
-            (a, idx) =>
-              getAlbumId(a) === getAlbumIdFromFingerprint(oldFingerprints[idx])
-          );
-        const afterMatch = newAlbums
-          .slice(i)
-          .every(
-            (a, idx) =>
-              getAlbumId(a) ===
-              getAlbumIdFromFingerprint(oldFingerprints[i + 1 + idx])
-          );
-
-        if (beforeMatch && afterMatch) {
-          return i;
-        }
-      }
-    }
-    return -1;
-  }
-
-  /**
-   * Detect what type of update is needed.
-   * Compares fingerprint strings instead of objects to reduce allocations.
-   * @param {Array<string>|null} oldFingerprints - Previous fingerprint strings (from extractMutableFingerprints)
-   * @param {Array} newAlbums - New album array
-   * @returns {string|Object} Update type string or object with details for add/remove
-   */
-  function detectUpdateType(oldFingerprints, newAlbums) {
-    if (!ENABLE_INCREMENTAL_UPDATES || !oldFingerprints) {
-      return 'FULL_REBUILD';
-    }
-
-    // Check for single addition
-    if (newAlbums.length === oldFingerprints.length + 1) {
-      const addition = findSingleAddition(oldFingerprints, newAlbums);
-      if (addition) {
-        return {
-          type: 'SINGLE_ADD',
-          album: addition.album,
-          index: addition.index,
-        };
-      }
-    }
-
-    // Check for single removal
-    if (newAlbums.length === oldFingerprints.length - 1) {
-      const removalIndex = findSingleRemoval(oldFingerprints, newAlbums);
-      if (removalIndex !== -1) {
-        return { type: 'SINGLE_REMOVE', index: removalIndex };
-      }
-    }
-
-    // Length must match for other incremental updates
-    if (oldFingerprints.length !== newAlbums.length) {
-      return 'FULL_REBUILD';
-    }
-
-    let positionChanges = 0;
-    let fieldChanges = 0;
-
-    for (let i = 0; i < newAlbums.length; i++) {
-      const oldId = getAlbumIdFromFingerprint(oldFingerprints[i]);
-      const newId = getAlbumId(newAlbums[i]);
-
-      if (oldId !== newId) {
-        positionChanges++;
-      } else {
-        // Build new fingerprint inline and compare as string -- cheaper than
-        // comparing 8+ object properties individually, and avoids allocating objects.
-        const newAlbum = newAlbums[i];
-        const newFp = `${newAlbum._id || ''}|${newAlbum.artist || ''}|${newAlbum.album || ''}|${newAlbum.release_date || ''}|${newAlbum.country || ''}|${newAlbum.genre_1 || ''}|${newAlbum.genre_2 || ''}|${newAlbum.comments || ''}|${newAlbum.comments_2 || ''}|${newAlbum.primary_track || ''}`;
-        if (oldFingerprints[i] !== newFp) {
-          fieldChanges++;
-        }
-      }
-    }
-
-    // Note: cover_image changes now always trigger full rebuild via fingerprint mismatch
-    // since we don't track cover_image in mutable state (too expensive)
-    if (positionChanges === 0 && fieldChanges > 0 && fieldChanges <= 10) {
-      return 'FIELD_UPDATE';
-    }
-    if (fieldChanges === 0 && positionChanges > 0) {
-      return 'POSITION_UPDATE';
-    }
-    if (positionChanges + fieldChanges <= 15) {
-      return 'HYBRID_UPDATE';
-    }
-
-    return 'FULL_REBUILD';
-  }
-
-  /**
    * Insert a single album at a specific index without full rebuild
    * @param {Array} albums - Full album array (for data)
    * @param {number} index - Index to insert at
@@ -2433,7 +2261,9 @@ export function createAlbumDisplay(deps = {}) {
         return; // No changes detected
       }
 
-      const updateType = detectUpdateType(lastRenderedMutableState, albums);
+      const updateType = detectUpdateType(lastRenderedMutableState, albums, {
+        incrementalEnabled: ENABLE_INCREMENTAL_UPDATES,
+      });
 
       // Handle single album addition
       if (

--- a/src/js/modules/album-display/incremental-update-detector.js
+++ b/src/js/modules/album-display/incremental-update-detector.js
@@ -1,0 +1,138 @@
+export function getAlbumId(album) {
+  return (
+    album._id || `${album.artist}::${album.album}::${album.release_date || ''}`
+  );
+}
+
+export function getAlbumIdFromFingerprint(fp) {
+  const pipeIdx = fp.indexOf('|');
+  const id = pipeIdx >= 0 ? fp.substring(0, pipeIdx) : fp;
+  if (id) return id;
+
+  const parts = fp.split('|');
+  return `${parts[1] || ''}::${parts[2] || ''}::${parts[3] || ''}`;
+}
+
+export function findSingleAddition(oldFingerprints, newAlbums) {
+  if (newAlbums.length !== oldFingerprints.length + 1) return null;
+
+  const oldIds = new Set(oldFingerprints.map(getAlbumIdFromFingerprint));
+
+  for (let i = 0; i < newAlbums.length; i++) {
+    const newId = getAlbumId(newAlbums[i]);
+    if (!oldIds.has(newId)) {
+      const beforeMatch = newAlbums
+        .slice(0, i)
+        .every(
+          (a, idx) =>
+            getAlbumId(a) === getAlbumIdFromFingerprint(oldFingerprints[idx])
+        );
+      const afterMatch = newAlbums
+        .slice(i + 1)
+        .every(
+          (a, idx) =>
+            getAlbumId(a) ===
+            getAlbumIdFromFingerprint(oldFingerprints[i + idx])
+        );
+
+      if (beforeMatch && afterMatch) {
+        return { album: newAlbums[i], index: i };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function findSingleRemoval(oldFingerprints, newAlbums) {
+  if (newAlbums.length !== oldFingerprints.length - 1) return -1;
+
+  const newIds = new Set(newAlbums.map(getAlbumId));
+
+  for (let i = 0; i < oldFingerprints.length; i++) {
+    const oldId = getAlbumIdFromFingerprint(oldFingerprints[i]);
+    if (!newIds.has(oldId)) {
+      const beforeMatch = newAlbums
+        .slice(0, i)
+        .every(
+          (a, idx) =>
+            getAlbumId(a) === getAlbumIdFromFingerprint(oldFingerprints[idx])
+        );
+      const afterMatch = newAlbums
+        .slice(i)
+        .every(
+          (a, idx) =>
+            getAlbumId(a) ===
+            getAlbumIdFromFingerprint(oldFingerprints[i + 1 + idx])
+        );
+
+      if (beforeMatch && afterMatch) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+}
+
+export function detectUpdateType(
+  oldFingerprints,
+  newAlbums,
+  { incrementalEnabled = true } = {}
+) {
+  if (!incrementalEnabled || !oldFingerprints) {
+    return 'FULL_REBUILD';
+  }
+
+  if (newAlbums.length === oldFingerprints.length + 1) {
+    const addition = findSingleAddition(oldFingerprints, newAlbums);
+    if (addition) {
+      return {
+        type: 'SINGLE_ADD',
+        album: addition.album,
+        index: addition.index,
+      };
+    }
+  }
+
+  if (newAlbums.length === oldFingerprints.length - 1) {
+    const removalIndex = findSingleRemoval(oldFingerprints, newAlbums);
+    if (removalIndex !== -1) {
+      return { type: 'SINGLE_REMOVE', index: removalIndex };
+    }
+  }
+
+  if (oldFingerprints.length !== newAlbums.length) {
+    return 'FULL_REBUILD';
+  }
+
+  let positionChanges = 0;
+  let fieldChanges = 0;
+
+  for (let i = 0; i < newAlbums.length; i++) {
+    const oldId = getAlbumIdFromFingerprint(oldFingerprints[i]);
+    const newId = getAlbumId(newAlbums[i]);
+
+    if (oldId !== newId) {
+      positionChanges++;
+    } else {
+      const newAlbum = newAlbums[i];
+      const newFp = `${newAlbum._id || ''}|${newAlbum.artist || ''}|${newAlbum.album || ''}|${newAlbum.release_date || ''}|${newAlbum.country || ''}|${newAlbum.genre_1 || ''}|${newAlbum.genre_2 || ''}|${newAlbum.comments || ''}|${newAlbum.comments_2 || ''}|${newAlbum.primary_track || ''}`;
+      if (oldFingerprints[i] !== newFp) {
+        fieldChanges++;
+      }
+    }
+  }
+
+  if (positionChanges === 0 && fieldChanges > 0 && fieldChanges <= 10) {
+    return 'FIELD_UPDATE';
+  }
+  if (fieldChanges === 0 && positionChanges > 0) {
+    return 'POSITION_UPDATE';
+  }
+  if (positionChanges + fieldChanges <= 15) {
+    return 'HYBRID_UPDATE';
+  }
+
+  return 'FULL_REBUILD';
+}

--- a/src/js/modules/mobile-ui.js
+++ b/src/js/modules/mobile-ui.js
@@ -14,6 +14,7 @@ import { createTransferHelpers } from './album-transfer.js';
 import { fetchSpotifyDevices } from '../utils/playback-service.js';
 import { createMobileAlbumActions } from './mobile-ui/album-actions.js';
 import { createTrackPickService } from './track-pick-service.js';
+import { createAlbumIdentityFinder } from './mobile-ui/album-identity.js';
 
 /**
  * Factory function to create the mobile UI module with injected dependencies
@@ -94,28 +95,10 @@ export function createMobileUI(deps = {}) {
     recommendAlbum,
   } = deps;
   const trackPickService = createTrackPickService({ apiCall });
-
-  /**
-   * Find album by identity string instead of index
-   * Prevents stale index issues when list order changes
-   * @param {string} albumId - Album identity string (artist::album::release_date)
-   * @returns {Object|null} { album, index } or null if not found
-   */
-  function findAlbumByIdentity(albumId) {
-    const currentList = getCurrentList();
-    const albums = getListData(currentList);
-    if (!currentList || !albums) return null;
-
-    for (let i = 0; i < albums.length; i++) {
-      const album = albums[i];
-      const currentId =
-        `${album.artist}::${album.album}::${album.release_date || ''}`.toLowerCase();
-      if (currentId === albumId) {
-        return { album, index: i };
-      }
-    }
-    return null;
-  }
+  const findAlbumByIdentity = createAlbumIdentityFinder({
+    getCurrentList,
+    getListData,
+  });
 
   // Create transfer helpers (move/copy with confirmation dialogs)
   const {

--- a/src/js/modules/mobile-ui/album-identity.js
+++ b/src/js/modules/mobile-ui/album-identity.js
@@ -1,0 +1,23 @@
+export function buildAlbumIdentity(album) {
+  return `${album.artist}::${album.album}::${album.release_date || ''}`.toLowerCase();
+}
+
+export function createAlbumIdentityFinder(deps = {}) {
+  const { getCurrentList = () => '', getListData = () => null } = deps;
+
+  return function findAlbumByIdentity(albumId) {
+    const currentList = getCurrentList();
+    const albums = getListData(currentList);
+    if (!currentList || !albums) return null;
+
+    for (let i = 0; i < albums.length; i++) {
+      const album = albums[i];
+      const currentId = buildAlbumIdentity(album);
+      if (currentId === albumId) {
+        return { album, index: i };
+      }
+    }
+
+    return null;
+  };
+}

--- a/src/js/modules/musicbrainz-artist-name.js
+++ b/src/js/modules/musicbrainz-artist-name.js
@@ -1,0 +1,105 @@
+export function hasNonLatinCharacters(str) {
+  if (!str) return false;
+
+  const alphaChars = str.match(/\p{L}/gu) || [];
+  const nonLatinChars = str.match(/[^\u0020-\u024F\u1E00-\u1EFF]/gu) || [];
+  return (
+    alphaChars.length > 0 && nonLatinChars.length / alphaChars.length > 0.5
+  );
+}
+
+export function extractLatinName(artist) {
+  let latinName = null;
+
+  if (artist['sort-name'] && artist['sort-name'] !== artist.name) {
+    if (!hasNonLatinCharacters(artist['sort-name'])) {
+      const sortName = artist['sort-name'];
+      if (sortName.includes(',')) {
+        const parts = sortName.split(',').map((p) => p.trim());
+        if (parts.length === 2) {
+          latinName = `${parts[1]} ${parts[0]}`;
+        } else {
+          latinName = sortName;
+        }
+      } else {
+        latinName = sortName;
+      }
+    }
+  }
+
+  if (!latinName && artist.name) {
+    const nameParenMatch = artist.name.match(/\(([^)]+)\)/);
+    if (nameParenMatch) {
+      const extracted = nameParenMatch[1].trim();
+      if (!hasNonLatinCharacters(extracted)) {
+        latinName = extracted;
+      }
+    }
+  }
+
+  if (!latinName && artist.disambiguation) {
+    if (!hasNonLatinCharacters(artist.disambiguation)) {
+      const looksLikeName =
+        !artist.disambiguation.includes(' ') ||
+        artist.disambiguation.split(' ').length <= 3;
+      if (
+        looksLikeName &&
+        !artist.disambiguation.toLowerCase().includes('group') &&
+        !artist.disambiguation.toLowerCase().includes('band')
+      ) {
+        latinName = artist.disambiguation;
+      }
+    }
+  }
+
+  if (!latinName && artist.aliases && Array.isArray(artist.aliases)) {
+    for (const alias of artist.aliases) {
+      if (alias.name && !hasNonLatinCharacters(alias.name)) {
+        if (alias.primary || alias.type === 'Artist name') {
+          latinName = alias.name;
+          break;
+        }
+      }
+    }
+
+    if (!latinName) {
+      const latinAlias = artist.aliases.find(
+        (a) => a.name && !hasNonLatinCharacters(a.name)
+      );
+      if (latinAlias) {
+        latinName = latinAlias.name;
+      }
+    }
+  }
+
+  return latinName;
+}
+
+export function formatArtistDisplayName(artist) {
+  const hasNonLatin = hasNonLatinCharacters(artist.name);
+
+  if (!hasNonLatin) {
+    return {
+      primary: artist.name,
+      secondary: artist.disambiguation || null,
+      original: artist.name,
+    };
+  }
+
+  const latinName = extractLatinName(artist);
+
+  if (latinName) {
+    return {
+      primary: latinName,
+      secondary: artist.name,
+      original: artist.name,
+    };
+  }
+
+  return {
+    primary: artist.name,
+    secondary: 'Non-Latin script',
+    original: artist.name,
+    warning: true,
+  };
+}

--- a/src/js/modules/recommendations-list-tooltips.js
+++ b/src/js/modules/recommendations-list-tooltips.js
@@ -1,0 +1,21 @@
+export function formatInUserListsTooltip(listNames, escapeHtml) {
+  if (!Array.isArray(listNames) || listNames.length === 0) {
+    return '';
+  }
+
+  const header = listNames.length === 1 ? 'In your list:' : 'In your lists:';
+  const items = listNames
+    .map((name) => `&bull; ${escapeHtml(name)}`)
+    .join('<br>');
+
+  return `<span class="font-semibold text-gray-200">${header}</span><br>${items}`;
+}
+
+export function formatInUserListsAriaLabel(listNames) {
+  if (!Array.isArray(listNames) || listNames.length === 0) {
+    return '';
+  }
+
+  const header = listNames.length === 1 ? 'In your list' : 'In your lists';
+  return `${header}: ${listNames.join(', ')}`;
+}

--- a/src/js/modules/recommendations.js
+++ b/src/js/modules/recommendations.js
@@ -1,4 +1,8 @@
 import { createContextSubmenuController } from '../utils/context-submenu-controller.js';
+import {
+  formatInUserListsTooltip as formatInUserListsTooltipBase,
+  formatInUserListsAriaLabel,
+} from './recommendations-list-tooltips.js';
 
 /**
  * Recommendations Module
@@ -289,30 +293,8 @@ export function createRecommendations(deps = {}) {
     showReasoningTooltip(trigger, rec);
   }
 
-  function formatInUserListsTooltip(listNames) {
-    if (!Array.isArray(listNames) || listNames.length === 0) {
-      return '';
-    }
-
-    const header = listNames.length === 1 ? 'In your list:' : 'In your lists:';
-    const items = listNames
-      .map((name) => `&bull; ${escapeHtml(name)}`)
-      .join('<br>');
-
-    return `<span class="font-semibold text-gray-200">${header}</span><br>${items}`;
-  }
-
-  function formatInUserListsAriaLabel(listNames) {
-    if (!Array.isArray(listNames) || listNames.length === 0) {
-      return '';
-    }
-
-    const header = listNames.length === 1 ? 'In your list' : 'In your lists';
-    return `${header}: ${listNames.join(', ')}`;
-  }
-
   function showInUserListsTooltip(trigger, rec, listNames) {
-    const tooltipHtml = formatInUserListsTooltip(listNames);
+    const tooltipHtml = formatInUserListsTooltipBase(listNames, escapeHtml);
     if (!tooltipHtml) return;
 
     showRecommendationDetailTooltip(trigger, {

--- a/src/js/modules/spotify-lastfm-utils.js
+++ b/src/js/modules/spotify-lastfm-utils.js
@@ -1,0 +1,13 @@
+export function getTrackId(track) {
+  if (!track?.name || !track?.artists?.[0]?.name) return null;
+  return track.id || `${track.name}-${track.artists[0].name}`;
+}
+
+export function buildLastfmBody(track) {
+  return {
+    artist: track.artists[0].name,
+    track: track.name,
+    album: track.album?.name || '',
+    duration: Math.floor((track.duration_ms || 0) / 1000),
+  };
+}

--- a/src/js/modules/spotify-player.js
+++ b/src/js/modules/spotify-player.js
@@ -8,6 +8,7 @@ import { showToast } from './utils.js';
 import { isAlbumMatchingPlayback } from './playback-utils.js';
 import { getDeviceIcon } from '../utils/device-icons.js';
 import { formatTime } from './time-utils.js';
+import { getTrackId, buildLastfmBody } from './spotify-lastfm-utils.js';
 
 // ============ MODULE STATE ============
 let currentPlayback = null;
@@ -138,16 +139,6 @@ const LASTFM_MIN_SCROBBLE_TIME = 4 * 60 * 1000; // 4 minutes in ms
 const LASTFM_SCROBBLE_PERCENT = 0.5; // 50%
 
 /**
- * Derive a stable identifier for a track (used for dedup and comparisons).
- * @param {Object} track - Spotify track object
- * @returns {string|null} Track identifier or null if track is invalid
- */
-function getTrackId(track) {
-  if (!track?.name || !track?.artists?.[0]?.name) return null;
-  return track.id || `${track.name}-${track.artists[0].name}`;
-}
-
-/**
  * Handle a Last.fm scrobble/now-playing failure by incrementing the
  * consecutive-failure counter and warning the user after the threshold.
  * @param {string} context - Human-readable context for the console.warn
@@ -191,20 +182,6 @@ async function lastfmApiCall(endpoint, body, trackId, onSuccess, logLabel) {
   } catch (err) {
     handleScrobbleFailure(logLabel, err);
   }
-}
-
-/**
- * Build the common Last.fm body fields from a Spotify track.
- * @param {Object} track - Spotify track object
- * @returns {Object} { artist, track, album, duration }
- */
-function buildLastfmBody(track) {
-  return {
-    artist: track.artists[0].name,
-    track: track.name,
-    album: track.album?.name || '',
-    duration: Math.floor((track.duration_ms || 0) / 1000),
-  };
 }
 
 /**

--- a/src/js/musicbrainz.js
+++ b/src/js/musicbrainz.js
@@ -5,6 +5,10 @@ import {
   stringSimilarity,
   normalizeForExternalApi,
 } from './modules/normalization.js';
+import {
+  hasNonLatinCharacters,
+  formatArtistDisplayName,
+} from './modules/musicbrainz-artist-name.js';
 
 const MUSICBRAINZ_PROXY = '/api/proxy/musicbrainz'; // Using our proxy
 const WIKIDATA_PROXY = '/api/proxy/wikidata'; // Using our proxy
@@ -2183,127 +2187,6 @@ async function addAlbumToRecommendations(album) {
     }
     console.error('Error adding recommendation:', error);
     showToast('Error adding recommendation', 'error');
-  }
-}
-
-function hasNonLatinCharacters(str) {
-  if (!str) return false;
-  // Check if more than 50% of alphabetic characters are non-Latin
-  const alphaChars = str.match(/\p{L}/gu) || [];
-  const nonLatinChars = str.match(/[^\u0020-\u024F\u1E00-\u1EFF]/gu) || [];
-  return (
-    alphaChars.length > 0 && nonLatinChars.length / alphaChars.length > 0.5
-  );
-}
-
-// Helper to extract Latin name from various sources
-function extractLatinName(artist) {
-  let latinName = null;
-
-  // Strategy 1: Check if sort-name is different and contains Latin characters
-  if (artist['sort-name'] && artist['sort-name'] !== artist.name) {
-    if (!hasNonLatinCharacters(artist['sort-name'])) {
-      // sort-name might be "Lastname, Firstname" format, so clean it up
-      const sortName = artist['sort-name'];
-      if (sortName.includes(',')) {
-        // Reverse "Lastname, Firstname" to "Firstname Lastname"
-        const parts = sortName.split(',').map((p) => p.trim());
-        if (parts.length === 2) {
-          latinName = `${parts[1]} ${parts[0]}`;
-        } else {
-          latinName = sortName;
-        }
-      } else {
-        latinName = sortName;
-      }
-    }
-  }
-
-  // Strategy 2: Check name for parentheses pattern (e.g., "מזמור (Mizmor)")
-  if (!latinName && artist.name) {
-    const nameParenMatch = artist.name.match(/\(([^)]+)\)/);
-    if (nameParenMatch) {
-      const extracted = nameParenMatch[1].trim();
-      if (!hasNonLatinCharacters(extracted)) {
-        latinName = extracted;
-      }
-    }
-  }
-
-  // Strategy 3: Check disambiguation for Latin version
-  if (!latinName && artist.disambiguation) {
-    // Sometimes the entire disambiguation is the Latin name
-    if (!hasNonLatinCharacters(artist.disambiguation)) {
-      // But only if it looks like a name, not a description
-      const looksLikeName =
-        !artist.disambiguation.includes(' ') ||
-        artist.disambiguation.split(' ').length <= 3;
-      if (
-        looksLikeName &&
-        !artist.disambiguation.toLowerCase().includes('group') &&
-        !artist.disambiguation.toLowerCase().includes('band')
-      ) {
-        latinName = artist.disambiguation;
-      }
-    }
-  }
-
-  // Strategy 4: Check aliases if available
-  if (!latinName && artist.aliases && Array.isArray(artist.aliases)) {
-    for (const alias of artist.aliases) {
-      if (alias.name && !hasNonLatinCharacters(alias.name)) {
-        // Prefer primary aliases or those marked as artist name
-        if (alias.primary || alias.type === 'Artist name') {
-          latinName = alias.name;
-          break;
-        }
-      }
-    }
-    // If no primary alias found, use any Latin alias
-    if (!latinName) {
-      const latinAlias = artist.aliases.find(
-        (a) => a.name && !hasNonLatinCharacters(a.name)
-      );
-      if (latinAlias) {
-        latinName = latinAlias.name;
-      }
-    }
-  }
-
-  return latinName;
-}
-
-// Helper to format artist display name
-function formatArtistDisplayName(artist) {
-  const hasNonLatin = hasNonLatinCharacters(artist.name);
-
-  if (!hasNonLatin) {
-    // Name is already in Latin script
-    return {
-      primary: artist.name,
-      secondary: artist.disambiguation || null,
-      original: artist.name,
-    };
-  }
-
-  // Try to extract Latin version using multiple strategies
-  const latinName = extractLatinName(artist);
-
-  if (latinName) {
-    // Show Latin name as primary, original as secondary
-    return {
-      primary: latinName,
-      secondary: artist.name,
-      original: artist.name,
-    };
-  } else {
-    // No Latin version found, show as-is with warning
-    return {
-      primary: artist.name,
-      secondary: 'Non-Latin script',
-      original: artist.name,
-      warning: true,
-    };
   }
 }
 

--- a/test/album-display-incremental-update-detector.test.js
+++ b/test/album-display-incremental-update-detector.test.js
@@ -1,0 +1,87 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('album-display incremental update detector', () => {
+  let detectUpdateType;
+
+  beforeEach(async () => {
+    const module =
+      await import('../src/js/modules/album-display/incremental-update-detector.js');
+    detectUpdateType = module.detectUpdateType;
+  });
+
+  it('returns FULL_REBUILD when incremental updates are disabled', () => {
+    const result = detectUpdateType([], [], { incrementalEnabled: false });
+    assert.strictEqual(result, 'FULL_REBUILD');
+  });
+
+  it('detects a single add operation', () => {
+    const oldFingerprints = ['id-1|Artist A|Album A|2020-01-01||||||'];
+    const newAlbums = [
+      {
+        _id: 'id-1',
+        artist: 'Artist A',
+        album: 'Album A',
+        release_date: '2020-01-01',
+      },
+      {
+        _id: 'id-2',
+        artist: 'Artist B',
+        album: 'Album B',
+        release_date: '2021-01-01',
+      },
+    ];
+
+    const result = detectUpdateType(oldFingerprints, newAlbums);
+
+    assert.deepStrictEqual(result, {
+      type: 'SINGLE_ADD',
+      album: newAlbums[1],
+      index: 1,
+    });
+  });
+
+  it('detects a single remove operation', () => {
+    const oldFingerprints = [
+      'id-1|Artist A|Album A|2020-01-01||||||',
+      'id-2|Artist B|Album B|2021-01-01||||||',
+    ];
+    const newAlbums = [
+      {
+        _id: 'id-2',
+        artist: 'Artist B',
+        album: 'Album B',
+        release_date: '2021-01-01',
+      },
+    ];
+
+    const result = detectUpdateType(oldFingerprints, newAlbums);
+
+    assert.deepStrictEqual(result, { type: 'SINGLE_REMOVE', index: 0 });
+  });
+
+  it('detects position-only updates', () => {
+    const oldFingerprints = [
+      'id-1|Artist A|Album A|2020-01-01||||||',
+      'id-2|Artist B|Album B|2021-01-01||||||',
+    ];
+    const newAlbums = [
+      {
+        _id: 'id-2',
+        artist: 'Artist B',
+        album: 'Album B',
+        release_date: '2021-01-01',
+      },
+      {
+        _id: 'id-1',
+        artist: 'Artist A',
+        album: 'Album A',
+        release_date: '2020-01-01',
+      },
+    ];
+
+    const result = detectUpdateType(oldFingerprints, newAlbums);
+
+    assert.strictEqual(result, 'POSITION_UPDATE');
+  });
+});

--- a/test/mobile-ui-album-identity.test.js
+++ b/test/mobile-ui-album-identity.test.js
@@ -1,0 +1,51 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('mobile-ui album identity helpers', () => {
+  let buildAlbumIdentity;
+  let createAlbumIdentityFinder;
+
+  beforeEach(async () => {
+    const module =
+      await import('../src/js/modules/mobile-ui/album-identity.js');
+    buildAlbumIdentity = module.buildAlbumIdentity;
+    createAlbumIdentityFinder = module.createAlbumIdentityFinder;
+  });
+
+  it('builds lowercase identity string', () => {
+    const identity = buildAlbumIdentity({
+      artist: 'Artist Name',
+      album: 'Album Name',
+      release_date: '2024-01-01',
+    });
+
+    assert.strictEqual(identity, 'artist name::album name::2024-01-01');
+  });
+
+  it('finds album by identity in current list', () => {
+    const albums = [
+      { artist: 'A', album: 'One', release_date: '2021-01-01' },
+      { artist: 'B', album: 'Two', release_date: '2022-01-01' },
+    ];
+
+    const findAlbumByIdentity = createAlbumIdentityFinder({
+      getCurrentList: () => 'list-1',
+      getListData: () => albums,
+    });
+
+    const result = findAlbumByIdentity('b::two::2022-01-01');
+
+    assert.strictEqual(result.index, 1);
+    assert.deepStrictEqual(result.album, albums[1]);
+  });
+
+  it('returns null when album is missing', () => {
+    const findAlbumByIdentity = createAlbumIdentityFinder({
+      getCurrentList: () => 'list-1',
+      getListData: () => [{ artist: 'A', album: 'One', release_date: '' }],
+    });
+
+    const result = findAlbumByIdentity('missing::album::');
+    assert.strictEqual(result, null);
+  });
+});

--- a/test/musicbrainz-artist-name.test.js
+++ b/test/musicbrainz-artist-name.test.js
@@ -1,0 +1,48 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('musicbrainz artist name helpers', () => {
+  let hasNonLatinCharacters;
+  let formatArtistDisplayName;
+
+  beforeEach(async () => {
+    const module = await import('../src/js/modules/musicbrainz-artist-name.js');
+    hasNonLatinCharacters = module.hasNonLatinCharacters;
+    formatArtistDisplayName = module.formatArtistDisplayName;
+  });
+
+  it('detects non-latin-heavy strings', () => {
+    assert.strictEqual(hasNonLatinCharacters('Mizmor'), false);
+    assert.strictEqual(
+      hasNonLatinCharacters('\u05de\u05d6\u05de\u05d5\u05e8'),
+      true
+    );
+  });
+
+  it('keeps latin names as primary display', () => {
+    const result = formatArtistDisplayName({
+      name: 'Radiohead',
+      disambiguation: 'UK band',
+    });
+
+    assert.deepStrictEqual(result, {
+      primary: 'Radiohead',
+      secondary: 'UK band',
+      original: 'Radiohead',
+    });
+  });
+
+  it('uses extracted latin transliteration for non-latin names', () => {
+    const result = formatArtistDisplayName({
+      name: '\u05de\u05d6\u05de\u05d5\u05e8',
+      'sort-name': 'Mizmor',
+      disambiguation: '',
+    });
+
+    assert.deepStrictEqual(result, {
+      primary: 'Mizmor',
+      secondary: '\u05de\u05d6\u05de\u05d5\u05e8',
+      original: '\u05de\u05d6\u05de\u05d5\u05e8',
+    });
+  });
+});

--- a/test/recommendations-list-tooltips.test.js
+++ b/test/recommendations-list-tooltips.test.js
@@ -1,0 +1,37 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('recommendation list tooltip helpers', () => {
+  let formatInUserListsTooltip;
+  let formatInUserListsAriaLabel;
+
+  beforeEach(async () => {
+    const module =
+      await import('../src/js/modules/recommendations-list-tooltips.js');
+    formatInUserListsTooltip = module.formatInUserListsTooltip;
+    formatInUserListsAriaLabel = module.formatInUserListsAriaLabel;
+  });
+
+  it('formats tooltip html with escaped list names', () => {
+    const html = formatInUserListsTooltip(['Favorites', '<Danger>'], (value) =>
+      value.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    );
+
+    assert.ok(html.includes('In your lists:'));
+    assert.ok(html.includes('&bull; Favorites'));
+    assert.ok(html.includes('&bull; &lt;Danger&gt;'));
+  });
+
+  it('returns empty tooltip output for empty list collection', () => {
+    assert.strictEqual(
+      formatInUserListsTooltip([], (value) => value),
+      ''
+    );
+    assert.strictEqual(formatInUserListsAriaLabel([]), '');
+  });
+
+  it('formats aria label text for list names', () => {
+    const label = formatInUserListsAriaLabel(['List A', 'List B']);
+    assert.strictEqual(label, 'In your lists: List A, List B');
+  });
+});

--- a/test/spotify-lastfm-utils.test.js
+++ b/test/spotify-lastfm-utils.test.js
@@ -1,0 +1,48 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('spotify lastfm helpers', () => {
+  let getTrackId;
+  let buildLastfmBody;
+
+  beforeEach(async () => {
+    const module = await import('../src/js/modules/spotify-lastfm-utils.js');
+    getTrackId = module.getTrackId;
+    buildLastfmBody = module.buildLastfmBody;
+  });
+
+  it('prefers spotify track id when present', () => {
+    const trackId = getTrackId({
+      id: 'spotify-id-1',
+      name: 'Song A',
+      artists: [{ name: 'Artist A' }],
+    });
+
+    assert.strictEqual(trackId, 'spotify-id-1');
+  });
+
+  it('falls back to name-artist identity when id is missing', () => {
+    const trackId = getTrackId({
+      name: 'Song B',
+      artists: [{ name: 'Artist B' }],
+    });
+
+    assert.strictEqual(trackId, 'Song B-Artist B');
+  });
+
+  it('builds normalized lastfm payload body', () => {
+    const body = buildLastfmBody({
+      name: 'Track X',
+      artists: [{ name: 'Artist X' }],
+      album: { name: 'Album X' },
+      duration_ms: 198765,
+    });
+
+    assert.deepStrictEqual(body, {
+      artist: 'Artist X',
+      track: 'Track X',
+      album: 'Album X',
+      duration: 198,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Split pure/high-churn helper logic out of the five largest frontend modules (lbum-display, musicbrainz, mobile-ui, spotify-player, and ecommendations) into focused helper modules while keeping orchestrator APIs unchanged.
- Move incremental update detection, mobile album identity lookup, MusicBrainz artist name formatting, Last.fm payload helpers, and recommendation list tooltip formatting into dedicated modules with explicit imports.
- Add focused unit tests for each extracted helper module to lock behavior and reduce regression risk during future decomposition work.

## Testing
- 
ode --test test/album-display-incremental-update-detector.test.js test/musicbrainz-artist-name.test.js test/mobile-ui-album-identity.test.js test/spotify-lastfm-utils.test.js test/recommendations-list-tooltips.test.js test/mobile-ui.test.js test/recommendations-context-menu.test.js`n- 
pm run lint:strict`n- 
pm test (fails on this host: /bin/bash not available)`n- docker compose -f docker-compose.local.yml exec app npm test (fails: Docker engine unavailable)