### PR TITLE
Freeze canonical list-entry shape at state boundary

### DIFF
--- a/src/js/modules/list-data-normalization.js
+++ b/src/js/modules/list-data-normalization.js
@@ -73,12 +73,11 @@ export function normalizeListsMap(newLists = {}) {
   Object.keys(newLists).forEach((listId) => {
     const entry = newLists[listId];
 
-    if (Array.isArray(entry)) {
-      normalized[listId] = createDefaultListEntry(listId, entry);
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
       return;
     }
 
-    if (entry && typeof entry === 'object' && Array.isArray(entry._data)) {
+    if (Array.isArray(entry._data)) {
       const normalizedData = normalizeAlbumRecords(entry._data);
       normalized[listId] =
         normalizedData === entry._data

--- a/test/app-state.test.js
+++ b/test/app-state.test.js
@@ -130,10 +130,10 @@ describe('app-state', async () => {
       assert.strictEqual(mod.getListData('id1'), albums);
     });
 
-    it('getListData handles legacy array format', () => {
+    it('getListData ignores legacy array-format list entries', () => {
       const albums = [{ album_id: 'a1' }];
       mod.setLists({ id1: albums });
-      assert.strictEqual(mod.getListData('id1'), albums);
+      assert.strictEqual(mod.getListData('id1'), null);
     });
 
     it('getListData returns null when _data is null', () => {
@@ -171,7 +171,7 @@ describe('app-state', async () => {
       assert.strictEqual(entry.name, 'Test'); // preserved
     });
 
-    it('setListData handles legacy array format by converting', () => {
+    it('setListData creates canonical entry when list metadata is missing', () => {
       mod.setLists({ id1: [{ album_id: 'old' }] });
       const albums = [{ album_id: 'new1' }, { album_id: 'new2' }];
       mod.setListData('id1', albums, false);
@@ -179,6 +179,7 @@ describe('app-state', async () => {
       assert.strictEqual(entry._data, albums);
       assert.strictEqual(entry.count, 2);
       assert.strictEqual(entry._id, 'id1');
+      assert.strictEqual(entry.name, 'Unknown');
     });
 
     it('setListData normalizes albumId aliases to album_id', () => {
@@ -226,12 +227,9 @@ describe('app-state', async () => {
       assert.strictEqual(mod.getListMetadata('id1'), entry);
     });
 
-    it('getListMetadata handles legacy array format', () => {
+    it('getListMetadata ignores legacy array-format list entries', () => {
       mod.setLists({ id1: [{ album_id: 'a1' }] });
-      const meta = mod.getListMetadata('id1');
-      assert.strictEqual(meta._id, 'id1');
-      assert.strictEqual(meta.count, 1);
-      assert.strictEqual(meta.name, 'Unknown');
+      assert.strictEqual(mod.getListMetadata('id1'), null);
     });
 
     it('updateListMetadata applies updates to existing list', () => {
@@ -250,12 +248,10 @@ describe('app-state', async () => {
       assert.deepStrictEqual(mod.getLists(), {});
     });
 
-    it('updateListMetadata converts legacy array format first', () => {
+    it('updateListMetadata does nothing when entry is legacy array format', () => {
       mod.setLists({ id1: [{ album_id: 'a1' }] });
       mod.updateListMetadata('id1', { name: 'Converted' });
-      const entry = mod.getLists()['id1'];
-      assert.strictEqual(entry.name, 'Converted');
-      assert.strictEqual(entry._id, 'id1');
+      assert.strictEqual(mod.getLists()['id1'], undefined);
     });
 
     it('findListByName finds a list by name', () => {
@@ -296,9 +292,9 @@ describe('app-state', async () => {
       assert.strictEqual(mod.isListDataLoaded('nope'), false);
     });
 
-    it('isListDataLoaded returns true for legacy array format', () => {
+    it('isListDataLoaded returns false for legacy array-format list entries', () => {
       mod.setLists({ id1: [{ album_id: 'a1' }] });
-      assert.strictEqual(mod.isListDataLoaded('id1'), true);
+      assert.strictEqual(mod.isListDataLoaded('id1'), false);
     });
 
     it('isListDataLoaded returns true when _data has items', () => {

--- a/test/list-data-normalization.test.js
+++ b/test/list-data-normalization.test.js
@@ -62,7 +62,7 @@ describe('list-data-normalization module', () => {
     assert.strictEqual(entry._data[0].genre_1, 'Jazz');
   });
 
-  it('normalizes mixed list map entries', () => {
+  it('normalizes canonical list map entries and skips legacy array entries', () => {
     const input = {
       'list-1': [{ albumId: 'a1' }],
       'list-2': {
@@ -73,8 +73,7 @@ describe('list-data-normalization module', () => {
 
     const normalized = normalizeListsMap(input);
 
-    assert.strictEqual(Array.isArray(normalized['list-1']._data), true);
-    assert.strictEqual(normalized['list-1']._data[0].album_id, 'a1');
+    assert.strictEqual(normalized['list-1'], undefined);
     assert.strictEqual(normalized['list-2']._data[0].album_id, 'a2');
     assert.strictEqual(normalized['list-2']._data[0].comments, 'hello');
   });


### PR DESCRIPTION
## Summary
- remove legacy array-entry adaptation from `normalizeListsMap` so list maps only retain object-shaped entries
- keep canonical `_data` normalization for object entries and skip invalid legacy list entries
- update state and normalization tests to assert canonical-only behavior for `setLists` input

## Verification
- node --test test/list-data-normalization.test.js
- node --test test/app-state.test.js
- npm run lint:strict