### PR TITLE
Remove window.lists compatibility bridge

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -636,8 +636,6 @@ async function refreshGroupsAndLists() {
         };
       }
     });
-    window.lists = currentLists;
-
     // Re-render the sidebar navigation
     updateListNav();
   } catch (err) {
@@ -1261,8 +1259,6 @@ async function importList(name, albums, metadata = null) {
       updatedAt: new Date().toISOString(),
       createdAt: new Date().toISOString(),
     };
-    window.lists = getLists();
-
     // Build a map from album_id to list_item_id for track picks
     const albumToListItemMap = new Map();
     for (const item of savedList) {

--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -805,7 +805,7 @@ export function createAlbumDisplay(deps = {}) {
       const recommendOption = document.getElementById('recommendAlbumOption');
       if (recommendOption) {
         const currentListId = getCurrentList();
-        const listMeta = window.lists && window.lists[currentListId];
+        const listMeta = getListMetadata(currentListId);
         const isYearBased =
           listMeta && listMeta.year !== null && listMeta.year !== undefined;
         const isViewingRecommendations =

--- a/src/js/modules/app-state.js
+++ b/src/js/modules/app-state.js
@@ -125,7 +125,6 @@ export function getLists() {
  */
 export function setLists(newLists) {
   lists = normalizeListsMap(newLists);
-  window.lists = lists;
 }
 
 /**

--- a/test/app-state.test.js
+++ b/test/app-state.test.js
@@ -60,11 +60,10 @@ describe('app-state', async () => {
       assert.deepStrictEqual(mod.getLists(), newLists);
     });
 
-    it('setLists syncs to window.lists', () => {
+    it('setLists does not expose window.lists compatibility bridge', () => {
       const newLists = { id1: { _id: 'id1', name: 'Test' } };
       mod.setLists(newLists);
-      assert.deepStrictEqual(window.lists, newLists);
-      assert.strictEqual(window.lists, mod.getLists());
+      assert.strictEqual(window.lists, undefined);
     });
 
     it('setLists preserves canonical album fields inside _data arrays', () => {


### PR DESCRIPTION
## Summary
- stop mirroring list state to `window.lists` in app-state and app orchestration flows
- switch album-display duplicate recommendation visibility check to `getListMetadata`
- update app-state coverage to enforce that `window.lists` is no longer exposed

## Testing
- node --test test/app-state.test.js
- node --test test/album-display.test.js
- node --test test/musicbrainz.test.js
- npm run lint:strict