### PR TITLE
Rework admin duplicate scanner around cluster merges

### DIFF
--- a/deduplication_scanner.md
+++ b/deduplication_scanner.md
@@ -1,0 +1,253 @@
+# Deduplication Scanner Implementation Plan
+
+## Objectives
+
+- Replace pair-by-pair admin duplicate review with a cluster-based workflow.
+- Merge album variants into a canonical record with best-available metadata.
+- Guarantee no album loss for any user/list when retiring duplicate album IDs.
+- Make behavior observable, testable, and deterministic.
+
+## Current State (Baseline)
+
+- Admin scan/review flow is pair-based:
+  - Scanner: `services/duplicate-service.js` (`scanDuplicates`)
+  - Admin routes: `routes/admin/duplicates.js`
+  - Review UI: `src/js/modules/duplicate-review-modal.js`
+  - Scan trigger: `src/js/modules/settings-drawer/handlers/audit-handlers.js`
+- Merge is transactional but does not fully handle same-list collision semantics.
+- UI does not present full duplicate groups (all variants for one album family).
+- Route error handling for `TransactionAbort` must align with `statusCode`.
+
+## High-Level Architecture
+
+### 1. Scan Layer
+
+- Keep fuzzy matching core from `utils/fuzzy-match.js`.
+- Build duplicate graph (album IDs as nodes, potential duplicate matches as edges).
+- Convert graph to connected components (clusters).
+- Return paginated cluster summaries + member variants.
+
+### 2. Review Layer (Admin UI)
+
+- Replace pair modal with cluster review modal:
+  - View all variants in one cluster.
+  - Show suggested canonical variant.
+  - Show field-level merge preview.
+  - Allow actions: merge variant, mark distinct pair, skip/defer.
+
+### 3. Merge Layer
+
+- Transactional cluster merge service:
+  - Select canonical album.
+  - Merge metadata from retired variants.
+  - Repoint all `list_items` to canonical album.
+  - Resolve same-list collisions deterministically.
+  - Delete retired album rows.
+  - Emit audit event with impact details.
+
+### 4. Safety + Observability
+
+- Dry-run endpoint for merge impact preview.
+- Structured logs for scan and merge metrics.
+- Enforce post-merge invariants and fail/rollback on violation.
+
+## Detailed Implementation Phases
+
+## Phase 0 - Guardrails and Contracts
+
+### Tasks
+
+- Define canonical merge rules in code-level constants/helpers.
+- Define same-list collision rules (position/comments/tracks precedence).
+- Normalize API response contracts for scan, dry-run, commit, mark-distinct.
+- Fix `TransactionAbort` route handling to use `statusCode` consistently.
+
+### Files
+
+- `routes/admin/duplicates.js`
+- `db/transaction.js` (reference only; behavior already established)
+- New/updated helper modules under `services/duplicate-*` and/or `utils/*`
+
+### Exit Criteria
+
+- API contracts documented in code comments/types.
+- Error statuses propagate correctly for expected failures.
+
+## Phase 1 - Cluster Scanner
+
+### Tasks
+
+- Extend scanning to output clusters instead of only pair list.
+- Respect `album_distinct_pairs` exclusions while building edges/clusters.
+- Add pagination (`page`, `pageSize`) and stable sort for clusters.
+- Include per-cluster metadata:
+  - cluster ID
+  - candidate count
+  - confidence summary
+  - suggested canonical ID
+
+### Files
+
+- `services/duplicate-service.js` (or split into scanner module)
+- `routes/admin/duplicates.js`
+
+### Exit Criteria
+
+- Scanner returns reproducible cluster output.
+- No silent truncation of actionable results.
+
+## Phase 2 - Cluster Review UI
+
+### Tasks
+
+- Replace/expand `duplicate-review-modal` to support cluster mode.
+- Render all variants with key metadata quality indicators:
+  - cover quality
+  - track count/structure
+  - text quality/specificity
+  - source/reliability hints
+- Add actions:
+  - choose canonical
+  - toggle merge/keep-distinct per variant pair
+  - skip/defer cluster
+- Add dry-run preview panel:
+  - affected users/lists
+  - same-list collision count
+  - metadata field changes summary
+
+### Files
+
+- `src/js/modules/duplicate-review-modal.js` (or split into cluster modal module)
+- `src/js/modules/settings-drawer/handlers/audit-handlers.js`
+- `src/js/modules/settings-drawer/renderers/admin-renderer.js` (if UI controls change)
+
+### Exit Criteria
+
+- Admin can resolve a full cluster in one workflow.
+- UI clearly shows what will change before commit.
+
+## Phase 3 - Transactional Cluster Merge Engine
+
+### Tasks
+
+- Add service method: `mergeCluster({ canonicalId, retireIds, options })`.
+- Implement deterministic metadata merge rules:
+  - cover preference
+  - release date precision
+  - country normalization
+  - genre merge
+  - tracklist selection/merge
+- Repoint `list_items` from retired IDs to canonical ID.
+- Implement collision resolver for lists containing multiple retiring variants:
+  - select base row (position/created_at)
+  - merge comments/track picks
+  - remove redundant rows
+- Delete retired album rows only after successful remap/collision handling.
+- Validate post-merge invariants before commit.
+
+### Files
+
+- `services/duplicate-service.js` (or split into `duplicate-merge-service.js`)
+- Potential helper module for list item collision merge logic under `services/list/*`
+- `routes/admin/duplicates.js`
+
+### Exit Criteria
+
+- No unique constraint violations during merge.
+- No list loses album membership.
+- Rollback works on any failure.
+
+## Phase 4 - API Surface and Auditability
+
+### Tasks
+
+- Add/adjust endpoints:
+  - `GET /admin/api/scan-duplicates` -> cluster payload
+  - `POST /admin/api/merge-cluster/dry-run` -> impact preview
+  - `POST /admin/api/merge-cluster` -> transactional commit
+  - existing mark-distinct endpoint remains, updated for cluster UX
+- Add admin event payload schema for merge audit trail:
+  - canonical ID
+  - retired IDs
+  - affected list IDs/user IDs
+  - collision resolutions
+  - field-level metadata decisions
+
+### Files
+
+- `routes/admin/duplicates.js`
+- `services/duplicate-service.js`
+
+### Exit Criteria
+
+- Endpoints are backward compatible where feasible or versioned if needed.
+- Every committed merge emits a complete audit record.
+
+## Phase 5 - Test Coverage
+
+### Unit Tests
+
+- Cluster builder (graph/components).
+- Canonical suggestion heuristic.
+- Metadata merge strategy per field.
+- Same-list collision resolver.
+- Distinct-pair exclusion behavior.
+
+### Integration/Service Tests
+
+- Transaction rollback on mid-merge failures.
+- Multi-user remap safety.
+- Same-list duplicate variants collapse to one row.
+- Retired IDs fully removed from `albums` and `list_items` references.
+
+### Frontend Tests
+
+- Audit handler flow with cluster responses.
+- Cluster modal actions and dry-run confirmation behavior.
+
+### Candidate Test Files
+
+- `test/duplicate-service.test.js`
+- `test/settings-audit-handlers.test.js`
+- New tests for cluster UI module if split.
+
+### Exit Criteria
+
+- New behavior covered with deterministic tests.
+- Existing dedupe tests continue passing.
+
+## Phase 6 - Rollout Strategy
+
+### Tasks
+
+- Release behind admin feature flag (cluster mode on/off).
+- Keep legacy pair mode fallback for one release cycle.
+- Run scanner in shadow mode and compare pair vs cluster outcomes.
+- Promote cluster mode after stability metrics are acceptable.
+
+### Monitoring Metrics
+
+- Scan: clusters found, average cluster size, exclusions applied.
+- Merge: success/failure counts, rollback counts, collision counts.
+- Safety: invariant violations (must be zero).
+
+### Exit Criteria
+
+- Cluster mode stable in production admin usage.
+- Legacy pair path removed only after confidence period.
+
+## Data and Rule Decisions (To Lock Before Coding)
+
+- Canonical suggestion scoring weights (source trust, metadata completeness, existing references).
+- Tracklist merge policy when two lists are similarly complete.
+- Comment merge format for conflicting non-empty values.
+- Distinct-pair reversibility UX and permissions.
+
+## Definition of Done
+
+- Admin can review and resolve duplicates by cluster.
+- Metadata consolidation follows deterministic, documented rules.
+- No user/list loses album membership after any merge.
+- Same-list collisions are handled without unique index failures.
+- Full audit trail exists for every merge action.
+- Test suite covers scanner, merge, collision, and UI review flow.

--- a/routes/admin/duplicates.js
+++ b/routes/admin/duplicates.js
@@ -14,6 +14,18 @@ const { TransactionAbort } = require('../../db/transaction');
 module.exports = (app, deps) => {
   const { ensureAuth, ensureAdmin, duplicateService } = deps;
 
+  function handleError(res, error, logContext, fallbackMessage) {
+    if (error instanceof TransactionAbort) {
+      return res.status(error.statusCode).json(error.body);
+    }
+
+    logger.error(fallbackMessage, {
+      ...logContext,
+      error: error.message,
+    });
+    return res.status(500).json({ error: error.message });
+  }
+
   // Admin: Scan for potential duplicate albums in the database
   app.get(
     '/admin/api/scan-duplicates',
@@ -24,21 +36,29 @@ module.exports = (app, deps) => {
         logger.info('Starting duplicate album scan', {
           adminId: req.user?._id,
           threshold: req.query.threshold,
+          page: req.query.page,
+          pageSize: req.query.pageSize,
         });
 
         const result = await duplicateService.scanDuplicates(
-          req.query.threshold
+          req.query.threshold,
+          {
+            page: req.query.page,
+            pageSize: req.query.pageSize,
+          }
         );
 
         res.json(result);
       } catch (error) {
-        if (error instanceof TransactionAbort) {
-          return res.status(error.status).json(error.body);
-        }
-        logger.error('Error scanning for duplicates', {
-          error: error.message,
-        });
-        res.status(500).json({ error: error.message });
+        return handleError(
+          res,
+          error,
+          {
+            adminId: req.user?._id,
+            threshold: req.query.threshold,
+          },
+          'Error scanning for duplicates'
+        );
       }
     }
   );
@@ -65,15 +85,86 @@ module.exports = (app, deps) => {
 
         res.json({ success: true, ...result });
       } catch (error) {
-        if (error instanceof TransactionAbort) {
-          return res.status(error.status).json(error.body);
-        }
-        logger.error('Error merging albums', {
-          error: error.message,
-          keepAlbumId: req.body?.keepAlbumId,
-          deleteAlbumId: req.body?.deleteAlbumId,
+        return handleError(
+          res,
+          error,
+          {
+            keepAlbumId: req.body?.keepAlbumId,
+            deleteAlbumId: req.body?.deleteAlbumId,
+            adminId: req.user?._id,
+          },
+          'Error merging albums'
+        );
+      }
+    }
+  );
+
+  app.post(
+    '/admin/api/merge-cluster/dry-run',
+    ensureAuth,
+    ensureAdmin,
+    async (req, res) => {
+      try {
+        const { canonicalAlbumId, retireAlbumIds } = req.body || {};
+
+        const result = await duplicateService.previewMergeCluster(
+          canonicalAlbumId,
+          retireAlbumIds
+        );
+
+        res.json(result);
+      } catch (error) {
+        return handleError(
+          res,
+          error,
+          {
+            canonicalAlbumId: req.body?.canonicalAlbumId,
+            retireAlbumIdsCount: Array.isArray(req.body?.retireAlbumIds)
+              ? req.body.retireAlbumIds.length
+              : null,
+            adminId: req.user?._id,
+          },
+          'Error running cluster merge dry-run'
+        );
+      }
+    }
+  );
+
+  app.post(
+    '/admin/api/merge-cluster',
+    ensureAuth,
+    ensureAdmin,
+    async (req, res) => {
+      try {
+        const { canonicalAlbumId, retireAlbumIds } = req.body || {};
+
+        logger.info('Merging duplicate cluster', {
+          canonicalAlbumId,
+          retireAlbumIdsCount: Array.isArray(retireAlbumIds)
+            ? retireAlbumIds.length
+            : 0,
+          adminId: req.user?._id,
         });
-        res.status(500).json({ error: error.message });
+
+        const result = await duplicateService.mergeCluster(
+          canonicalAlbumId,
+          retireAlbumIds
+        );
+
+        res.json({ success: true, ...result });
+      } catch (error) {
+        return handleError(
+          res,
+          error,
+          {
+            canonicalAlbumId: req.body?.canonicalAlbumId,
+            retireAlbumIdsCount: Array.isArray(req.body?.retireAlbumIds)
+              ? req.body.retireAlbumIds.length
+              : null,
+            adminId: req.user?._id,
+          },
+          'Error merging duplicate cluster'
+        );
       }
     }
   );

--- a/services/duplicate-service.js
+++ b/services/duplicate-service.js
@@ -3,8 +3,10 @@
  *
  * Business logic for duplicate album detection and merging:
  * - Scan all albums for fuzzy-match duplicates
+ * - Build duplicate clusters for admin review
  * - Smart-merge metadata from one album into another
- * - Reassign list_items and clean up distinct pairs
+ * - Reassign list_items safely (including same-list collisions)
+ * - Clean up distinct pairs
  *
  * Follows dependency injection pattern for testability.
  */
@@ -15,6 +17,208 @@ const {
   findPotentialDuplicates,
   normalizeForComparison,
 } = require('../utils/fuzzy-match');
+
+const DEFAULT_PAIR_LIMIT = 100;
+const DEFAULT_CLUSTER_PAGE = 1;
+const DEFAULT_CLUSTER_PAGE_SIZE = 25;
+const MAX_CLUSTER_PAGE_SIZE = 100;
+
+function clampNumber(value, min, max, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function hasText(value) {
+  return normalizeText(value).length > 0;
+}
+
+function chooseBetterText(existing, incoming) {
+  const current = normalizeText(existing);
+  const candidate = normalizeText(incoming);
+
+  if (!candidate) return current;
+  if (!current) return candidate;
+  if (candidate.length > current.length + 2) return candidate;
+  return current;
+}
+
+function releaseDatePrecision(value) {
+  const text = normalizeText(value);
+  if (!text) return 0;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(text)) return 3;
+  if (/^\d{4}-\d{2}$/.test(text)) return 2;
+  if (/^\d{4}$/.test(text)) return 1;
+  return 0;
+}
+
+function chooseBetterReleaseDate(existing, incoming) {
+  const current = normalizeText(existing);
+  const candidate = normalizeText(incoming);
+
+  if (!candidate) return current;
+  if (!current) return candidate;
+
+  const currentPrecision = releaseDatePrecision(current);
+  const candidatePrecision = releaseDatePrecision(candidate);
+
+  if (candidatePrecision > currentPrecision) return candidate;
+  if (candidatePrecision < currentPrecision) return current;
+  return candidate.length > current.length ? candidate : current;
+}
+
+function collectUniqueTexts(values) {
+  const deduped = [];
+  const seen = new Set();
+
+  for (const value of values) {
+    const text = normalizeText(value);
+    if (!text) continue;
+
+    const key = text.toLowerCase();
+    if (seen.has(key)) continue;
+
+    seen.add(key);
+    deduped.push(text);
+  }
+
+  return deduped;
+}
+
+function parseTrackValue(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== 'string' || !value.trim()) return null;
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function coverSize(album) {
+  const cover = album?.cover_image;
+  if (!cover) return 0;
+  if (Buffer.isBuffer(cover)) return cover.length;
+  if (typeof cover === 'string') return Buffer.byteLength(cover, 'base64');
+  return 0;
+}
+
+function mergeTextField(rows, fieldName) {
+  const values = collectUniqueTexts(rows.map((row) => row[fieldName]));
+  if (values.length === 0) return null;
+  if (values.length === 1) return values[0];
+  return values.join(' | ');
+}
+
+function mergeTrackSelections(rows) {
+  const values = [];
+  const seen = new Set();
+
+  for (const row of rows) {
+    for (const key of ['primary_track', 'secondary_track']) {
+      const text = normalizeText(row[key]);
+      if (!text) continue;
+
+      const normalized = text.toLowerCase();
+      if (seen.has(normalized)) continue;
+
+      seen.add(normalized);
+      values.push(text);
+
+      if (values.length >= 2) {
+        return {
+          primaryTrack: values[0] || null,
+          secondaryTrack: values[1] || null,
+        };
+      }
+    }
+  }
+
+  return {
+    primaryTrack: values[0] || null,
+    secondaryTrack: values[1] || null,
+  };
+}
+
+function listItemSortValue(row) {
+  const position = Number.isFinite(row.position)
+    ? row.position
+    : Number.MAX_SAFE_INTEGER;
+  const createdAt = row.created_at
+    ? new Date(row.created_at).getTime()
+    : Number.MAX_SAFE_INTEGER;
+  return { position, createdAt };
+}
+
+function compareListItems(a, b) {
+  const aSort = listItemSortValue(a);
+  const bSort = listItemSortValue(b);
+
+  if (aSort.position !== bSort.position) {
+    return aSort.position - bSort.position;
+  }
+
+  if (aSort.createdAt !== bSort.createdAt) {
+    return aSort.createdAt - bSort.createdAt;
+  }
+
+  return String(a._id).localeCompare(String(b._id));
+}
+
+function canonicalScore(album) {
+  let score = 0;
+
+  if (album.album_id && !album.album_id.startsWith('internal-')) score += 50;
+  if (album.hasCover) score += 20;
+  score += Math.min(30, album.trackCount || 0);
+  score += Math.min(15, album.listRefs || 0);
+
+  const datePrecision = releaseDatePrecision(album.release_date);
+  if (datePrecision > 0) score += datePrecision * 3;
+
+  if (hasText(album.genre_1)) score += 4;
+  if (hasText(album.genre_2)) score += 2;
+  if (hasText(album.summary)) score += 3;
+
+  score += normalizeText(album.artist).length * 0.05;
+  score += normalizeText(album.album).length * 0.05;
+
+  return score;
+}
+
+function compareCanonicalAlbums(a, b) {
+  if (a.canonicalScore !== b.canonicalScore) {
+    return b.canonicalScore - a.canonicalScore;
+  }
+
+  if ((a.listRefs || 0) !== (b.listRefs || 0)) {
+    return (b.listRefs || 0) - (a.listRefs || 0);
+  }
+
+  if ((a.trackCount || 0) !== (b.trackCount || 0)) {
+    return (b.trackCount || 0) - (a.trackCount || 0);
+  }
+
+  const aCreatedAt = a.created_at
+    ? new Date(a.created_at).getTime()
+    : Number.MAX_SAFE_INTEGER;
+  const bCreatedAt = b.created_at
+    ? new Date(b.created_at).getTime()
+    : Number.MAX_SAFE_INTEGER;
+
+  if (aCreatedAt !== bCreatedAt) {
+    return aCreatedAt - bCreatedAt;
+  }
+
+  return String(a.album_id).localeCompare(String(b.album_id));
+}
 
 /**
  * Create duplicate service with injected dependencies
@@ -105,29 +309,472 @@ function createDuplicateService(deps = {}) {
     return [...candidateIndexes].sort((a, b) => a - b);
   }
 
+  function buildDuplicateClusters(duplicatePairs) {
+    if (duplicatePairs.length === 0) return [];
+
+    const adjacency = new Map();
+    const albumById = new Map();
+    const pairIndexesById = new Map();
+
+    const ensureNode = (album) => {
+      if (!adjacency.has(album.album_id)) {
+        adjacency.set(album.album_id, new Set());
+      }
+      if (!pairIndexesById.has(album.album_id)) {
+        pairIndexesById.set(album.album_id, new Set());
+      }
+      if (!albumById.has(album.album_id)) {
+        albumById.set(album.album_id, album);
+      }
+    };
+
+    duplicatePairs.forEach((pair, index) => {
+      ensureNode(pair.album1);
+      ensureNode(pair.album2);
+
+      adjacency.get(pair.album1.album_id).add(pair.album2.album_id);
+      adjacency.get(pair.album2.album_id).add(pair.album1.album_id);
+
+      pairIndexesById.get(pair.album1.album_id).add(index);
+      pairIndexesById.get(pair.album2.album_id).add(index);
+    });
+
+    const clusters = [];
+    const visited = new Set();
+
+    for (const albumId of adjacency.keys()) {
+      if (visited.has(albumId)) continue;
+
+      const memberIds = [];
+      const queue = [albumId];
+      visited.add(albumId);
+
+      while (queue.length > 0) {
+        const current = queue.shift();
+        memberIds.push(current);
+
+        for (const neighbor of adjacency.get(current) || []) {
+          if (visited.has(neighbor)) continue;
+          visited.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+
+      if (memberIds.length < 2) continue;
+
+      const memberSet = new Set(memberIds);
+      const pairIndexes = new Set();
+
+      for (const id of memberIds) {
+        for (const pairIndex of pairIndexesById.get(id) || []) {
+          pairIndexes.add(pairIndex);
+        }
+      }
+
+      const clusterPairs = [...pairIndexes]
+        .map((pairIndex) => duplicatePairs[pairIndex])
+        .filter(
+          (pair) =>
+            memberSet.has(pair.album1.album_id) &&
+            memberSet.has(pair.album2.album_id)
+        )
+        .sort((a, b) => b.confidence - a.confidence);
+
+      const members = memberIds
+        .map((id) => ({
+          ...albumById.get(id),
+          canonicalScore: canonicalScore(albumById.get(id)),
+        }))
+        .sort(compareCanonicalAlbums);
+
+      const confidenceValues = clusterPairs.map((pair) => pair.confidence);
+      const maxConfidence = confidenceValues.length
+        ? Math.max(...confidenceValues)
+        : 0;
+      const minConfidence = confidenceValues.length
+        ? Math.min(...confidenceValues)
+        : 0;
+      const avgConfidence = confidenceValues.length
+        ? Math.round(
+            confidenceValues.reduce((sum, value) => sum + value, 0) /
+              confidenceValues.length
+          )
+        : 0;
+
+      const suggestedCanonicalId = members[0].album_id;
+      const clusterId = `${suggestedCanonicalId}::${memberIds.length}`;
+
+      clusters.push({
+        clusterId,
+        memberCount: members.length,
+        suggestedCanonicalId,
+        maxConfidence,
+        minConfidence,
+        avgConfidence,
+        members,
+        pairs: clusterPairs.map((pair) => ({
+          album1Id: pair.album1.album_id,
+          album2Id: pair.album2.album_id,
+          confidence: pair.confidence,
+          artistScore: pair.artistScore,
+          albumScore: pair.albumScore,
+        })),
+      });
+    }
+
+    clusters.sort((a, b) => {
+      if (a.maxConfidence !== b.maxConfidence) {
+        return b.maxConfidence - a.maxConfidence;
+      }
+      if (a.memberCount !== b.memberCount) {
+        return b.memberCount - a.memberCount;
+      }
+      return a.suggestedCanonicalId.localeCompare(b.suggestedCanonicalId);
+    });
+
+    return clusters;
+  }
+
+  function buildMergeFields(keepAlbum, deleteAlbum) {
+    const fieldsToMerge = [];
+    const fieldNames = [];
+    const values = [keepAlbum.album_id];
+    const nextParam = () => `$${values.length + 1}`;
+
+    const pushField = (fieldName, value) => {
+      fieldsToMerge.push(`${fieldName} = ${nextParam()}`);
+      fieldNames.push(fieldName);
+      values.push(value);
+    };
+
+    const bestArtist = chooseBetterText(keepAlbum.artist, deleteAlbum.artist);
+    if (normalizeText(bestArtist) !== normalizeText(keepAlbum.artist)) {
+      pushField('artist', bestArtist);
+    }
+
+    const bestAlbum = chooseBetterText(keepAlbum.album, deleteAlbum.album);
+    if (normalizeText(bestAlbum) !== normalizeText(keepAlbum.album)) {
+      pushField('album', bestAlbum);
+    }
+
+    const bestReleaseDate = chooseBetterReleaseDate(
+      keepAlbum.release_date,
+      deleteAlbum.release_date
+    );
+    if (
+      normalizeText(bestReleaseDate) !== normalizeText(keepAlbum.release_date)
+    ) {
+      pushField('release_date', bestReleaseDate);
+    }
+
+    const bestCountry = chooseBetterText(
+      keepAlbum.country,
+      deleteAlbum.country
+    );
+    if (normalizeText(bestCountry) !== normalizeText(keepAlbum.country)) {
+      pushField('country', bestCountry);
+    }
+
+    const mergedGenres = collectUniqueTexts([
+      keepAlbum.genre_1,
+      keepAlbum.genre_2,
+      deleteAlbum.genre_1,
+      deleteAlbum.genre_2,
+    ]).slice(0, 2);
+
+    const mergedGenre1 = mergedGenres[0] || normalizeText(keepAlbum.genre_1);
+    const mergedGenre2 = mergedGenres[1] || normalizeText(keepAlbum.genre_2);
+
+    if (normalizeText(mergedGenre1) !== normalizeText(keepAlbum.genre_1)) {
+      pushField('genre_1', mergedGenre1);
+    }
+    if (normalizeText(mergedGenre2) !== normalizeText(keepAlbum.genre_2)) {
+      pushField('genre_2', mergedGenre2);
+    }
+
+    const keepTracks = parseTrackValue(keepAlbum.tracks);
+    const deleteTracks = parseTrackValue(deleteAlbum.tracks);
+    const keepTrackCount = keepTracks ? keepTracks.length : 0;
+    const deleteTrackCount = deleteTracks ? deleteTracks.length : 0;
+
+    if (deleteTrackCount > keepTrackCount) {
+      pushField('tracks', JSON.stringify(deleteTracks));
+    }
+
+    const keepCoverSize = coverSize(keepAlbum);
+    const deleteCoverSize = coverSize(deleteAlbum);
+
+    if (deleteCoverSize > keepCoverSize) {
+      pushField('cover_image', deleteAlbum.cover_image);
+      pushField('cover_image_format', deleteAlbum.cover_image_format || 'jpeg');
+    }
+
+    const keepSummary = normalizeText(keepAlbum.summary);
+    const deleteSummary = normalizeText(deleteAlbum.summary);
+    if (deleteSummary && deleteSummary.length > keepSummary.length) {
+      pushField('summary', deleteAlbum.summary);
+      pushField('summary_source', deleteAlbum.summary_source);
+      pushField('summary_fetched_at', deleteAlbum.summary_fetched_at);
+    }
+
+    return { fieldsToMerge, fieldNames, values };
+  }
+
+  function applyMergeFieldValues(album, fieldNames, values) {
+    const nextAlbum = { ...album };
+
+    for (let i = 0; i < fieldNames.length; i++) {
+      const fieldName = fieldNames[i];
+      const rawValue = values[i + 1];
+
+      if (fieldName === 'tracks') {
+        nextAlbum[fieldName] = parseTrackValue(rawValue);
+      } else {
+        nextAlbum[fieldName] = rawValue;
+      }
+    }
+
+    return nextAlbum;
+  }
+
+  async function resolveListItemCollisions(client, keepAlbumId, deleteAlbumId) {
+    const rowsResult = await client.query(
+      `SELECT _id, list_id, album_id, position, comments, comments_2,
+              primary_track, secondary_track, created_at
+       FROM list_items
+       WHERE album_id = $1 OR album_id = $2
+       ORDER BY list_id, position ASC, created_at ASC`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    const rowsByListId = new Map();
+
+    for (const row of rowsResult.rows) {
+      if (!rowsByListId.has(row.list_id)) {
+        rowsByListId.set(row.list_id, []);
+      }
+      rowsByListId.get(row.list_id).push(row);
+    }
+
+    let collisionsResolved = 0;
+    let rowsUpdated = 0;
+    let rowsDeleted = 0;
+
+    for (const listRows of rowsByListId.values()) {
+      const hasKeep = listRows.some((row) => row.album_id === keepAlbumId);
+      const hasDelete = listRows.some((row) => row.album_id === deleteAlbumId);
+
+      if (!hasKeep || !hasDelete) continue;
+
+      collisionsResolved++;
+
+      const sortedRows = [...listRows].sort(compareListItems);
+      const baseRow = sortedRows[0];
+      const otherRows = sortedRows.slice(1);
+
+      const numericPositions = sortedRows
+        .map((row) => row.position)
+        .filter((value) => Number.isFinite(value));
+
+      const mergedPosition =
+        numericPositions.length > 0
+          ? Math.min(...numericPositions)
+          : baseRow.position;
+      const mergedComments = mergeTextField(sortedRows, 'comments');
+      const mergedComments2 = mergeTextField(sortedRows, 'comments_2');
+      const mergedTracks = mergeTrackSelections(sortedRows);
+
+      await client.query(
+        `UPDATE list_items
+         SET album_id = $1,
+             position = $2,
+             comments = $3,
+             comments_2 = $4,
+             primary_track = $5,
+             secondary_track = $6,
+             updated_at = NOW()
+         WHERE _id = $7`,
+        [
+          keepAlbumId,
+          mergedPosition,
+          mergedComments,
+          mergedComments2,
+          mergedTracks.primaryTrack,
+          mergedTracks.secondaryTrack,
+          baseRow._id,
+        ]
+      );
+      rowsUpdated++;
+
+      const deleteIds = otherRows.map((row) => row._id);
+      if (deleteIds.length > 0) {
+        const deleteResult = await client.query(
+          `DELETE FROM list_items WHERE _id = ANY($1::text[])`,
+          [deleteIds]
+        );
+        rowsDeleted += deleteResult.rowCount;
+      }
+    }
+
+    return {
+      collisionsResolved,
+      rowsUpdated,
+      rowsDeleted,
+    };
+  }
+
+  async function mergeAlbumsWithinTransaction(
+    client,
+    keepAlbumId,
+    deleteAlbumId
+  ) {
+    const albumsResult = await client.query(
+      `SELECT album_id, artist, album, release_date, country,
+              genre_1, genre_2, tracks, cover_image, cover_image_format,
+              summary, summary_source, summary_fetched_at
+       FROM albums WHERE album_id = $1 OR album_id = $2`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    const keepAlbum = albumsResult.rows.find((a) => a.album_id === keepAlbumId);
+    const deleteAlbum = albumsResult.rows.find(
+      (a) => a.album_id === deleteAlbumId
+    );
+
+    if (!keepAlbum) {
+      throw new TransactionAbort(404, { error: 'Keep album not found' });
+    }
+
+    let metadataMerged = false;
+    let mergedFieldNames = [];
+
+    if (deleteAlbum) {
+      const { fieldsToMerge, fieldNames, values } = buildMergeFields(
+        keepAlbum,
+        deleteAlbum
+      );
+
+      if (fieldsToMerge.length > 0) {
+        fieldsToMerge.push('updated_at = NOW()');
+        await client.query(
+          `UPDATE albums SET ${fieldsToMerge.join(', ')} WHERE album_id = $1`,
+          values
+        );
+        metadataMerged = true;
+        mergedFieldNames = fieldNames;
+      }
+    }
+
+    const collisionStats = await resolveListItemCollisions(
+      client,
+      keepAlbumId,
+      deleteAlbumId
+    );
+
+    const updateResult = await client.query(
+      `UPDATE list_items SET album_id = $1, updated_at = NOW() WHERE album_id = $2`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    const deleteResult = await client.query(
+      `DELETE FROM albums WHERE album_id = $1`,
+      [deleteAlbumId]
+    );
+
+    await client.query(
+      `DELETE FROM album_distinct_pairs WHERE album_id_1 = $1 OR album_id_2 = $1`,
+      [deleteAlbumId]
+    );
+
+    const listItemsUpdated = updateResult.rowCount + collisionStats.rowsUpdated;
+
+    logger.info('Albums merged successfully', {
+      keepAlbumId,
+      deleteAlbumId,
+      listItemsUpdated,
+      albumsDeleted: deleteResult.rowCount,
+      metadataMerged,
+      mergedFieldCount: mergedFieldNames.length,
+      collisionsResolved: collisionStats.collisionsResolved,
+      collisionRowsDeleted: collisionStats.rowsDeleted,
+    });
+
+    return {
+      listItemsUpdated,
+      albumsDeleted: deleteResult.rowCount,
+      metadataMerged,
+      mergedFieldNames,
+      collisionsResolved: collisionStats.collisionsResolved,
+      collisionRowsDeleted: collisionStats.rowsDeleted,
+    };
+  }
+
+  function normalizeRetireAlbumIds(canonicalAlbumId, retireAlbumIds) {
+    if (!Array.isArray(retireAlbumIds)) {
+      throw new TransactionAbort(400, {
+        error: 'retireAlbumIds must be an array',
+      });
+    }
+
+    const cleaned = [];
+    const seen = new Set();
+
+    for (const albumId of retireAlbumIds) {
+      const value = normalizeText(albumId);
+      if (!value || value === canonicalAlbumId || seen.has(value)) continue;
+      seen.add(value);
+      cleaned.push(value);
+    }
+
+    if (cleaned.length === 0) {
+      throw new TransactionAbort(400, {
+        error: 'At least one retire album ID is required',
+      });
+    }
+
+    return cleaned;
+  }
+
   /**
    * Scan all albums for potential fuzzy-match duplicates.
+   *
    * @param {number} threshold - Similarity threshold (0.03–0.5, default 0.15)
-   * @returns {Promise<Object>} { totalAlbums, potentialDuplicates, excludedPairs, pairs }
+   * @param {Object} options - Pagination options for clusters
+   * @returns {Promise<Object>} scan result with pairs and clusters
    */
-  async function scanDuplicates(threshold) {
+  async function scanDuplicates(threshold, options = {}) {
     const clampedThreshold = Math.max(
       0.03,
       Math.min(0.5, parseFloat(threshold) || 0.15)
     );
 
-    // Get all albums with extended fields for diff comparison
-    // Exclude albums without album_id (data integrity issue)
+    const page = clampNumber(
+      options.page,
+      1,
+      Number.MAX_SAFE_INTEGER,
+      DEFAULT_CLUSTER_PAGE
+    );
+    const pageSize = clampNumber(
+      options.pageSize,
+      1,
+      MAX_CLUSTER_PAGE_SIZE,
+      DEFAULT_CLUSTER_PAGE_SIZE
+    );
+
     const albumsResult = await pool.query(`
-      SELECT 
-        album_id, 
-        artist, 
-        album, 
+      SELECT
+        album_id,
+        artist,
+        album,
         release_date,
+        country,
         genre_1,
         genre_2,
+        tracks,
+        summary,
         COALESCE(jsonb_array_length(tracks), 0) as track_count,
-        cover_image IS NOT NULL as has_cover
+        cover_image IS NOT NULL as has_cover,
+        created_at
       FROM albums
       WHERE artist IS NOT NULL AND artist != ''
         AND album IS NOT NULL AND album != ''
@@ -135,7 +782,6 @@ function createDuplicateService(deps = {}) {
       ORDER BY artist, album
     `);
 
-    // Get excluded pairs from album_distinct_pairs table
     const excludedPairsResult = await pool.query(
       `SELECT album_id_1, album_id_2 FROM album_distinct_pairs`
     );
@@ -151,15 +797,38 @@ function createDuplicateService(deps = {}) {
       artist: row.artist,
       album: row.album,
       release_date: row.release_date || null,
+      country: row.country || null,
       genre_1: row.genre_1 || null,
       genre_2: row.genre_2 || null,
+      tracks: parseTrackValue(row.tracks),
+      summary: row.summary || null,
       trackCount: row.track_count > 0 ? row.track_count : null,
       hasCover: row.has_cover,
+      created_at: row.created_at,
+      listRefs: 0,
     }));
+
+    if (albums.length > 0) {
+      const albumIds = albums.map((album) => album.album_id);
+      const refsResult = await pool.query(
+        `SELECT album_id, COUNT(*)::int AS list_refs
+         FROM list_items
+         WHERE album_id = ANY($1::text[])
+         GROUP BY album_id`,
+        [albumIds]
+      );
+
+      const refsByAlbumId = new Map(
+        refsResult.rows.map((row) => [row.album_id, row.list_refs])
+      );
+
+      for (const album of albums) {
+        album.listRefs = refsByAlbumId.get(album.album_id) || 0;
+      }
+    }
 
     const blockingBuckets = buildBlockingBuckets(albums);
 
-    // Find all potential duplicate pairs
     const duplicatePairs = [];
     const processedPairs = new Set();
     const totalPossibleComparisons = (albums.length * (albums.length - 1)) / 2;
@@ -173,9 +842,9 @@ function createDuplicateService(deps = {}) {
         blockingBuckets,
         albums.length
       );
-      const candidates = candidateIndexes.map(
-        (candidateIndex) => albums[candidateIndex]
-      );
+      const candidates = candidateIndexes.map((candidateIndex) => {
+        return albums[candidateIndex];
+      });
       candidateComparisons += candidates.length;
 
       const matches = findPotentialDuplicates(album, candidates, {
@@ -188,25 +857,30 @@ function createDuplicateService(deps = {}) {
         const pairKey = [album.album_id, match.candidate.album_id]
           .sort()
           .join('::');
-        if (!processedPairs.has(pairKey)) {
-          processedPairs.add(pairKey);
-          duplicatePairs.push({
-            album1: album,
-            album2: match.candidate,
-            confidence: Math.round(match.confidence * 100),
-            artistScore: Math.round(match.artistScore.score * 100),
-            albumScore: Math.round(match.albumScore.score * 100),
-          });
-        }
+        if (processedPairs.has(pairKey)) continue;
+
+        processedPairs.add(pairKey);
+        duplicatePairs.push({
+          album1: album,
+          album2: match.candidate,
+          confidence: Math.round(match.confidence * 100),
+          artistScore: Math.round(match.artistScore.score * 100),
+          albumScore: Math.round(match.albumScore.score * 100),
+        });
       }
     }
 
-    // Sort by confidence (highest first)
     duplicatePairs.sort((a, b) => b.confidence - a.confidence);
+
+    const clusters = buildDuplicateClusters(duplicatePairs);
+    const totalClusters = clusters.length;
+    const clusterStart = (page - 1) * pageSize;
+    const pagedClusters = clusters.slice(clusterStart, clusterStart + pageSize);
 
     logger.info('Duplicate scan completed', {
       totalAlbums: albums.length,
       potentialDuplicates: duplicatePairs.length,
+      totalClusters,
       excludedPairs: excludePairs.size / 2,
       comparisonsEvaluated: candidateComparisons,
       totalPossibleComparisons,
@@ -224,101 +898,21 @@ function createDuplicateService(deps = {}) {
       totalAlbums: albums.length,
       potentialDuplicates: duplicatePairs.length,
       excludedPairs: excludePairs.size / 2,
-      pairs: duplicatePairs.slice(0, 100), // Limit to top 100 for performance
+      pairs: duplicatePairs.slice(0, DEFAULT_PAIR_LIMIT),
+      clusters: pagedClusters,
+      totalClusters,
+      page,
+      pageSize,
+      hasMoreClusters: clusterStart + pageSize < totalClusters,
     };
-  }
-
-  /**
-   * Build SET clause fields for smart metadata merge.
-   * Fills missing fields in keepAlbum with values from deleteAlbum.
-   * @param {Object} keepAlbum - Album being kept
-   * @param {Object} deleteAlbum - Album being deleted (source of fill data)
-   * @returns {{ fieldsToMerge: string[], values: any[] }}
-   */
-  function buildMergeFields(keepAlbum, deleteAlbum) {
-    const fieldsToMerge = [];
-    // values[0] will be keepAlbumId ($1), so next param is always values.length + 1
-    const values = [keepAlbum.album_id];
-    const nextParam = () => `$${values.length + 1}`;
-
-    // Helper: use deleteVal when keepVal is empty/null
-    const shouldMerge = (keepVal, deleteVal) => {
-      const keepEmpty =
-        keepVal === null || keepVal === undefined || keepVal === '';
-      const deleteHasValue =
-        deleteVal !== null && deleteVal !== undefined && deleteVal !== '';
-      return keepEmpty && deleteHasValue;
-    };
-
-    // Text fields
-    if (shouldMerge(keepAlbum.release_date, deleteAlbum.release_date)) {
-      fieldsToMerge.push(`release_date = ${nextParam()}`);
-      values.push(deleteAlbum.release_date);
-    }
-    if (shouldMerge(keepAlbum.country, deleteAlbum.country)) {
-      fieldsToMerge.push(`country = ${nextParam()}`);
-      values.push(deleteAlbum.country);
-    }
-    if (shouldMerge(keepAlbum.genre_1, deleteAlbum.genre_1)) {
-      fieldsToMerge.push(`genre_1 = ${nextParam()}`);
-      values.push(deleteAlbum.genre_1);
-    }
-    if (shouldMerge(keepAlbum.genre_2, deleteAlbum.genre_2)) {
-      fieldsToMerge.push(`genre_2 = ${nextParam()}`);
-      values.push(deleteAlbum.genre_2);
-    }
-
-    // Tracks (if keep has none and delete has some)
-    if (
-      deleteAlbum.tracks &&
-      Array.isArray(deleteAlbum.tracks) &&
-      deleteAlbum.tracks.length > 0
-    ) {
-      const keepTracks = keepAlbum.tracks;
-      const keepHasTracks =
-        keepTracks && Array.isArray(keepTracks) && keepTracks.length > 0;
-      if (!keepHasTracks) {
-        fieldsToMerge.push(`tracks = ${nextParam()}`);
-        values.push(JSON.stringify(deleteAlbum.tracks));
-      }
-    }
-
-    // Cover image: prefer larger (higher quality)
-    if (deleteAlbum.cover_image && !keepAlbum.cover_image) {
-      fieldsToMerge.push(`cover_image = ${nextParam()}`);
-      values.push(deleteAlbum.cover_image);
-      fieldsToMerge.push(`cover_image_format = ${nextParam()}`);
-      values.push(deleteAlbum.cover_image_format || 'jpeg');
-    } else if (deleteAlbum.cover_image && keepAlbum.cover_image) {
-      // Both have covers — use larger one
-      const deleteSize = deleteAlbum.cover_image.length;
-      const keepSize = keepAlbum.cover_image.length;
-      if (deleteSize > keepSize) {
-        fieldsToMerge.push(`cover_image = ${nextParam()}`);
-        values.push(deleteAlbum.cover_image);
-        fieldsToMerge.push(`cover_image_format = ${nextParam()}`);
-        values.push(deleteAlbum.cover_image_format || 'jpeg');
-      }
-    }
-
-    // Summary: fill if missing
-    if (shouldMerge(keepAlbum.summary, deleteAlbum.summary)) {
-      fieldsToMerge.push(`summary = ${nextParam()}`);
-      values.push(deleteAlbum.summary);
-      fieldsToMerge.push(`summary_source = ${nextParam()}`);
-      values.push(deleteAlbum.summary_source);
-      fieldsToMerge.push(`summary_fetched_at = ${nextParam()}`);
-      values.push(deleteAlbum.summary_fetched_at);
-    }
-
-    return { fieldsToMerge, values };
   }
 
   /**
    * Merge two albums: keep one, transfer list_items, smart-merge metadata, delete the other.
+   *
    * @param {string} keepAlbumId - Album ID to keep
    * @param {string} deleteAlbumId - Album ID to delete
-   * @returns {Promise<Object>} { listItemsUpdated, albumsDeleted, metadataMerged }
+   * @returns {Promise<Object>} merge result
    * @throws {TransactionAbort} on validation failure
    */
   async function mergeAlbums(keepAlbumId, deleteAlbumId) {
@@ -335,83 +929,207 @@ function createDuplicateService(deps = {}) {
     }
 
     return withTransaction(pool, async (client) => {
-      // Fetch both albums to merge metadata
-      const albumsResult = await client.query(
-        `SELECT album_id, artist, album, release_date, country,
-                genre_1, genre_2, tracks, cover_image, cover_image_format,
-                summary, summary_source, summary_fetched_at
-         FROM albums WHERE album_id = $1 OR album_id = $2`,
-        [keepAlbumId, deleteAlbumId]
-      );
+      return mergeAlbumsWithinTransaction(client, keepAlbumId, deleteAlbumId);
+    });
+  }
 
-      const keepAlbum = albumsResult.rows.find(
-        (a) => a.album_id === keepAlbumId
-      );
-      const deleteAlbum = albumsResult.rows.find(
-        (a) => a.album_id === deleteAlbumId
-      );
+  /**
+   * Preview the impact of merging a cluster into a canonical album.
+   *
+   * @param {string} canonicalAlbumId - Canonical album ID to keep
+   * @param {string[]} retireAlbumIds - Album IDs to retire
+   * @returns {Promise<Object>} dry-run impact summary
+   */
+  async function previewMergeCluster(canonicalAlbumId, retireAlbumIds) {
+    const canonicalId = normalizeText(canonicalAlbumId);
+    if (!canonicalId) {
+      throw new TransactionAbort(400, {
+        error: 'canonicalAlbumId is required',
+      });
+    }
 
-      if (!keepAlbum) {
-        throw new TransactionAbort(404, { error: 'Keep album not found' });
+    const retireIds = normalizeRetireAlbumIds(canonicalId, retireAlbumIds);
+    const allIds = [canonicalId, ...retireIds];
+
+    const albumsResult = await pool.query(
+      `SELECT album_id, artist, album, release_date, country,
+              genre_1, genre_2, tracks, cover_image, cover_image_format,
+              summary, summary_source, summary_fetched_at
+       FROM albums
+       WHERE album_id = ANY($1::text[])`,
+      [allIds]
+    );
+
+    const albumsById = new Map(
+      albumsResult.rows.map((album) => [album.album_id, album])
+    );
+    const canonicalAlbum = albumsById.get(canonicalId);
+
+    if (!canonicalAlbum) {
+      throw new TransactionAbort(404, { error: 'Canonical album not found' });
+    }
+
+    const existingRetireIds = retireIds.filter((id) => albumsById.has(id));
+    const missingRetireIds = retireIds.filter((id) => !albumsById.has(id));
+
+    const impactedRowsResult = await pool.query(
+      `SELECT li.list_id, li.album_id,
+              l.name AS list_name, l.year,
+              l.user_id, u.username
+       FROM list_items li
+       JOIN lists l ON li.list_id = l._id
+       JOIN users u ON l.user_id = u._id
+       WHERE li.album_id = ANY($1::text[])`,
+      [allIds]
+    );
+
+    const impactedListIds = new Set();
+    const impactedUserIds = new Set();
+    const listInfoById = new Map();
+    const listAlbumSets = new Map();
+
+    for (const row of impactedRowsResult.rows) {
+      impactedListIds.add(row.list_id);
+      impactedUserIds.add(row.user_id);
+
+      if (!listInfoById.has(row.list_id)) {
+        listInfoById.set(row.list_id, {
+          listId: row.list_id,
+          listName: row.list_name,
+          year: row.year,
+          userId: row.user_id,
+          username: row.username,
+        });
       }
 
-      // Smart merge metadata from deleted album into kept album
-      let metadataMerged = false;
-      if (deleteAlbum) {
-        const { fieldsToMerge, values } = buildMergeFields(
-          keepAlbum,
-          deleteAlbum
+      if (!listAlbumSets.has(row.list_id)) {
+        listAlbumSets.set(row.list_id, new Set());
+      }
+      listAlbumSets.get(row.list_id).add(row.album_id);
+    }
+
+    const collisions = [];
+    for (const [listId, albumIds] of listAlbumSets.entries()) {
+      if (albumIds.size < 2) continue;
+      collisions.push({
+        ...listInfoById.get(listId),
+        albumIds: [...albumIds].sort(),
+        variantCount: albumIds.size,
+      });
+    }
+
+    const mergedFieldNames = new Set();
+    let simulatedCanonical = { ...canonicalAlbum };
+
+    for (const retireId of existingRetireIds) {
+      const retireAlbum = albumsById.get(retireId);
+      const mergePreview = buildMergeFields(simulatedCanonical, retireAlbum);
+
+      for (const fieldName of mergePreview.fieldNames) {
+        mergedFieldNames.add(fieldName);
+      }
+
+      simulatedCanonical = applyMergeFieldValues(
+        simulatedCanonical,
+        mergePreview.fieldNames,
+        mergePreview.values
+      );
+    }
+
+    return {
+      canonicalAlbumId: canonicalId,
+      retireAlbumIds: existingRetireIds,
+      missingRetireAlbumIds: missingRetireIds,
+      impactedLists: impactedListIds.size,
+      impactedUsers: impactedUserIds.size,
+      collisionCount: collisions.length,
+      collisions: collisions.slice(0, 100),
+      metadataFieldsLikelyMerged: [...mergedFieldNames].sort(),
+    };
+  }
+
+  /**
+   * Merge multiple albums into a canonical album in one transaction.
+   *
+   * @param {string} canonicalAlbumId - Album ID to keep
+   * @param {string[]} retireAlbumIds - Album IDs to retire
+   * @returns {Promise<Object>} aggregate merge result
+   */
+  async function mergeCluster(canonicalAlbumId, retireAlbumIds) {
+    const canonicalId = normalizeText(canonicalAlbumId);
+    if (!canonicalId) {
+      throw new TransactionAbort(400, {
+        error: 'canonicalAlbumId is required',
+      });
+    }
+
+    const retireIds = normalizeRetireAlbumIds(canonicalId, retireAlbumIds);
+
+    return withTransaction(pool, async (client) => {
+      const aggregate = {
+        canonicalAlbumId: canonicalId,
+        requestedRetireIds: retireIds,
+        mergedAlbums: 0,
+        missingAlbums: 0,
+        listItemsUpdated: 0,
+        albumsDeleted: 0,
+        metadataMerged: false,
+        mergedFieldNames: new Set(),
+        collisionsResolved: 0,
+        collisionRowsDeleted: 0,
+        results: [],
+      };
+
+      for (const retireId of retireIds) {
+        const result = await mergeAlbumsWithinTransaction(
+          client,
+          canonicalId,
+          retireId
         );
 
-        if (fieldsToMerge.length > 0) {
-          fieldsToMerge.push(`updated_at = NOW()`);
-          await client.query(
-            `UPDATE albums SET ${fieldsToMerge.join(', ')} WHERE album_id = $1`,
-            values
-          );
-          metadataMerged = true;
-          logger.info('Merged metadata into kept album', {
-            keepAlbumId,
-            fieldsMerged: fieldsToMerge.length - 1, // -1 for updated_at
-          });
+        aggregate.results.push({ retireAlbumId: retireId, ...result });
+        aggregate.listItemsUpdated += result.listItemsUpdated;
+        aggregate.albumsDeleted += result.albumsDeleted;
+        aggregate.collisionsResolved += result.collisionsResolved;
+        aggregate.collisionRowsDeleted += result.collisionRowsDeleted;
+
+        if (result.albumsDeleted > 0) {
+          aggregate.mergedAlbums++;
+        } else {
+          aggregate.missingAlbums++;
+        }
+
+        if (result.metadataMerged) {
+          aggregate.metadataMerged = true;
+        }
+
+        for (const fieldName of result.mergedFieldNames || []) {
+          aggregate.mergedFieldNames.add(fieldName);
         }
       }
 
-      // Update all list_items to point to the kept album
-      const updateResult = await client.query(
-        `UPDATE list_items SET album_id = $1 WHERE album_id = $2`,
-        [keepAlbumId, deleteAlbumId]
-      );
-
-      // Delete the duplicate album
-      const deleteResult = await client.query(
-        `DELETE FROM albums WHERE album_id = $1`,
-        [deleteAlbumId]
-      );
-
-      // Clean up any distinct pairs involving the deleted album
-      await client.query(
-        `DELETE FROM album_distinct_pairs WHERE album_id_1 = $1 OR album_id_2 = $1`,
-        [deleteAlbumId]
-      );
-
-      logger.info('Albums merged successfully', {
-        keepAlbumId,
-        deleteAlbumId,
-        listItemsUpdated: updateResult.rowCount,
-        albumsDeleted: deleteResult.rowCount,
-        metadataMerged,
-      });
-
       return {
-        listItemsUpdated: updateResult.rowCount,
-        albumsDeleted: deleteResult.rowCount,
-        metadataMerged,
+        canonicalAlbumId: aggregate.canonicalAlbumId,
+        requestedRetireIds: aggregate.requestedRetireIds,
+        mergedAlbums: aggregate.mergedAlbums,
+        missingAlbums: aggregate.missingAlbums,
+        listItemsUpdated: aggregate.listItemsUpdated,
+        albumsDeleted: aggregate.albumsDeleted,
+        metadataMerged: aggregate.metadataMerged,
+        mergedFieldNames: [...aggregate.mergedFieldNames].sort(),
+        collisionsResolved: aggregate.collisionsResolved,
+        collisionRowsDeleted: aggregate.collisionRowsDeleted,
+        results: aggregate.results,
       };
     });
   }
 
-  return { scanDuplicates, mergeAlbums };
+  return {
+    scanDuplicates,
+    mergeAlbums,
+    previewMergeCluster,
+    mergeCluster,
+  };
 }
 
 module.exports = { createDuplicateService };

--- a/src/js/modules/duplicate-review-modal.js
+++ b/src/js/modules/duplicate-review-modal.js
@@ -1,8 +1,9 @@
 /**
  * Duplicate Review Modal
  *
- * Full-featured modal for reviewing and resolving potential duplicate albums.
- * Shows side-by-side comparison with field diffs, cover images, and action buttons.
+ * Cluster-based admin modal for reviewing and resolving duplicate albums.
+ * Allows canonical selection, selective merge, dry-run preview, and marking
+ * variant pairs as distinct.
  */
 
 import { escapeHtml, getPlaceholderSvg } from './html-utils.js';
@@ -12,39 +13,144 @@ import { markAlbumsDistinct } from '../utils/album-api.js';
 
 let modalElement = null;
 let modalController = null;
-let currentPairs = [];
-let currentIndex = 0;
+let currentClusters = [];
+let currentClusterIndex = 0;
 let onComplete = null;
 let resolvedCount = 0;
+let loading = false;
+
+function normalizeClusterMember(member) {
+  return {
+    album_id: member.album_id,
+    artist: member.artist || 'Unknown artist',
+    album: member.album || 'Unknown album',
+    release_date: member.release_date || null,
+    country: member.country || null,
+    genre_1: member.genre_1 || null,
+    genre_2: member.genre_2 || null,
+    trackCount: Number.isFinite(member.trackCount) ? member.trackCount : null,
+    hasCover: Boolean(member.hasCover),
+    listRefs: Number.isFinite(member.listRefs) ? member.listRefs : 0,
+    canonicalScore: Number.isFinite(member.canonicalScore)
+      ? member.canonicalScore
+      : 0,
+  };
+}
+
+function normalizeClusters(input) {
+  let sourceClusters = [];
+
+  if (Array.isArray(input)) {
+    if (input.length > 0 && Array.isArray(input[0].members)) {
+      sourceClusters = input;
+    } else if (input.length > 0 && input[0].album1 && input[0].album2) {
+      sourceClusters = input.map((pair, index) => {
+        return {
+          clusterId: `pair-${index}`,
+          suggestedCanonicalId: pair.album1.album_id,
+          members: [pair.album1, pair.album2],
+          maxConfidence: pair.confidence,
+          avgConfidence: pair.confidence,
+          pairs: [
+            {
+              album1Id: pair.album1.album_id,
+              album2Id: pair.album2.album_id,
+              confidence: pair.confidence,
+            },
+          ],
+        };
+      });
+    }
+  } else if (input && typeof input === 'object') {
+    if (Array.isArray(input.clusters) && input.clusters.length > 0) {
+      sourceClusters = input.clusters;
+    } else if (Array.isArray(input.pairs) && input.pairs.length > 0) {
+      sourceClusters = input.pairs.map((pair, index) => {
+        return {
+          clusterId: `pair-${index}`,
+          suggestedCanonicalId: pair.album1.album_id,
+          members: [pair.album1, pair.album2],
+          maxConfidence: pair.confidence,
+          avgConfidence: pair.confidence,
+          pairs: [
+            {
+              album1Id: pair.album1.album_id,
+              album2Id: pair.album2.album_id,
+              confidence: pair.confidence,
+            },
+          ],
+        };
+      });
+    }
+  }
+
+  return sourceClusters
+    .filter(
+      (cluster) => Array.isArray(cluster.members) && cluster.members.length > 1
+    )
+    .map((cluster, index) => {
+      const members = cluster.members
+        .map(normalizeClusterMember)
+        .sort((a, b) => (b.canonicalScore || 0) - (a.canonicalScore || 0));
+
+      const suggestedCanonicalId =
+        cluster.suggestedCanonicalId || members[0]?.album_id || null;
+      const selectedCanonicalId = suggestedCanonicalId;
+      const mergeTargets = new Set(
+        members
+          .map((member) => member.album_id)
+          .filter((albumId) => albumId !== selectedCanonicalId)
+      );
+
+      return {
+        clusterId: cluster.clusterId || `cluster-${index}`,
+        members,
+        memberCount: members.length,
+        pairs: Array.isArray(cluster.pairs) ? cluster.pairs : [],
+        maxConfidence: Number.isFinite(cluster.maxConfidence)
+          ? cluster.maxConfidence
+          : 0,
+        avgConfidence: Number.isFinite(cluster.avgConfidence)
+          ? cluster.avgConfidence
+          : 0,
+        selectedCanonicalId,
+        mergeTargets,
+      };
+    });
+}
 
 /**
- * Open the duplicate review modal with a list of potential duplicate pairs
+ * Open the duplicate review modal.
  *
- * @param {Array} pairs - Array of duplicate pairs from the API
- * @param {Function} onCompleteCallback - Called when all pairs are processed or modal is closed
+ * @param {Object|Array} scanData - scan response or legacy pair array
+ * @param {Function} onCompleteCallback - completion callback
  * @returns {Promise<{resolved: number, remaining: number}>}
  */
-export function openDuplicateReviewModal(pairs, onCompleteCallback = null) {
+export function openDuplicateReviewModal(scanData, onCompleteCallback = null) {
   return new Promise((resolve) => {
-    if (!pairs || pairs.length === 0) {
+    const clusters = normalizeClusters(scanData);
+    if (clusters.length === 0) {
       resolve({ resolved: 0, remaining: 0 });
       return;
     }
 
-    currentPairs = [...pairs];
-    currentIndex = 0;
+    currentClusters = clusters;
+    currentClusterIndex = 0;
     resolvedCount = 0;
+    loading = false;
+
     onComplete = () => {
       const result = {
         resolved: resolvedCount,
-        remaining: currentPairs.length - currentIndex,
+        remaining: currentClusters.length - currentClusterIndex,
       };
+
       if (onCompleteCallback) onCompleteCallback(result);
       resolve(result);
     };
 
     createModalDOM();
-    renderCurrentPair();
+    renderCurrentCluster();
     showModal();
   });
 }
@@ -56,41 +162,33 @@ function createModalDOM() {
 
   modalElement = document.createElement('div');
   modalElement.id = 'duplicateReviewModal';
-  // Use z-[10002] to ensure modal is above #modalPortal (z-10001) and similar-album-modal (z-10001)
   modalElement.className =
     'fixed inset-0 z-[10002] flex items-center justify-center p-4 safe-area-modal duplicate-review-modal hidden';
   modalElement.innerHTML = `
     <div class="settings-modal-backdrop"></div>
-    <div class="settings-modal-content duplicate-review-modal-content">
+    <div class="settings-modal-content duplicate-review-modal-content max-w-5xl w-full">
       <div class="settings-modal-header">
         <div class="flex items-center gap-2">
-          <h3 class="settings-modal-title">Review Duplicates</h3>
+          <h3 class="settings-modal-title">Review Duplicate Clusters</h3>
           <span id="duplicateProgress" class="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs sm:text-sm rounded">
             1 / 1
           </span>
         </div>
-        <button class="settings-modal-close" id="duplicateModalClose">
+        <button class="settings-modal-close" id="duplicateModalClose" type="button">
           <i class="fas fa-times"></i>
         </button>
       </div>
-      <div class="settings-modal-body duplicate-review-modal-body" id="duplicateReviewContent">
-        <!-- Content rendered dynamically -->
-      </div>
+      <div class="settings-modal-body duplicate-review-modal-body" id="duplicateReviewContent"></div>
       <div class="settings-modal-footer duplicate-review-modal-footer">
-        <div class="flex gap-2">
-          <button id="keepLeftBtn" class="settings-button bg-green-700 hover:bg-green-600" type="button">
-            <i class="fas fa-check"></i><span class="hidden sm:inline ml-1">Keep</span> Left
+        <div class="flex gap-2 flex-wrap">
+          <button id="previewClusterBtn" class="settings-button" type="button">
+            <i class="fas fa-search mr-1"></i>Preview
           </button>
-          <button id="keepRightBtn" class="settings-button bg-green-700 hover:bg-green-600" type="button">
-            <i class="fas fa-check"></i><span class="hidden sm:inline ml-1">Keep</span> Right
+          <button id="mergeClusterBtn" class="settings-button bg-green-700 hover:bg-green-600" type="button">
+            <i class="fas fa-code-branch mr-1"></i>Merge Selected
           </button>
-        </div>
-        <div class="flex gap-2">
-          <button id="markDistinctBtn" class="settings-button bg-blue-700 hover:bg-blue-600" type="button">
-            <i class="fas fa-not-equal"></i><span class="hidden sm:inline ml-1">Different</span>
-          </button>
-          <button id="skipPairBtn" class="settings-button" type="button">
-            <i class="fas fa-forward"></i><span class="hidden sm:inline ml-1">Skip</span>
+          <button id="skipClusterBtn" class="settings-button" type="button">
+            <i class="fas fa-forward mr-1"></i>Skip Cluster
           </button>
         </div>
       </div>
@@ -106,35 +204,27 @@ function setupModalController() {
 
   modalController = createModal({
     element: modalElement,
-    backdrop: backdrop,
+    backdrop,
     closeButton: closeBtn,
-    closeOnEscape: false, // We handle keyboard shortcuts ourselves
+    closeOnEscape: false,
     onClose: () => {
       if (onComplete) onComplete();
     },
   });
 
-  // Keyboard shortcuts (including Escape) - managed via addListener for cleanup
   modalController.addListener(document, 'keydown', handleKeyboard);
-
-  // Button handlers
   modalController.addListener(
-    modalElement.querySelector('#keepLeftBtn'),
+    modalElement.querySelector('#previewClusterBtn'),
     'click',
-    () => handleMerge('left')
+    handlePreview
   );
   modalController.addListener(
-    modalElement.querySelector('#keepRightBtn'),
+    modalElement.querySelector('#mergeClusterBtn'),
     'click',
-    () => handleMerge('right')
+    handleMergeCluster
   );
   modalController.addListener(
-    modalElement.querySelector('#markDistinctBtn'),
-    'click',
-    handleMarkDistinct
-  );
-  modalController.addListener(
-    modalElement.querySelector('#skipPairBtn'),
+    modalElement.querySelector('#skipClusterBtn'),
     'click',
     handleSkip
   );
@@ -144,6 +234,7 @@ function showModal() {
   if (!modalController) {
     setupModalController();
   }
+
   modalController.open();
 }
 
@@ -151,248 +242,299 @@ function hideModal() {
   if (modalController) {
     modalController.close();
     modalController = null;
-  } else {
+  } else if (modalElement) {
     modalElement.classList.add('hidden');
     document.body.style.overflow = '';
   }
 }
 
-function handleClose() {
-  hideModal();
+function currentCluster() {
+  return currentClusters[currentClusterIndex] || null;
 }
 
-function handleKeyboard(e) {
-  if (!modalController || !modalController.isOpen()) return;
-
-  switch (e.key) {
-    case 'Escape':
-      handleClose();
-      break;
-    case '1':
-    case 'ArrowLeft':
-      if (!e.ctrlKey && !e.metaKey) {
-        e.preventDefault();
-        handleMerge('left');
-      }
-      break;
-    case '2':
-    case 'ArrowRight':
-      if (!e.ctrlKey && !e.metaKey) {
-        e.preventDefault();
-        handleMerge('right');
-      }
-      break;
-    case '3':
-    case 'd':
-      if (!e.ctrlKey && !e.metaKey) {
-        e.preventDefault();
-        handleMarkDistinct();
-      }
-      break;
-    case 's':
-    case 'ArrowDown':
-      if (!e.ctrlKey && !e.metaKey) {
-        e.preventDefault();
-        handleSkip();
-      }
-      break;
-  }
+function formatGenres(member) {
+  const genres = [member.genre_1, member.genre_2].filter((value) => {
+    return Boolean(value && String(value).trim());
+  });
+  return genres.length > 0 ? genres.join(', ') : 'None';
 }
 
-function renderCurrentPair() {
-  if (currentIndex >= currentPairs.length) {
+function renderCurrentCluster() {
+  if (currentClusterIndex >= currentClusters.length) {
     renderComplete();
     return;
   }
 
-  const pair = currentPairs[currentIndex];
-  const content = modalElement.querySelector('#duplicateReviewContent');
+  const cluster = currentCluster();
   const progress = modalElement.querySelector('#duplicateProgress');
+  const content = modalElement.querySelector('#duplicateReviewContent');
+  const placeholderSvg = getPlaceholderSvg(80);
 
-  progress.textContent = `${currentIndex + 1} / ${currentPairs.length}`;
-
-  const leftCoverUrl = pair.album1.hasCover
-    ? `/api/albums/${encodeURIComponent(pair.album1.album_id)}/cover`
-    : null;
-  const rightCoverUrl = pair.album2.hasCover
-    ? `/api/albums/${encodeURIComponent(pair.album2.album_id)}/cover`
-    : null;
-
-  const placeholderSvg = getPlaceholderSvg(200);
-
-  // Calculate field diffs
-  const diffs = calculateDiffs(pair.album1, pair.album2);
-
-  // Build list of differing fields (only shown if they differ)
-  const diffFields1 = [];
-  const diffFields2 = [];
-
-  // Show artist/album diffs if they differ (since names are always shown, highlight the difference)
-  if (diffs.artist) {
-    diffFields1.push(renderDiffField('Artist', pair.album1.artist));
-    diffFields2.push(renderDiffField('Artist', pair.album2.artist));
-  }
-  if (diffs.album) {
-    diffFields1.push(renderDiffField('Album', pair.album1.album));
-    diffFields2.push(renderDiffField('Album', pair.album2.album));
-  }
-  if (diffs.release_date) {
-    diffFields1.push(
-      renderDiffField('Release', pair.album1.release_date || 'Unknown')
-    );
-    diffFields2.push(
-      renderDiffField('Release', pair.album2.release_date || 'Unknown')
-    );
-  }
-  if (diffs.genres) {
-    diffFields1.push(
-      renderDiffField(
-        'Genre',
-        formatGenres(pair.album1.genre_1, pair.album1.genre_2)
-      )
-    );
-    diffFields2.push(
-      renderDiffField(
-        'Genre',
-        formatGenres(pair.album2.genre_1, pair.album2.genre_2)
-      )
-    );
-  }
-  if (diffs.trackCount) {
-    diffFields1.push(
-      renderDiffField(
-        'Tracks',
-        pair.album1.trackCount !== null
-          ? `${pair.album1.trackCount} tracks`
-          : 'Unknown'
-      )
-    );
-    diffFields2.push(
-      renderDiffField(
-        'Tracks',
-        pair.album2.trackCount !== null
-          ? `${pair.album2.trackCount} tracks`
-          : 'Unknown'
-      )
-    );
+  if (progress) {
+    progress.textContent = `${currentClusterIndex + 1} / ${currentClusters.length}`;
   }
 
-  const diffSection1 =
-    diffFields1.length > 0
-      ? `<div class="mt-2 pt-2 border-t border-gray-700 space-y-0.5">${diffFields1.join('')}</div>`
-      : '';
-  const diffSection2 =
-    diffFields2.length > 0
-      ? `<div class="mt-2 pt-2 border-t border-gray-700 space-y-0.5">${diffFields2.join('')}</div>`
-      : '';
+  const confidenceLabel =
+    cluster.maxConfidence > 0
+      ? `${cluster.maxConfidence}% top match`
+      : `${cluster.memberCount} variants`;
+
+  const canonicalOptions = cluster.members
+    .map((member) => {
+      const selected =
+        member.album_id === cluster.selectedCanonicalId ? 'selected' : '';
+      return `<option value="${escapeHtml(member.album_id)}" ${selected}>${escapeHtml(member.artist)} - ${escapeHtml(member.album)}</option>`;
+    })
+    .join('');
+
+  const variantRows = cluster.members
+    .map((member) => {
+      const isCanonical = member.album_id === cluster.selectedCanonicalId;
+      const isSelected = cluster.mergeTargets.has(member.album_id);
+      const coverUrl = member.hasCover
+        ? `/api/albums/${encodeURIComponent(member.album_id)}/cover`
+        : placeholderSvg;
+
+      return `
+        <div class="flex items-center gap-3 p-3 rounded border border-gray-700 bg-gray-800/40" data-variant-id="${escapeHtml(member.album_id)}">
+          <input
+            type="checkbox"
+            class="merge-target-checkbox"
+            data-album-id="${escapeHtml(member.album_id)}"
+            ${isCanonical ? 'disabled' : ''}
+            ${isSelected ? 'checked' : ''}
+          />
+          <img
+            src="${coverUrl}"
+            alt="${escapeHtml(member.album)}"
+            class="w-12 h-12 rounded object-cover bg-gray-900"
+            onerror="this.src='${placeholderSvg}'"
+          />
+          <div class="min-w-0 flex-1">
+            <div class="text-sm text-white truncate">${escapeHtml(member.album)}</div>
+            <div class="text-xs text-gray-400 truncate">${escapeHtml(member.artist)}</div>
+            <div class="text-xs text-gray-500 mt-1">
+              ${member.trackCount ? `${member.trackCount} tracks` : 'Tracks unknown'}
+              • ${member.release_date ? escapeHtml(member.release_date) : 'Date unknown'}
+              • ${escapeHtml(formatGenres(member))}
+              • ${member.listRefs || 0} list refs
+            </div>
+          </div>
+          <div class="flex items-center gap-2 shrink-0">
+            ${isCanonical ? '<span class="text-xs px-2 py-1 bg-green-900/40 border border-green-700 text-green-300 rounded">Canonical</span>' : ''}
+            <button
+              class="settings-button mark-distinct-btn"
+              type="button"
+              data-album-id="${escapeHtml(member.album_id)}"
+              ${isCanonical ? 'disabled' : ''}
+            >
+              Distinct
+            </button>
+          </div>
+        </div>
+      `;
+    })
+    .join('');
 
   content.innerHTML = `
-    <!-- Confidence Banner - compact on mobile -->
-    <div class="mb-3 p-2 sm:p-3 rounded-lg ${pair.confidence >= 90 ? 'bg-red-900/30 border border-red-700/50' : pair.confidence >= 75 ? 'bg-yellow-900/30 border border-yellow-700/50' : 'bg-blue-900/30 border border-blue-700/50'}">
-      <div class="flex items-center justify-between flex-wrap gap-1">
-        <span class="text-sm sm:text-base font-bold ${pair.confidence >= 90 ? 'text-red-400' : pair.confidence >= 75 ? 'text-yellow-400' : 'text-blue-400'}">
-          ${pair.confidence}% Match
-        </span>
-        <span class="text-xs ${diffs.hasDifferences ? 'text-yellow-400' : 'text-green-400'}">
-          ${diffs.hasDifferences ? `${diffs.differenceCount} diff` : 'Match'}
-        </span>
-      </div>
-    </div>
-
-    <!-- Side-by-side comparison - always 2 columns -->
-    <div class="duplicate-review-compare">
-      <!-- Left Album -->
-      <div class="duplicate-review-card bg-gray-800/50 rounded-lg p-2 sm:p-4 border-2 border-transparent hover:border-green-600/50 transition-colors">
-        <div class="text-center mb-2">
-          <span class="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded-full">Left</span>
-        </div>
-        <div class="duplicate-review-cover aspect-square mb-2 sm:mb-3 bg-gray-900 rounded overflow-hidden">
-          <img 
-            src="${leftCoverUrl || placeholderSvg}" 
-            alt="${escapeHtml(pair.album1.album)}"
-            class="w-full h-full object-cover"
-            onerror="this.src='${placeholderSvg}'"
-          />
-        </div>
-        <div class="text-center">
-          <div class="album-title text-white font-semibold text-sm sm:text-base truncate" title="${escapeHtml(pair.album1.album)}">${escapeHtml(pair.album1.album)}</div>
-          <div class="album-artist text-gray-400 text-xs sm:text-sm truncate" title="${escapeHtml(pair.album1.artist)}">${escapeHtml(pair.album1.artist)}</div>
-          ${diffSection1}
-        </div>
+    <div class="space-y-4">
+      <div class="p-3 rounded border border-gray-700 bg-gray-900/50">
+        <div class="text-sm text-gray-200">${cluster.memberCount} variants in this cluster</div>
+        <div class="text-xs text-gray-400 mt-1">${confidenceLabel}</div>
       </div>
 
-      <!-- Right Album -->
-      <div class="duplicate-review-card bg-gray-800/50 rounded-lg p-2 sm:p-4 border-2 border-transparent hover:border-green-600/50 transition-colors">
-        <div class="text-center mb-2">
-          <span class="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded-full">Right</span>
-        </div>
-        <div class="duplicate-review-cover aspect-square mb-2 sm:mb-3 bg-gray-900 rounded overflow-hidden">
-          <img 
-            src="${rightCoverUrl || placeholderSvg}" 
-            alt="${escapeHtml(pair.album2.album)}"
-            class="w-full h-full object-cover"
-            onerror="this.src='${placeholderSvg}'"
-          />
-        </div>
-        <div class="text-center">
-          <div class="album-title text-white font-semibold text-sm sm:text-base truncate" title="${escapeHtml(pair.album2.album)}">${escapeHtml(pair.album2.album)}</div>
-          <div class="album-artist text-gray-400 text-xs sm:text-sm truncate" title="${escapeHtml(pair.album2.artist)}">${escapeHtml(pair.album2.artist)}</div>
-          ${diffSection2}
-        </div>
+      <div>
+        <label for="canonicalAlbumSelect" class="settings-label">Canonical album to keep</label>
+        <select id="canonicalAlbumSelect" class="bg-gray-700 text-white text-sm rounded px-2 py-2 border border-gray-600 w-full">
+          ${canonicalOptions}
+        </select>
+      </div>
+
+      <div id="clusterPreviewPanel" class="hidden p-3 rounded border border-gray-700 bg-gray-900/50 text-sm text-gray-300"></div>
+
+      <div class="space-y-2">
+        ${variantRows}
       </div>
     </div>
   `;
 
-  // Store current pair data for actions
-  modalElement.dataset.leftId = pair.album1.album_id;
-  modalElement.dataset.rightId = pair.album2.album_id;
+  const canonicalSelect = content.querySelector('#canonicalAlbumSelect');
+  canonicalSelect.addEventListener('change', (event) => {
+    applyCanonicalSelection(event.target.value);
+  });
+
+  content.querySelectorAll('.merge-target-checkbox').forEach((checkbox) => {
+    checkbox.addEventListener('change', () => {
+      applyMergeSelection(checkbox.dataset.albumId, checkbox.checked);
+    });
+  });
+
+  content.querySelectorAll('.mark-distinct-btn').forEach((button) => {
+    button.addEventListener('click', () => {
+      handleMarkDistinct(button.dataset.albumId);
+    });
+  });
+
+  setButtonsLoading(loading);
 }
 
-function renderDiffField(label, value) {
-  return `
-    <div class="bg-yellow-900/20 border-l-2 border-yellow-500 pl-1.5 py-0.5 text-xs">
-      <span class="text-gray-500">${label}:</span>
-      <span class="text-yellow-300 block truncate" title="${escapeHtml(value)}">${escapeHtml(value)}</span>
-    </div>
+function applyCanonicalSelection(canonicalId) {
+  const cluster = currentCluster();
+  if (!cluster) return;
+
+  cluster.selectedCanonicalId = canonicalId;
+  cluster.mergeTargets.delete(canonicalId);
+
+  for (const member of cluster.members) {
+    if (
+      member.album_id !== canonicalId &&
+      !cluster.mergeTargets.has(member.album_id)
+    ) {
+      cluster.mergeTargets.add(member.album_id);
+    }
+  }
+
+  renderCurrentCluster();
+}
+
+function applyMergeSelection(albumId, isSelected) {
+  const cluster = currentCluster();
+  if (!cluster) return;
+  if (albumId === cluster.selectedCanonicalId) return;
+
+  if (isSelected) {
+    cluster.mergeTargets.add(albumId);
+  } else {
+    cluster.mergeTargets.delete(albumId);
+  }
+}
+
+function selectedPayload() {
+  const cluster = currentCluster();
+  if (!cluster) return null;
+
+  return {
+    canonicalAlbumId: cluster.selectedCanonicalId,
+    retireAlbumIds: [...cluster.mergeTargets],
+  };
+}
+
+function renderPreview(preview) {
+  const panel = modalElement.querySelector('#clusterPreviewPanel');
+  if (!panel) return;
+
+  panel.classList.remove('hidden');
+  panel.innerHTML = `
+    <div class="font-medium text-gray-100 mb-2">Dry-run impact</div>
+    <div>Lists affected: ${preview.impactedLists}</div>
+    <div>Users affected: ${preview.impactedUsers}</div>
+    <div>Same-list collisions: ${preview.collisionCount}</div>
+    <div class="mt-2">Metadata fields likely merged: ${
+      preview.metadataFieldsLikelyMerged?.length
+        ? preview.metadataFieldsLikelyMerged
+            .map((field) => escapeHtml(field))
+            .join(', ')
+        : 'none'
+    }</div>
+    ${
+      preview.missingRetireAlbumIds?.length
+        ? `<div class="mt-2 text-yellow-400">Already missing: ${preview.missingRetireAlbumIds.map((id) => escapeHtml(id)).join(', ')}</div>`
+        : ''
+    }
   `;
 }
 
-function calculateDiffs(album1, album2) {
-  // Normalize strings, treating null/undefined/empty as equivalent
-  const normalize = (s) => (s || '').toLowerCase().trim();
+async function handlePreview() {
+  const payload = selectedPayload();
+  if (!payload) return;
 
-  // Check if two values are meaningfully different (not just null vs empty)
-  const isDifferent = (a, b) => {
-    const normA = normalize(a);
-    const normB = normalize(b);
-    // Both empty = same, otherwise compare
-    if (!normA && !normB) return false;
-    return normA !== normB;
-  };
+  if (payload.retireAlbumIds.length === 0) {
+    showToast('No variants selected to merge', 'info');
+    return;
+  }
 
-  const diffs = {
-    artist: isDifferent(album1.artist, album2.artist),
-    album: isDifferent(album1.album, album2.album),
-    release_date: isDifferent(album1.release_date, album2.release_date),
-    genres:
-      isDifferent(album1.genre_1, album2.genre_1) ||
-      isDifferent(album1.genre_2, album2.genre_2),
-    trackCount:
-      album1.trackCount !== album2.trackCount &&
-      album1.trackCount !== null &&
-      album2.trackCount !== null,
-  };
+  setButtonsLoading(true);
 
-  diffs.hasDifferences = Object.values(diffs).some((v) => v === true);
-  diffs.differenceCount = Object.values(diffs).filter((v) => v === true).length;
-
-  return diffs;
+  try {
+    const preview = await apiCall('/admin/api/merge-cluster/dry-run', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    renderPreview(preview);
+  } catch (error) {
+    console.error('Error previewing cluster merge:', error);
+    showToast(`Preview failed: ${error.message}`, 'error');
+  } finally {
+    setButtonsLoading(false);
+  }
 }
 
-function formatGenres(g1, g2) {
-  if (!g1 && !g2) return 'None';
-  if (!g2) return g1;
-  return `${g1}, ${g2}`;
+async function handleMergeCluster() {
+  const payload = selectedPayload();
+  if (!payload) return;
+
+  if (payload.retireAlbumIds.length === 0) {
+    showToast('No variants selected to merge', 'info');
+    return;
+  }
+
+  setButtonsLoading(true);
+
+  try {
+    const result = await apiCall('/admin/api/merge-cluster', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+
+    const fieldsSummary = Array.isArray(result.mergedFieldNames)
+      ? result.mergedFieldNames.length
+      : 0;
+
+    showToast(
+      `Merged ${result.mergedAlbums} album variants, updated ${result.listItemsUpdated} list references${fieldsSummary ? `, ${fieldsSummary} metadata fields` : ''}`,
+      'success'
+    );
+
+    resolvedCount++;
+    currentClusterIndex++;
+    renderCurrentCluster();
+  } catch (error) {
+    console.error('Error merging cluster:', error);
+    showToast(`Merge failed: ${error.message}`, 'error');
+  } finally {
+    setButtonsLoading(false);
+  }
+}
+
+async function handleMarkDistinct(albumId) {
+  const cluster = currentCluster();
+  if (!cluster) return;
+
+  const canonicalId = cluster.selectedCanonicalId;
+  if (!canonicalId || canonicalId === albumId) return;
+
+  setButtonsLoading(true);
+
+  try {
+    const result = await markAlbumsDistinct(canonicalId, albumId);
+    if (!result.ok) {
+      throw new Error(result.error || 'Failed to mark albums as distinct');
+    }
+
+    cluster.mergeTargets.delete(albumId);
+    showToast('Marked as different albums', 'success');
+    renderCurrentCluster();
+  } catch (error) {
+    console.error('Error marking albums as distinct:', error);
+    showToast(`Error: ${error.message}`, 'error');
+  } finally {
+    setButtonsLoading(false);
+  }
+}
+
+function handleSkip() {
+  currentClusterIndex++;
+  renderCurrentCluster();
 }
 
 function renderComplete() {
@@ -408,10 +550,10 @@ function renderComplete() {
         <i class="fas fa-check-circle text-5xl text-green-500 mb-4"></i>
         <h3 class="text-xl font-bold text-white mb-2">Review Complete</h3>
         <p class="text-gray-400 mb-4">
-          Processed ${resolvedCount} of ${currentPairs.length} potential duplicates
+          Resolved ${resolvedCount} of ${currentClusters.length} clusters
         </p>
         <p class="text-sm text-gray-500">
-          ${currentPairs.length - resolvedCount > 0 ? `${currentPairs.length - resolvedCount} pairs were skipped` : 'All pairs processed!'}
+          ${currentClusters.length - resolvedCount > 0 ? `${currentClusters.length - resolvedCount} clusters were skipped` : 'All clusters processed!'}
         </p>
       </div>
     `;
@@ -419,93 +561,56 @@ function renderComplete() {
 
   if (footer) {
     footer.innerHTML = `
-      <button id="closeCompleteBtn" class="settings-button bg-green-700 hover:bg-green-600 px-6">
+      <button id="closeCompleteBtn" class="settings-button bg-green-700 hover:bg-green-600 px-6" type="button">
         <i class="fas fa-check mr-2"></i>Done
       </button>
     `;
 
     const closeBtn = footer.querySelector('#closeCompleteBtn');
     if (closeBtn) {
-      closeBtn.addEventListener('click', handleClose);
+      closeBtn.addEventListener('click', hideModal);
     }
   }
 }
 
-async function handleMerge(direction) {
-  const keepId =
-    direction === 'left'
-      ? modalElement.dataset.leftId
-      : modalElement.dataset.rightId;
-  const deleteId =
-    direction === 'left'
-      ? modalElement.dataset.rightId
-      : modalElement.dataset.leftId;
+function setButtonsLoading(isLoading) {
+  loading = isLoading;
 
-  setButtonsLoading(true);
+  if (!modalElement) return;
 
-  try {
-    const data = await apiCall('/admin/api/merge-albums', {
-      method: 'POST',
-      body: JSON.stringify({ keepAlbumId: keepId, deleteAlbumId: deleteId }),
+  modalElement
+    .querySelectorAll(
+      '#previewClusterBtn, #mergeClusterBtn, #skipClusterBtn, .mark-distinct-btn, .merge-target-checkbox, #canonicalAlbumSelect'
+    )
+    .forEach((element) => {
+      element.disabled = isLoading;
     });
+}
 
-    const metadataMsg = data.metadataMerged ? ' (metadata merged)' : '';
-    showToast(
-      `Merged: ${data.listItemsUpdated} reference${data.listItemsUpdated !== 1 ? 's' : ''} updated${metadataMsg}`,
-      'success'
-    );
-    resolvedCount++;
-    currentIndex++;
-    renderCurrentPair();
-  } catch (err) {
-    console.error('Error merging albums:', err);
-    showToast('Error merging albums: ' + err.message, 'error');
-  } finally {
-    setButtonsLoading(false);
+function handleKeyboard(event) {
+  if (!modalController || !modalController.isOpen()) return;
+
+  if (event.key === 'Escape') {
+    hideModal();
+    return;
   }
-}
 
-async function handleMarkDistinct() {
-  const album1 = modalElement.dataset.leftId;
-  const album2 = modalElement.dataset.rightId;
-
-  setButtonsLoading(true);
-
-  try {
-    const result = await markAlbumsDistinct(album1, album2);
-    if (!result.ok) throw new Error(result.error);
-
-    showToast('Marked as different albums', 'success');
-    resolvedCount++;
-    currentIndex++;
-    renderCurrentPair();
-  } catch (err) {
-    console.error('Error marking as distinct:', err);
-    showToast('Error: ' + err.message, 'error');
-  } finally {
-    setButtonsLoading(false);
+  if (event.key === 's' || event.key === 'S') {
+    event.preventDefault();
+    handleSkip();
+    return;
   }
-}
 
-function handleSkip() {
-  currentIndex++;
-  renderCurrentPair();
-}
-
-function setButtonsLoading(loading) {
-  const buttons = modalElement.querySelectorAll(
-    '#keepLeftBtn, #keepRightBtn, #markDistinctBtn, #skipPairBtn'
-  );
-  buttons.forEach((btn) => {
-    btn.disabled = loading;
-  });
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    handleMergeCluster();
+  }
 }
 
 /**
- * Close the modal programmatically
+ * Close the modal programmatically.
  */
 export function closeDuplicateReviewModal() {
-  if (modalElement) {
-    handleClose();
-  }
+  if (!modalElement) return;
+  hideModal();
 }

--- a/src/js/modules/settings-drawer/handlers/audit-handlers.js
+++ b/src/js/modules/settings-drawer/handlers/audit-handlers.js
@@ -34,7 +34,12 @@ export function createSettingsAuditHandlers(deps = {}) {
         throw new Error(response.error);
       }
 
-      if (response.pairs.length === 0) {
+      const hasClusters =
+        Array.isArray(response.clusters) && response.clusters.length > 0;
+      const hasPairs =
+        Array.isArray(response.pairs) && response.pairs.length > 0;
+
+      if (!hasClusters && !hasPairs) {
         statusDiv.innerHTML = `
           <span class="text-green-400">
             <i class="fas fa-check-circle mr-2"></i>
@@ -43,17 +48,23 @@ export function createSettingsAuditHandlers(deps = {}) {
         `;
         showToast('No potential duplicates found', 'success');
       } else {
+        const clusterCount = Number.isFinite(response.totalClusters)
+          ? response.totalClusters
+          : hasClusters
+            ? response.clusters.length
+            : 0;
+
         statusDiv.innerHTML = `
           <span class="text-yellow-400">
-            Found ${response.potentialDuplicates} potential duplicates. Opening review...
+            Found ${response.potentialDuplicates} potential duplicate pairs across ${clusterCount} clusters. Opening review...
           </span>
         `;
 
-        const result = await openDuplicateReviewModal(response.pairs);
+        const result = await openDuplicateReviewModal(response);
 
         statusDiv.innerHTML = `
           <span class="text-gray-400">
-            Last scan: ${response.potentialDuplicates} found, ${result.resolved} resolved, ${result.remaining} remaining
+            Last scan: ${response.potentialDuplicates} pairs across ${clusterCount} clusters, ${result.resolved} resolved, ${result.remaining} remaining
           </span>
         `;
       }

--- a/test/duplicate-service.test.js
+++ b/test/duplicate-service.test.js
@@ -14,34 +14,52 @@ describe('duplicate-service', () => {
             artist: 'Radiohead',
             album: 'OK Computer',
             release_date: null,
+            country: null,
             genre_1: null,
             genre_2: null,
+            tracks: null,
+            summary: null,
             track_count: 12,
             has_cover: true,
+            created_at: new Date('2020-01-01T00:00:00Z'),
           },
           {
             album_id: 'a2',
             artist: 'Radiohead',
             album: 'OK Computer (Deluxe Edition)',
             release_date: null,
+            country: null,
             genre_1: null,
             genre_2: null,
+            tracks: null,
+            summary: null,
             track_count: 24,
             has_cover: true,
+            created_at: new Date('2021-01-01T00:00:00Z'),
           },
           {
             album_id: 'a3',
             artist: 'Miles Davis',
             album: 'Kind of Blue',
             release_date: null,
+            country: null,
             genre_1: null,
             genre_2: null,
+            tracks: null,
+            summary: null,
             track_count: 5,
             has_cover: false,
+            created_at: new Date('2019-01-01T00:00:00Z'),
           },
         ],
       },
       { rows: [] },
+      {
+        rows: [
+          { album_id: 'a1', list_refs: 2 },
+          { album_id: 'a2', list_refs: 1 },
+        ],
+      },
     ]);
 
     const logger = createMockLogger();
@@ -57,6 +75,14 @@ describe('duplicate-service', () => {
       return ids[0] === 'a1' && ids[1] === 'a2';
     });
     assert.ok(hasExpectedPair);
+    assert.ok(Array.isArray(result.clusters));
+    assert.ok(result.totalClusters >= 1);
+
+    const radioheadCluster = result.clusters.find((cluster) =>
+      cluster.members.some((member) => member.album_id === 'a1')
+    );
+    assert.ok(radioheadCluster);
+    assert.ok(radioheadCluster.suggestedCanonicalId);
   });
 
   it('scanDuplicates should log comparison reduction metrics', async () => {
@@ -68,23 +94,32 @@ describe('duplicate-service', () => {
             artist: 'Boards of Canada',
             album: 'Geogaddi',
             release_date: null,
+            country: null,
             genre_1: null,
             genre_2: null,
+            tracks: null,
+            summary: null,
             track_count: 23,
             has_cover: true,
+            created_at: new Date('2020-01-01T00:00:00Z'),
           },
           {
             album_id: 'x2',
             artist: 'Bicep',
             album: 'Isles',
             release_date: null,
+            country: null,
             genre_1: null,
             genre_2: null,
+            tracks: null,
+            summary: null,
             track_count: 10,
             has_cover: true,
+            created_at: new Date('2020-01-02T00:00:00Z'),
           },
         ],
       },
+      { rows: [] },
       { rows: [] },
     ]);
 
@@ -158,6 +193,10 @@ describe('duplicate-service', () => {
           return { rows: [], rowCount: 1 };
         }
 
+        if (sql.includes('FROM list_items')) {
+          return { rows: [], rowCount: 0 };
+        }
+
         if (sql.includes('UPDATE list_items SET album_id')) {
           return { rows: [], rowCount: 3 };
         }
@@ -189,5 +228,141 @@ describe('duplicate-service', () => {
     assert.ok(callLog.includes('BEGIN'));
     assert.ok(callLog.includes('ROLLBACK'));
     assert.ok(!callLog.includes('COMMIT'));
+  });
+
+  it('mergeAlbums should resolve same-list collisions before remap', async () => {
+    const updates = [];
+    const deletions = [];
+
+    const client = {
+      query: async (sql, params) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('FROM albums WHERE album_id = $1 OR album_id = $2')) {
+          return {
+            rows: [
+              {
+                album_id: 'keep1',
+                artist: 'Artist',
+                album: 'Album',
+                release_date: null,
+                country: null,
+                genre_1: null,
+                genre_2: null,
+                tracks: null,
+                cover_image: null,
+                cover_image_format: null,
+                summary: null,
+                summary_source: null,
+                summary_fetched_at: null,
+              },
+              {
+                album_id: 'del1',
+                artist: 'Artist',
+                album: 'Album (Remaster)',
+                release_date: '2020-01-01',
+                country: null,
+                genre_1: 'Rock',
+                genre_2: null,
+                tracks: null,
+                cover_image: null,
+                cover_image_format: null,
+                summary: null,
+                summary_source: null,
+                summary_fetched_at: null,
+              },
+            ],
+          };
+        }
+
+        if (
+          sql.includes('FROM list_items') &&
+          sql.includes('album_id = $1 OR album_id = $2')
+        ) {
+          return {
+            rows: [
+              {
+                _id: 'item-keep',
+                list_id: 'list-1',
+                album_id: 'keep1',
+                position: 5,
+                comments: 'Existing comment',
+                comments_2: null,
+                primary_track: 'Track A',
+                secondary_track: null,
+                created_at: new Date('2020-01-01T00:00:00Z'),
+              },
+              {
+                _id: 'item-del',
+                list_id: 'list-1',
+                album_id: 'del1',
+                position: 3,
+                comments: 'New comment',
+                comments_2: 'Extra',
+                primary_track: 'Track B',
+                secondary_track: null,
+                created_at: new Date('2020-01-02T00:00:00Z'),
+              },
+            ],
+          };
+        }
+
+        if (
+          sql.includes('UPDATE list_items') &&
+          sql.includes('WHERE _id = $7')
+        ) {
+          updates.push({ sql, params });
+          return { rows: [], rowCount: 1 };
+        }
+
+        if (sql.includes('DELETE FROM list_items WHERE _id = ANY')) {
+          deletions.push(params);
+          return { rows: [], rowCount: 1 };
+        }
+
+        if (
+          sql.includes(
+            'UPDATE list_items SET album_id = $1, updated_at = NOW()'
+          )
+        ) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('DELETE FROM albums WHERE album_id = $1')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        if (sql.includes('DELETE FROM album_distinct_pairs')) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('UPDATE albums SET')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        return { rows: [], rowCount: 0 };
+      },
+      release: mock.fn(),
+    };
+
+    const pool = {
+      connect: mock.fn(async () => client),
+      query: mock.fn(async () => ({ rows: [], rowCount: 0 })),
+    };
+
+    const service = createDuplicateService({
+      pool,
+      logger: createMockLogger(),
+    });
+
+    const result = await service.mergeAlbums('keep1', 'del1');
+
+    assert.strictEqual(result.collisionsResolved, 1);
+    assert.strictEqual(result.collisionRowsDeleted, 1);
+    assert.strictEqual(result.albumsDeleted, 1);
+    assert.ok(updates.length >= 1);
+    assert.ok(deletions.length >= 1);
   });
 });

--- a/test/settings-audit-handlers.test.js
+++ b/test/settings-audit-handlers.test.js
@@ -54,6 +54,8 @@ describe('settings audit handlers', () => {
         apiCalls.push(url);
         return {
           pairs: [],
+          clusters: [],
+          totalClusters: 0,
           totalAlbums: 10,
           excludedPairs: 2,
         };
@@ -90,23 +92,27 @@ describe('settings audit handlers', () => {
       }),
       apiCall: async () => ({
         pairs: [{ id: 'p1' }],
+        clusters: [{ clusterId: 'c1', members: [{}, {}] }],
+        totalClusters: 1,
         potentialDuplicates: 1,
         totalAlbums: 10,
         excludedPairs: 0,
       }),
       showToast: () => {},
-      openDuplicateReviewModal: async (pairs) => {
-        modalCalls.push(pairs);
+      openDuplicateReviewModal: async (scanResult) => {
+        modalCalls.push(scanResult);
         return { resolved: 1, remaining: 0 };
       },
     });
 
     await handleScanDuplicates();
 
-    assert.deepStrictEqual(modalCalls, [[{ id: 'p1' }]]);
+    assert.strictEqual(modalCalls.length, 1);
+    assert.strictEqual(modalCalls[0].potentialDuplicates, 1);
+    assert.strictEqual(modalCalls[0].totalClusters, 1);
     assert.match(
       statusDiv.innerHTML,
-      /Last scan: 1 found, 1 resolved, 0 remaining/
+      /Last scan: 1 pairs across 1 clusters, 1 resolved, 0 remaining/
     );
   });
 


### PR DESCRIPTION
## Summary
- reworked duplicate scanning to produce paginated duplicate clusters with canonical suggestions while keeping legacy pair output for compatibility
- replaced the admin duplicate review modal with a cluster workflow that supports canonical selection, selective merges, dry-run impact preview, and per-variant mark-distinct actions
- hardened merge logic with deterministic metadata consolidation, same-list collision resolution before remapping, and new admin endpoints for cluster dry-run/commit
- fixed admin duplicate route handling for TransactionAbort status propagation and updated duplicate-related tests
- added deduplication_scanner.md in the project root with the implementation plan

## Validation
- npm run lint:strict
- node --test test/duplicate-service.test.js test/settings-audit-handlers.test.js
- node --test test/admin-routes.test.js
- npm run build