### PR TITLE
Remove window.currentList compatibility bridge

### DIFF
--- a/src/js/modules/app-state.js
+++ b/src/js/modules/app-state.js
@@ -650,15 +650,6 @@ export function setAvailableCountries(countries) {
 // These are set up once by initWindowGlobals() called from app.js.
 
 export function initWindowGlobals() {
-  // Keep currentList as alias for modules still reading window.currentList.
-  Object.defineProperty(window, 'currentList', {
-    get: () => currentListId,
-    set: (val) => {
-      currentListId = val;
-    },
-    configurable: true,
-  });
-
   Object.defineProperty(window, 'currentListId', {
     get: () => currentListId,
     set: (val) => {

--- a/src/js/modules/settings-drawer.js
+++ b/src/js/modules/settings-drawer.js
@@ -32,6 +32,7 @@ import { createSettingsRecommenderManagerActions } from './settings-drawer/handl
 import { createSettingsCoreHandlers } from './settings-drawer/handlers/core-handlers.js';
 import { createSettingsAuditHandlers } from './settings-drawer/handlers/audit-handlers.js';
 import { createSettingsAdminHandlers } from './settings-drawer/handlers/admin-handlers.js';
+import { getCurrentListId } from './app-state.js';
 
 /**
  * Create settings drawer utilities with injected dependencies
@@ -339,7 +340,7 @@ export function createSettingsDrawer(deps = {}) {
     // Restore FAB and mobile now-playing bar visibility
     const fab = document.getElementById('addAlbumFAB');
     const nowPlaying = document.getElementById('mobileNowPlaying');
-    const currentList = window.currentList || null;
+    const currentList = getCurrentListId();
 
     if (fab) {
       // Only show FAB if there's a current list (matches mobile menu pattern)

--- a/src/js/modules/spotify-player.js
+++ b/src/js/modules/spotify-player.js
@@ -9,6 +9,7 @@ import { isAlbumMatchingPlayback } from './playback-utils.js';
 import { getDeviceIcon } from '../utils/device-icons.js';
 import { formatTime } from './time-utils.js';
 import { getTrackId, buildLastfmBody } from './spotify-lastfm-utils.js';
+import { getCurrentListId, getListData } from './app-state.js';
 
 // ============ MODULE STATE ============
 let currentPlayback = null;
@@ -65,14 +66,8 @@ function isCurrentTrackInCurrentList(playbackState) {
   }
 
   // No current list = not in list
-  const currentList = window.currentList;
+  const currentList = getCurrentListId();
   if (!currentList) {
-    return false;
-  }
-
-  // Get list data
-  const getListData = window.getListData;
-  if (!getListData) {
     return false;
   }
 

--- a/src/js/musicbrainz.js
+++ b/src/js/musicbrainz.js
@@ -9,6 +9,12 @@ import {
   hasNonLatinCharacters,
   formatArtistDisplayName,
 } from './modules/musicbrainz-artist-name.js';
+import {
+  getCurrentListId,
+  getListData,
+  setListData,
+  getListMetadata,
+} from './modules/app-state.js';
 
 const MUSICBRAINZ_PROXY = '/api/proxy/musicbrainz'; // Using our proxy
 const WIKIDATA_PROXY = '/api/proxy/wikidata'; // Using our proxy
@@ -1244,9 +1250,11 @@ function clearSearchResults() {
 
 // Unified open modal function
 window.openAddAlbumModal = function () {
+  const currentListId = getCurrentListId();
+
   console.log(
     'openAddAlbumModal called, currentList:',
-    window.currentList,
+    currentListId,
     'recommendations year:',
     window.currentRecommendationsYear,
     'modal:',
@@ -1254,7 +1262,7 @@ window.openAddAlbumModal = function () {
   );
 
   // Allow opening if we have a list OR if we're viewing recommendations
-  if (!window.currentList && !window.currentRecommendationsYear) {
+  if (!currentListId && !window.currentRecommendationsYear) {
     console.log('No list or recommendations selected, showing toast');
     showToast('Please select a list first', 'error');
     return;
@@ -1495,8 +1503,10 @@ async function handleManualSubmit(e) {
 }
 
 async function finishManualAdd(album) {
+  const currentListId = getCurrentListId();
+
   try {
-    const currentListData = window.getListData(window.currentList);
+    const currentListData = getListData(currentListId);
     if (!currentListData) {
       showToast('No list selected', 'error');
       return;
@@ -1514,13 +1524,17 @@ async function finishManualAdd(album) {
         `"${album.album}" is already in this list${label}`,
         usedExisting ? 'info' : 'error'
       );
-      if (usedExisting) window.selectList(window.currentList);
+      if (usedExisting && currentListId) window.selectList(currentListId);
       return;
     }
 
     // Add to current list
     currentListData.push(resolved);
-    window.setListData(window.currentList, currentListData);
+    if (!currentListId) {
+      showToast('No list selected', 'error');
+      return;
+    }
+    setListData(currentListId, currentListData);
 
     if (!Array.isArray(resolved.tracks) || resolved.tracks.length === 0) {
       try {
@@ -1530,15 +1544,15 @@ async function finishManualAdd(album) {
       }
     }
 
-    await window.saveList(window.currentList, currentListData);
+    await window.saveList(currentListId, currentListData);
 
     // Force refresh from server to get merged album data
-    const listMetadata = window.lists[window.currentList];
+    const listMetadata = getListMetadata(currentListId);
     if (listMetadata) {
       listMetadata._data = null;
     }
 
-    window.selectList(window.currentList);
+    window.selectList(currentListId);
     closeAddAlbumModal();
 
     const suffix = usedExisting ? ' (using existing album)' : ' to the list';
@@ -1546,10 +1560,12 @@ async function finishManualAdd(album) {
   } catch (_error) {
     showToast('Error adding album to list', 'error');
 
-    const currentListData = window.getListData(window.currentList);
+    const currentListData = getListData(currentListId);
     if (currentListData) {
       currentListData.pop();
-      window.setListData(window.currentList, currentListData);
+      if (currentListId) {
+        setListData(currentListId, currentListData);
+      }
     }
   }
 }
@@ -2086,8 +2102,10 @@ async function addAlbumToCurrentList(album) {
     return;
   }
 
+  const currentListId = getCurrentListId();
+
   try {
-    const currentListData = window.getListData(window.currentList);
+    const currentListData = getListData(currentListId);
     if (!currentListData) {
       showToast('No list selected', 'error');
       return;
@@ -2105,12 +2123,16 @@ async function addAlbumToCurrentList(album) {
         `"${album.album}" is already in this list${label}`,
         usedExisting ? 'info' : 'error'
       );
-      if (usedExisting) window.selectList(window.currentList);
+      if (usedExisting && currentListId) window.selectList(currentListId);
       return;
     }
 
     currentListData.push(resolved);
-    window.setListData(window.currentList, currentListData);
+    if (!currentListId) {
+      showToast('No list selected', 'error');
+      return;
+    }
+    setListData(currentListId, currentListData);
 
     if (!Array.isArray(resolved.tracks) || resolved.tracks.length === 0) {
       try {
@@ -2120,25 +2142,27 @@ async function addAlbumToCurrentList(album) {
       }
     }
 
-    await window.saveList(window.currentList, currentListData);
+    await window.saveList(currentListId, currentListData);
 
     // Force refresh from server to get merged album data
-    const listMetadata = window.lists[window.currentList];
+    const listMetadata = getListMetadata(currentListId);
     if (listMetadata) {
       listMetadata._data = null;
     }
 
-    window.selectList(window.currentList);
+    window.selectList(currentListId);
     closeAddAlbumModal();
 
     showToast(`Added "${resolved.album}" by ${resolved.artist} to the list`);
   } catch (_error) {
     showToast('Error adding album to list', 'error');
 
-    const currentListData = window.getListData(window.currentList);
+    const currentListData = getListData(currentListId);
     if (currentListData) {
       currentListData.pop();
-      window.setListData(window.currentList, currentListData);
+      if (currentListId) {
+        setListData(currentListId, currentListData);
+      }
     }
   }
 }

--- a/test/app-state.test.js
+++ b/test/app-state.test.js
@@ -727,17 +727,10 @@ describe('app-state', async () => {
   // ============ WINDOW GLOBALS ============
 
   describe('initWindowGlobals', () => {
-    it('creates window.currentList as alias for currentListId', () => {
+    it('does not expose legacy window.currentList alias', () => {
       mod.initWindowGlobals();
       mod.setCurrentListId('test-id');
-      assert.strictEqual(window.currentList, 'test-id');
-    });
-
-    it('window.currentList setter updates currentListId', () => {
-      mod.initWindowGlobals();
-      window.currentList = 'from-window';
-      assert.strictEqual(mod.getCurrentListId(), 'from-window');
-      mod.setCurrentListId(''); // cleanup
+      assert.strictEqual(window.currentList, undefined);
     });
 
     it('window.currentListId getter reflects state', () => {


### PR DESCRIPTION
## Summary
- remove the `window.currentList` alias from app-state window globals
- migrate direct readers in musicbrainz, spotify-player, and settings drawer to `app-state` accessors
- update app-state coverage to assert `window.currentList` is no longer exposed

## Testing
- node --test test/app-state.test.js
- node --test test/app-startup-ui.test.js
- node --test test/spotify-lastfm-utils.test.js
- node --test test/musicbrainz.test.js
- npm run lint:strict