### PR TITLE
Retire frontend album alias normalization adapters

### DIFF
--- a/src/js/modules/list-data-normalization.js
+++ b/src/js/modules/list-data-normalization.js
@@ -3,38 +3,7 @@ export function normalizeAlbumRecord(album) {
     return { album, changed: false };
   }
 
-  let changed = false;
-  const normalized = { ...album };
-
-  if (!normalized.album_id && normalized.albumId) {
-    normalized.album_id = normalized.albumId;
-    changed = true;
-  }
-
-  if (normalized.comments == null && normalized.comment != null) {
-    normalized.comments = normalized.comment;
-    changed = true;
-  }
-
-  if (!normalized.genre_1 && normalized.genre) {
-    normalized.genre_1 = normalized.genre;
-    changed = true;
-  }
-
-  const legacyPrimary =
-    normalized.track_picks?.primary || normalized.track_pick || null;
-  if (!normalized.primary_track && legacyPrimary) {
-    normalized.primary_track = legacyPrimary;
-    changed = true;
-  }
-
-  const legacySecondary = normalized.track_picks?.secondary || null;
-  if (!normalized.secondary_track && legacySecondary) {
-    normalized.secondary_track = legacySecondary;
-    changed = true;
-  }
-
-  return { album: changed ? normalized : album, changed };
+  return { album, changed: false };
 }
 
 export function normalizeAlbumRecords(albums = []) {
@@ -42,14 +11,7 @@ export function normalizeAlbumRecords(albums = []) {
     return [];
   }
 
-  let changed = false;
-  const normalized = albums.map((album) => {
-    const result = normalizeAlbumRecord(album);
-    changed = changed || result.changed;
-    return result.album;
-  });
-
-  return changed ? normalized : albums;
+  return albums;
 }
 
 export function createDefaultListEntry(listId, albums = []) {

--- a/test/app-state.test.js
+++ b/test/app-state.test.js
@@ -67,22 +67,21 @@ describe('app-state', async () => {
       assert.strictEqual(window.lists, mod.getLists());
     });
 
-    it('setLists normalizes albumId aliases inside _data arrays', () => {
+    it('setLists preserves canonical album fields inside _data arrays', () => {
       mod.setLists({
         id1: {
           _id: 'id1',
           name: 'Test',
-          _data: [{ albumId: 'legacy-1' }],
+          _data: [{ album_id: 'canonical-1' }],
           count: 1,
         },
       });
 
       const album = mod.getListData('id1')[0];
-      assert.strictEqual(album.album_id, 'legacy-1');
-      assert.strictEqual(album.albumId, 'legacy-1');
+      assert.strictEqual(album.album_id, 'canonical-1');
     });
 
-    it('setLists normalizes legacy comment and track-pick aliases', () => {
+    it('setLists does not map legacy aliases to canonical fields', () => {
       mod.setLists({
         id1: {
           _id: 'id1',
@@ -93,12 +92,13 @@ describe('app-state', async () => {
       });
 
       const album = mod.getListData('id1')[0];
-      assert.strictEqual(album.comments, 'Legacy note');
-      assert.strictEqual(album.primary_track, '5');
+      assert.strictEqual(album.comments, undefined);
+      assert.strictEqual(album.primary_track, undefined);
+      assert.strictEqual(album.comment, 'Legacy note');
       assert.strictEqual(album.track_pick, '5');
     });
 
-    it('setLists normalizes legacy genre alias to genre_1', () => {
+    it('setLists does not map legacy genre alias to genre_1', () => {
       mod.setLists({
         id1: {
           _id: 'id1',
@@ -109,7 +109,7 @@ describe('app-state', async () => {
       });
 
       const album = mod.getListData('id1')[0];
-      assert.strictEqual(album.genre_1, 'Post-rock');
+      assert.strictEqual(album.genre_1, undefined);
       assert.strictEqual(album.genre, 'Post-rock');
     });
 
@@ -182,16 +182,15 @@ describe('app-state', async () => {
       assert.strictEqual(entry.name, 'Unknown');
     });
 
-    it('setListData normalizes albumId aliases to album_id', () => {
+    it('setListData preserves canonical album_id values', () => {
       mod.setLists({ id1: { _id: 'id1', _data: [], count: 0 } });
-      mod.setListData('id1', [{ albumId: 'legacy-2' }], false);
+      mod.setListData('id1', [{ album_id: 'canonical-2' }], false);
 
       const album = mod.getListData('id1')[0];
-      assert.strictEqual(album.album_id, 'legacy-2');
-      assert.strictEqual(album.albumId, 'legacy-2');
+      assert.strictEqual(album.album_id, 'canonical-2');
     });
 
-    it('setListData normalizes track_picks to canonical track fields', () => {
+    it('setListData does not map track_picks aliases to canonical fields', () => {
       mod.setLists({ id1: { _id: 'id1', _data: [], count: 0 } });
       mod.setListData(
         'id1',
@@ -200,8 +199,10 @@ describe('app-state', async () => {
       );
 
       const album = mod.getListData('id1')[0];
-      assert.strictEqual(album.primary_track, 'Track A');
-      assert.strictEqual(album.secondary_track, 'Track B');
+      assert.strictEqual(album.primary_track, undefined);
+      assert.strictEqual(album.secondary_track, undefined);
+      assert.strictEqual(album.track_picks.primary, 'Track A');
+      assert.strictEqual(album.track_picks.secondary, 'Track B');
     });
 
     it('setListData does nothing when listId is falsy', () => {

--- a/test/list-data-normalization.test.js
+++ b/test/list-data-normalization.test.js
@@ -15,7 +15,7 @@ describe('list-data-normalization module', () => {
     normalizeListsMap = module.normalizeListsMap;
   });
 
-  it('normalizes legacy album fields into canonical keys', () => {
+  it('leaves legacy album fields unchanged when adapters are removed', () => {
     const legacyAlbum = {
       albumId: 'abc',
       comment: 'legacy comment',
@@ -26,19 +26,8 @@ describe('list-data-normalization module', () => {
 
     const result = normalizeAlbumRecord(legacyAlbum);
 
-    assert.strictEqual(result.changed, true);
-    assert.deepStrictEqual(result.album, {
-      albumId: 'abc',
-      album_id: 'abc',
-      comment: 'legacy comment',
-      comments: 'legacy comment',
-      genre: 'Rock',
-      genre_1: 'Rock',
-      track_pick: 'Song 1',
-      track_picks: { secondary: 'Song 2' },
-      primary_track: 'Song 1',
-      secondary_track: 'Song 2',
-    });
+    assert.strictEqual(result.changed, false);
+    assert.strictEqual(result.album, legacyAlbum);
   });
 
   it('returns original album array reference when no normalization is needed', () => {
@@ -49,9 +38,9 @@ describe('list-data-normalization module', () => {
     assert.strictEqual(normalized, albums);
   });
 
-  it('creates default list entry with normalized data', () => {
+  it('creates default list entry with canonical data', () => {
     const entry = createDefaultListEntry('list-1', [
-      { albumId: 'a1', comment: 'x', genre: 'Jazz' },
+      { album_id: 'a1', comments: 'x', genre_1: 'Jazz' },
     ]);
 
     assert.strictEqual(entry._id, 'list-1');
@@ -67,7 +56,7 @@ describe('list-data-normalization module', () => {
       'list-1': [{ albumId: 'a1' }],
       'list-2': {
         _id: 'list-2',
-        _data: [{ albumId: 'a2', comment: 'hello' }],
+        _data: [{ album_id: 'a2', comments: 'hello' }],
       },
     };
 


### PR DESCRIPTION
## Summary
- remove legacy alias mapping in list-data-normalization so album records are treated as canonical-only input
- keep list normalization focused on shape boundaries without translating albumId/comment/genre/track picks aliases
- update normalization and app-state tests to assert canonical-only behavior

## Verification
- node --test test/list-data-normalization.test.js
- node --test test/app-state.test.js
- npm run lint:strict