### PR TITLE
Tighten duplicate review contract to cluster-only payloads

### DIFF
--- a/src/js/modules/duplicate-review-modal.js
+++ b/src/js/modules/duplicate-review-modal.js
@@ -37,52 +37,10 @@ function normalizeClusterMember(member) {
   };
 }
 
-function normalizeClusters(input) {
-  let sourceClusters = [];
-
-  if (Array.isArray(input)) {
-    if (input.length > 0 && Array.isArray(input[0].members)) {
-      sourceClusters = input;
-    } else if (input.length > 0 && input[0].album1 && input[0].album2) {
-      sourceClusters = input.map((pair, index) => {
-        return {
-          clusterId: `pair-${index}`,
-          suggestedCanonicalId: pair.album1.album_id,
-          members: [pair.album1, pair.album2],
-          maxConfidence: pair.confidence,
-          avgConfidence: pair.confidence,
-          pairs: [
-            {
-              album1Id: pair.album1.album_id,
-              album2Id: pair.album2.album_id,
-              confidence: pair.confidence,
-            },
-          ],
-        };
-      });
-    }
-  } else if (input && typeof input === 'object') {
-    if (Array.isArray(input.clusters) && input.clusters.length > 0) {
-      sourceClusters = input.clusters;
-    } else if (Array.isArray(input.pairs) && input.pairs.length > 0) {
-      sourceClusters = input.pairs.map((pair, index) => {
-        return {
-          clusterId: `pair-${index}`,
-          suggestedCanonicalId: pair.album1.album_id,
-          members: [pair.album1, pair.album2],
-          maxConfidence: pair.confidence,
-          avgConfidence: pair.confidence,
-          pairs: [
-            {
-              album1Id: pair.album1.album_id,
-              album2Id: pair.album2.album_id,
-              confidence: pair.confidence,
-            },
-          ],
-        };
-      });
-    }
-  }
+function normalizeClusters(scanData) {
+  const sourceClusters = Array.isArray(scanData?.clusters)
+    ? scanData.clusters
+    : [];
 
   return sourceClusters
     .filter(
@@ -122,7 +80,7 @@ function normalizeClusters(input) {
 /**
  * Open the duplicate review modal.
  *
- * @param {Object|Array} scanData - scan response or legacy pair array
+ * @param {Object} scanData - duplicate scan response with `clusters`
  * @param {Function} onCompleteCallback - completion callback
  * @returns {Promise<{resolved: number, remaining: number}>}
  */

--- a/src/js/modules/settings-drawer/handlers/audit-handlers.js
+++ b/src/js/modules/settings-drawer/handlers/audit-handlers.js
@@ -11,6 +11,25 @@ export function createSettingsAuditHandlers(deps = {}) {
   const { apiCall, showToast, openDuplicateReviewModal, openManualAlbumAudit } =
     deps;
 
+  function parseDuplicateClusters(response) {
+    if (!Array.isArray(response?.clusters)) {
+      throw new Error(
+        'Invalid duplicate scan response: missing clusters array'
+      );
+    }
+
+    const hasInvalidCluster = response.clusters.some((cluster) => {
+      return !Array.isArray(cluster?.members);
+    });
+    if (hasInvalidCluster) {
+      throw new Error(
+        'Invalid duplicate scan response: each cluster must include members'
+      );
+    }
+
+    return response.clusters;
+  }
+
   async function handleScanDuplicates() {
     const scanBtn = doc.getElementById('scanDuplicatesBtn');
     const statusDiv = doc.getElementById('duplicateScanStatus');
@@ -34,12 +53,10 @@ export function createSettingsAuditHandlers(deps = {}) {
         throw new Error(response.error);
       }
 
-      const hasClusters =
-        Array.isArray(response.clusters) && response.clusters.length > 0;
-      const hasPairs =
-        Array.isArray(response.pairs) && response.pairs.length > 0;
+      const clusters = parseDuplicateClusters(response);
+      const hasClusters = clusters.length > 0;
 
-      if (!hasClusters && !hasPairs) {
+      if (!hasClusters) {
         statusDiv.innerHTML = `
           <span class="text-green-400">
             <i class="fas fa-check-circle mr-2"></i>
@@ -48,23 +65,33 @@ export function createSettingsAuditHandlers(deps = {}) {
         `;
         showToast('No potential duplicates found', 'success');
       } else {
+        const duplicatePairCount = Number.isFinite(response.potentialDuplicates)
+          ? response.potentialDuplicates
+          : clusters.reduce((count, cluster) => {
+              return (
+                count +
+                (Array.isArray(cluster.pairs) ? cluster.pairs.length : 0)
+              );
+            }, 0);
+
         const clusterCount = Number.isFinite(response.totalClusters)
           ? response.totalClusters
-          : hasClusters
-            ? response.clusters.length
-            : 0;
+          : clusters.length;
 
         statusDiv.innerHTML = `
           <span class="text-yellow-400">
-            Found ${response.potentialDuplicates} potential duplicate pairs across ${clusterCount} clusters. Opening review...
+            Found ${duplicatePairCount} potential duplicate pairs across ${clusterCount} clusters. Opening review...
           </span>
         `;
 
-        const result = await openDuplicateReviewModal(response);
+        const result = await openDuplicateReviewModal({
+          ...response,
+          clusters,
+        });
 
         statusDiv.innerHTML = `
           <span class="text-gray-400">
-            Last scan: ${response.potentialDuplicates} pairs across ${clusterCount} clusters, ${result.resolved} resolved, ${result.remaining} remaining
+            Last scan: ${duplicatePairCount} pairs across ${clusterCount} clusters, ${result.resolved} resolved, ${result.remaining} remaining
           </span>
         `;
       }

--- a/test/settings-audit-handlers.test.js
+++ b/test/settings-audit-handlers.test.js
@@ -53,7 +53,6 @@ describe('settings audit handlers', () => {
       apiCall: async (url) => {
         apiCalls.push(url);
         return {
-          pairs: [],
           clusters: [],
           totalClusters: 0,
           totalAlbums: 10,
@@ -91,7 +90,6 @@ describe('settings audit handlers', () => {
         duplicateThreshold: threshold,
       }),
       apiCall: async () => ({
-        pairs: [{ id: 'p1' }],
         clusters: [{ clusterId: 'c1', members: [{}, {}] }],
         totalClusters: 1,
         potentialDuplicates: 1,
@@ -110,10 +108,51 @@ describe('settings audit handlers', () => {
     assert.strictEqual(modalCalls.length, 1);
     assert.strictEqual(modalCalls[0].potentialDuplicates, 1);
     assert.strictEqual(modalCalls[0].totalClusters, 1);
+    assert.deepStrictEqual(modalCalls[0].clusters, [
+      { clusterId: 'c1', members: [{}, {}] },
+    ]);
     assert.match(
       statusDiv.innerHTML,
       /Last scan: 1 pairs across 1 clusters, 1 resolved, 0 remaining/
     );
+  });
+
+  it('rejects legacy duplicate scan payloads without clusters', async () => {
+    const scanBtn = createElement();
+    const statusDiv = createElement();
+    const threshold = createElement({ value: '0.15' });
+    const toasts = [];
+    let modalCallCount = 0;
+
+    const { handleScanDuplicates } = createSettingsAuditHandlers({
+      doc: createDocument({
+        scanDuplicatesBtn: scanBtn,
+        duplicateScanStatus: statusDiv,
+        duplicateThreshold: threshold,
+      }),
+      apiCall: async () => ({
+        pairs: [{ id: 'legacy-pair' }],
+        potentialDuplicates: 1,
+        totalAlbums: 10,
+        excludedPairs: 0,
+      }),
+      showToast: (...args) => toasts.push(args),
+      openDuplicateReviewModal: async () => {
+        modalCallCount++;
+        return { resolved: 0, remaining: 0 };
+      },
+    });
+
+    await handleScanDuplicates();
+
+    assert.strictEqual(modalCallCount, 0);
+    assert.match(statusDiv.innerHTML, /Error:/);
+    assert.deepStrictEqual(toasts[0], [
+      'Error scanning for duplicates',
+      'error',
+    ]);
+    assert.strictEqual(scanBtn.disabled, false);
+    assert.strictEqual(scanBtn.textContent, 'Scan & Review');
   });
 
   it('runs manual album audit and opens modal when review data exists', async () => {


### PR DESCRIPTION
## Summary
- remove legacy pair-array adapters from the duplicate review modal normalization path
- require duplicate scan responses to include a `clusters` array (with `members`) before opening review UI
- add handler coverage that rejects legacy pair-only payloads and keeps status/toast behavior stable

## Testing
- node --test test/settings-audit-handlers.test.js
- node --test test/duplicate-service.test.js
- node --test test/admin-routes.test.js
- npm run lint:strict