### PR TITLE
Mark PR5 complete in legacy backlog

### DIFF
--- a/legacy_backlog.md
+++ b/legacy_backlog.md
@@ -204,7 +204,7 @@ High.
 - Major legacy bridge reduction.
 - Better testability for dependent modules.
 
-## PR 5: Remove `window.lists` Compat Bridge
+## PR 5: Remove `window.lists` Compat Bridge ✅ Completed (PR #345)
 
 ### Goal
 


### PR DESCRIPTION
## Summary
- mark PR5 as completed in `legacy_backlog.md`
- link completion status to merged PR #345