### PR TITLE
Mark PR4 complete in legacy backlog

### DIFF
--- a/legacy_backlog.md
+++ b/legacy_backlog.md
@@ -161,7 +161,7 @@ Low to medium.
 - Simpler duplicate UI state.
 - Better alignment with recent cluster-merge work.
 
-## PR 4: Remove `window.currentList` Compat Bridge
+## PR 4: Remove `window.currentList` Compat Bridge ✅ Completed (PR #343)
 
 ### Goal
 


### PR DESCRIPTION
## Summary
- mark PR4 as completed in `legacy_backlog.md`
- link completion status to merged PR #343