### PR TITLE
Refactor legacy window bridges and unify list menu behavior

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -68,7 +68,6 @@ import {
   getListMetadata,
   updateListMetadata,
   findListByName,
-  getCurrentListName,
   isListDataLoaded,
   getGroups,
   getGroup,
@@ -252,7 +251,7 @@ function getTrackName(track) {
 function getTrackLength(track) {
   return getTrackSelectionModule().getTrackLength(track);
 }
-function fetchTracksForAlbum(album, signal) {
+export function fetchTracksForAlbum(album, signal) {
   return getTrackSelectionModule().fetchTracksForAlbum(album, signal);
 }
 function showTrackSelectionMenu(album, albumIndex, x, y) {
@@ -314,9 +313,6 @@ const getPlaybackModule = createLazyModule(() =>
 // Wrapper functions for playback module
 function playAlbum(index) {
   return getPlaybackModule().playAlbum(index);
-}
-function playTrack(index) {
-  return getPlaybackModule().playTrack(index);
 }
 function playSpecificTrack(index, trackName) {
   return getPlaybackModule().playSpecificTrack(index, trackName);
@@ -390,12 +386,13 @@ const getAlbumDisplayModule = createLazyModule(() =>
       getLinkPreviewModule().attachLinkPreview(...args),
     showTrackSelectionMenu,
     showMobileEditForm,
-    showMobileAlbumMenu: (el) => window.showMobileAlbumMenu(el),
-    showMobileSummarySheet: (summary, albumName, artist) =>
-      window.showMobileSummarySheet(summary, albumName, artist),
+    showMobileAlbumMenu,
+    showMobileSummarySheet,
     playAlbumByMetadata: (artist, album, options) =>
       getPlaybackModule().playAlbumByMetadata(artist, album, options),
-    playTrackSafe: (albumId) => window.playTrackSafe(albumId),
+    playTrackSafe: (albumId) => getPlaybackModule().playTrackSafe(albumId),
+    playSpecificTrack,
+    isViewingRecommendations,
     getTrackName,
     getTrackLength,
     formatTrackTime,
@@ -438,12 +435,10 @@ const getContextMenusModule = createLazyModule(() =>
     getListMetadata,
     getCurrentList: () => getCurrentListId(),
     getLists,
-    saveList,
     selectList,
     showToast,
     showConfirmation,
     apiCall,
-    findAlbumByIdentity,
     downloadListAsJSON,
     downloadListAsPDF,
     downloadListAsCSV,
@@ -451,14 +446,7 @@ const getContextMenusModule = createLazyModule(() =>
     openRenameModal,
     updateListNav,
     updateListMetadata,
-    showMobileEditForm,
-    playAlbum,
-    playAlbumSafe: (albumId) => window.playAlbumSafe(albumId),
-    loadLists,
-    getContextAlbum: () => getContextAlbumState(),
-    setContextAlbum: (index, albumId) => {
-      setContextAlbumState(index, albumId);
-    },
+    clearSnapshotFromStorage,
     getContextList: () => getContextListState(),
     setContextList: (listId) => {
       setContextListState(listId);
@@ -471,6 +459,7 @@ const getContextMenusModule = createLazyModule(() =>
         window.refreshMobileBarVisibility();
       }
     },
+    getCurrentUser: () => window.currentUser || {},
     toggleMainStatus,
     getSortedGroups,
     refreshGroupsAndLists,
@@ -478,10 +467,6 @@ const getContextMenusModule = createLazyModule(() =>
 );
 
 // Wrapper functions for context menus module
-function getListMenuConfig(listName) {
-  return getContextMenusModule().getListMenuConfig(listName);
-}
-
 function getDeviceIcon(type) {
   return getContextMenusModule().getDeviceIcon(type);
 }
@@ -521,7 +506,6 @@ const getMobileUIModule = createLazyModule(() =>
     updatePlaylist,
     toggleMainStatus,
     getDeviceIcon,
-    getListMenuConfig,
     getAvailableCountries,
     getAvailableGenres,
     setCurrentContextAlbum: (idx) => {
@@ -543,16 +527,14 @@ const getMobileUIModule = createLazyModule(() =>
     isViewingRecommendations,
     recommendAlbum: (...args) =>
       getRecommendationsModule().recommendAlbum(...args),
+    openRenameCategoryModal,
+    getCurrentUser: () => window.currentUser || {},
   })
 );
 
 // Wrapper functions for mobile UI module
 function showMobileAlbumMenu(indexOrElement) {
   return getMobileUIModule().showMobileAlbumMenu(indexOrElement);
-}
-
-function showMobileMoveToListSheet(index, albumId) {
-  return getMobileUIModule().showMobileMoveToListSheet(index, albumId);
 }
 
 function showMobileListMenu(listName) {
@@ -581,10 +563,6 @@ function showMobileEditFormSafe(albumId) {
 
 function playAlbumSafe(albumId) {
   return getMobileUIModule().playAlbumSafe(albumId);
-}
-
-function removeAlbumSafe(albumId) {
-  return getMobileUIModule().removeAlbumSafe(albumId);
 }
 
 function findAlbumByIdentity(albumId) {
@@ -651,7 +629,6 @@ const getListNavModule = createLazyModule(() =>
     getSortedGroups,
     getCurrentList: () => getCurrentListId(),
     selectList,
-    getListMenuConfig,
     hideAllContextMenus,
     positionContextMenu,
     toggleMobileLists,
@@ -665,6 +642,11 @@ const getListNavModule = createLazyModule(() =>
     showToast,
     refreshGroupsAndLists,
     yearHasRecommendations,
+    getCurrentUser: () => window.currentUser || {},
+    showMobileListMenu,
+    showMobileCategoryMenu,
+    selectRecommendations,
+    getCurrentRecommendationsYear,
   })
 );
 
@@ -1350,7 +1332,7 @@ async function importList(name, albums, metadata = null) {
 // @param {string} listId - List ID
 // @param {Array} data - Album array
 // @param {number|null} year - Optional year for the list (required for new lists)
-async function saveList(listId, data, year = undefined) {
+export async function saveList(listId, data, year = undefined) {
   try {
     const cleanedData = data.map((album) => {
       const cleaned = { ...album };
@@ -1455,14 +1437,13 @@ const getListSelectionModule = createLazyModule(() =>
   })
 );
 
-async function selectList(listId) {
+export async function selectList(listId) {
   return getListSelectionModule().selectList(listId);
 }
 
 // ============ RECOMMENDATIONS MODULE BRIDGE ============
-// Thin wrapper for backward compatibility (called via window.selectRecommendations)
 
-function selectRecommendations(year) {
+export function selectRecommendations(year) {
   // Clear any stale lock indicator from a previously viewed locked main list
   clearYearLockUI();
   return getRecommendationsModule().selectRecommendations(year);
@@ -1482,49 +1463,10 @@ const { refreshLockedYearStatus } = createYearLockStatusRefresh({
 const debouncedSaveList = createDebouncedSave({ saveList, showToast });
 
 registerAppWindowGlobals({
-  apiCall,
-  showToast,
-  showReasoningModal,
-  getListData,
-  setListData,
-  getListMetadata,
-  updateListMetadata,
-  isListDataLoaded,
-  saveList,
-  loadLists,
   selectList,
   updateListNav,
   collapseGroupsForActiveList,
-  updatePlaylist,
-  toggleMainStatus,
   displayAlbums,
-  getGroup,
-  updateGroupsFromServer,
-  getCurrentListName,
-  findListByName,
-  isViewingRecommendations,
-  getCurrentRecommendationsYear,
-  selectRecommendations,
-  clearSnapshotFromStorage,
-  showMobileAlbumMenu,
-  showMobileMoveToListSheet,
-  showMobileListMenu,
-  showMobileCategoryMenu,
-  showMobileEditForm,
-  showMobileEditFormSafe,
-  showMobileSummarySheet,
-  openRenameCategoryModal,
-  playAlbum,
-  playTrack,
-  getPlaybackModule,
-  playSpecificTrack,
-  playAlbumSafe,
-  removeAlbumSafe,
-  fetchTracksForAlbum,
-  getTrackName,
-  getTrackLength,
-  formatTrackTime,
-  refreshLockedYearStatus,
 });
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -1551,7 +1493,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const settingsDrawer = createSettingsDrawer({
       showToast,
       showConfirmation,
-      apiCall: window.apiCall,
+      apiCall,
+      refreshLockedYearStatus,
     });
 
     settingsDrawer.initialize();
@@ -1620,7 +1563,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // Check if user needs to complete list setup (year + main list designation)
       // Delay slightly to let the main UI render first
       setTimeout(() => {
-        checkListSetupStatus().catch((err) => {
+        checkListSetupStatus({ refreshLists: loadLists }).catch((err) => {
           console.warn('Failed to check list setup status:', err);
         });
       }, 1000);

--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -93,6 +93,8 @@ const pollingControllers = new Map(); // listId -> AbortController
  * @param {Function} deps.showMobileSummarySheet - Show mobile summary sheet
  * @param {Function} deps.playAlbumByMetadata - Play album by artist/album metadata
  * @param {Function} deps.playTrackSafe - Play track safely by album ID
+ * @param {Function} deps.playSpecificTrack - Play a specific track by index + identifier
+ * @param {Function} deps.isViewingRecommendations - Check if recommendations view is active
  * @param {Function} deps.reapplyNowPlayingBorder - Re-apply now playing border
  * @param {Function} deps.initializeUnifiedSorting - Initialize drag-drop sorting
  * @param {Function} deps.destroySorting - Destroy drag-drop sorting instance
@@ -119,6 +121,8 @@ export function createAlbumDisplay(deps = {}) {
     showMobileSummarySheet,
     playAlbumByMetadata,
     playTrackSafe,
+    playSpecificTrack,
+    isViewingRecommendations,
     reapplyNowPlayingBorder,
     initializeUnifiedSorting,
     destroySorting,
@@ -808,11 +812,13 @@ export function createAlbumDisplay(deps = {}) {
         const listMeta = getListMetadata(currentListId);
         const isYearBased =
           listMeta && listMeta.year !== null && listMeta.year !== undefined;
-        const isViewingRecommendations =
-          window.isViewingRecommendations && window.isViewingRecommendations();
+        const viewingRecommendations =
+          typeof isViewingRecommendations === 'function'
+            ? isViewingRecommendations()
+            : false;
 
         // Show recommend option only for year-based lists (not when viewing recommendations)
-        const showRecommend = isYearBased && !isViewingRecommendations;
+        const showRecommend = isYearBased && !viewingRecommendations;
         recommendOption.classList.toggle('hidden', !showRecommend);
       }
 
@@ -1230,9 +1236,9 @@ export function createAlbumDisplay(deps = {}) {
         e.stopPropagation();
         e.preventDefault();
         const trackIdentifier = trackPlayBtn.dataset.trackIdentifier;
-        if (trackIdentifier && window.playSpecificTrack) {
+        if (trackIdentifier && typeof playSpecificTrack === 'function') {
           // Play the specific track using its identifier
-          window.playSpecificTrack(index, trackIdentifier);
+          playSpecificTrack(index, trackIdentifier);
         } else {
           // Fallback to album's default track
           const albumsForTrackPlay = getListData(getCurrentList());

--- a/src/js/modules/app-window-globals.js
+++ b/src/js/modules/app-window-globals.js
@@ -7,101 +7,14 @@ export function registerAppWindowGlobals(deps = {}) {
   if (!win) return;
 
   const {
-    apiCall,
-    showToast,
-    showReasoningModal,
-    getListData,
-    setListData,
-    getListMetadata,
-    updateListMetadata,
-    isListDataLoaded,
-    saveList,
-    loadLists,
     selectList,
     updateListNav,
     collapseGroupsForActiveList,
-    updatePlaylist,
-    toggleMainStatus,
     displayAlbums,
-    getGroup,
-    updateGroupsFromServer,
-    getCurrentListName,
-    findListByName,
-    isViewingRecommendations,
-    getCurrentRecommendationsYear,
-    selectRecommendations,
-    clearSnapshotFromStorage,
-    showMobileAlbumMenu,
-    showMobileMoveToListSheet,
-    showMobileListMenu,
-    showMobileCategoryMenu,
-    showMobileEditForm,
-    showMobileEditFormSafe,
-    showMobileSummarySheet,
-    openRenameCategoryModal,
-    playAlbum,
-    playTrack,
-    getPlaybackModule,
-    playSpecificTrack,
-    playAlbumSafe,
-    removeAlbumSafe,
-    fetchTracksForAlbum,
-    getTrackName,
-    getTrackLength,
-    formatTrackTime,
-    refreshLockedYearStatus,
   } = deps;
 
-  win.apiCall = apiCall;
-  win.showToast = showToast;
-  win.showReasoningModal = showReasoningModal;
-
-  win.getListData = getListData;
-  win.setListData = setListData;
-  win.getListMetadata = getListMetadata;
-  win.updateListMetadata = updateListMetadata;
-  win.isListDataLoaded = isListDataLoaded;
-
-  win.saveList = saveList;
-  win.loadLists = loadLists;
   win.selectList = selectList;
   win.updateListNav = updateListNav;
   win.collapseGroupsForActiveList = collapseGroupsForActiveList;
-  win.updatePlaylist = updatePlaylist;
-  win.toggleMainStatus = toggleMainStatus;
   win.displayAlbums = displayAlbums;
-
-  win.getGroup = getGroup;
-  win.updateGroupsFromServer = updateGroupsFromServer;
-
-  win.getCurrentListName = getCurrentListName;
-  win.findListByName = findListByName;
-  win.isViewingRecommendations = isViewingRecommendations;
-  win.getCurrentRecommendationsYear = getCurrentRecommendationsYear;
-  win.selectRecommendations = selectRecommendations;
-  win.clearSnapshotFromStorage = clearSnapshotFromStorage;
-
-  win.showMobileAlbumMenu = showMobileAlbumMenu;
-  win.showMobileMoveToListSheet = showMobileMoveToListSheet;
-  win.showMobileListMenu = showMobileListMenu;
-  win.showMobileCategoryMenu = showMobileCategoryMenu;
-  win.showMobileEditForm = showMobileEditForm;
-  win.showMobileEditFormSafe = showMobileEditFormSafe;
-  win.showMobileSummarySheet = showMobileSummarySheet;
-  win.openRenameCategoryModal = openRenameCategoryModal;
-
-  win.playAlbum = playAlbum;
-  win.playTrack = playTrack;
-  win.playTrackSafe = function (albumId) {
-    return getPlaybackModule().playTrackSafe(albumId);
-  };
-  win.playSpecificTrack = playSpecificTrack;
-  win.playAlbumSafe = playAlbumSafe;
-  win.removeAlbumSafe = removeAlbumSafe;
-
-  win.fetchTracksForAlbum = fetchTracksForAlbum;
-  win.getTrackName = getTrackName;
-  win.getTrackLength = getTrackLength;
-  win.formatTrackTime = formatTrackTime;
-  win.refreshLockedYearStatus = refreshLockedYearStatus;
 }

--- a/src/js/modules/context-menus.js
+++ b/src/js/modules/context-menus.js
@@ -7,12 +7,15 @@
  * @module context-menus
  */
 
-import { createTransferHelpers } from './album-transfer.js';
 import {
   positionContextMenu,
   hideAllContextMenus as hideAllMenusBase,
 } from './context-menu.js';
 import { getDeviceIcon } from '../utils/device-icons.js';
+import {
+  buildListMenuConfig,
+  createListMenuActions,
+} from './list-menu-shared.js';
 
 /**
  * Factory function to create the context menus module with injected dependencies
@@ -22,31 +25,24 @@ import { getDeviceIcon } from '../utils/device-icons.js';
  * @param {Function} deps.getListMetadata - Get metadata for a list
  * @param {Function} deps.getCurrentList - Get current list name
  * @param {Function} deps.getLists - Get all lists
- * @param {Function} deps.saveList - Save list to server
  * @param {Function} deps.selectList - Select a list
  * @param {Function} deps.showToast - Show toast notification
  * @param {Function} deps.showConfirmation - Show confirmation dialog
  * @param {Function} deps.apiCall - Make API call
- * @param {Function} deps.findAlbumByIdentity - Find album by identity string
  * @param {Function} deps.downloadListAsJSON - Download list as JSON
  * @param {Function} deps.downloadListAsPDF - Download list as PDF
  * @param {Function} deps.downloadListAsCSV - Download list as CSV
  * @param {Function} deps.updatePlaylist - Update playlist on music service
  * @param {Function} deps.openRenameModal - Open rename modal
  * @param {Function} deps.updateListNav - Update list navigation
- * @param {Function} deps.updateListMetadata - Update list metadata
- * @param {Function} deps.showMobileEditForm - Show mobile edit form
- * @param {Function} deps.playAlbum - Play album
- * @param {Function} deps.playAlbumSafe - Play album safely by ID
- * @param {Function} deps.loadLists - Reload lists
- * @param {Function} deps.getContextAlbum - Get context menu album state
- * @param {Function} deps.setContextAlbum - Set context menu album state
  * @param {Function} deps.getContextList - Get context menu list state
  * @param {Function} deps.setContextList - Set context menu list state
  * @param {Function} deps.setCurrentList - Set current list (for delete)
  * @param {Function} deps.refreshMobileBarVisibility - Refresh mobile bar visibility
  * @param {Function} deps.getSortedGroups - Get groups sorted by sort_order
  * @param {Function} deps.refreshGroupsAndLists - Refresh groups and lists after changes
+ * @param {Function} deps.clearSnapshotFromStorage - Clear local list snapshot cache
+ * @param {Function} deps.getCurrentUser - Get authenticated frontend user
  * @returns {Object} Context menus module API
  */
 export function createContextMenus(deps = {}) {
@@ -55,25 +51,16 @@ export function createContextMenus(deps = {}) {
     getListMetadata,
     getCurrentList,
     getLists,
-    saveList,
     selectList,
     showToast,
     showConfirmation,
     apiCall,
-    findAlbumByIdentity,
     downloadListAsJSON,
     downloadListAsPDF,
     downloadListAsCSV,
     updatePlaylist,
     openRenameModal,
     updateListNav,
-    updateListMetadata: _updateListMetadata,
-    showMobileEditForm: _showMobileEditForm,
-    playAlbum: _playAlbum,
-    playAlbumSafe: _playAlbumSafe,
-    loadLists: _loadLists,
-    getContextAlbum = () => ({ index: null, albumId: null }),
-    setContextAlbum,
     getContextList,
     setContextList,
     setCurrentList,
@@ -81,28 +68,27 @@ export function createContextMenus(deps = {}) {
     getSortedGroups,
     refreshGroupsAndLists,
     toggleMainStatus,
+    clearSnapshotFromStorage,
+    getCurrentUser = () => window.currentUser || {},
   } = deps;
 
-  // Track loading performance optimization
-  let trackAbortController = null;
-
-  function getContextAlbumId() {
-    return getContextAlbum().albumId || null;
-  }
+  const listMenuActions = createListMenuActions({
+    getListData,
+    updatePlaylist,
+    downloadListAsJSON,
+    downloadListAsPDF,
+    downloadListAsCSV,
+    openRenameModal,
+    toggleMainStatus,
+    logger: console,
+  });
 
   /**
    * Hide all context menus and perform module-specific cleanup.
-   * Delegates to shared hideAllMenusBase() then clears local state.
+   * Delegates to shared hideAllMenusBase().
    */
   function hideAllContextMenus() {
     hideAllMenusBase();
-
-    // Module-specific cleanup: clear context state and cancel track fetches
-    setContextAlbum(null, null);
-    if (trackAbortController) {
-      trackAbortController.abort();
-      trackAbortController = null;
-    }
 
     // Only show FAB when a list is actually selected
     const currentList = getCurrentList();
@@ -120,210 +106,11 @@ export function createContextMenus(deps = {}) {
    * @returns {Object} Menu configuration
    */
   function getListMenuConfig(listName) {
-    const meta = getListMetadata(listName);
-    const hasSpotify = window.currentUser?.spotifyAuth;
-    const hasTidal = window.currentUser?.tidalAuth;
-    const musicService = window.currentUser?.musicService;
-
-    let musicServiceText = 'Send to Music Service';
-    if (musicService === 'spotify' && hasSpotify) {
-      musicServiceText = 'Send to Spotify';
-    } else if (musicService === 'tidal' && hasTidal) {
-      musicServiceText = 'Send to Tidal';
-    } else if (hasSpotify && !hasTidal) {
-      musicServiceText = 'Send to Spotify';
-    } else if (hasTidal && !hasSpotify) {
-      musicServiceText = 'Send to Tidal';
-    }
-
-    // Determine if list is in a collection (not a year-group)
-    // Lists in collections (or orphaned/uncategorized) can be moved to other collections
-    // Lists in year-groups cannot be moved via this menu (they're organized by year)
-    const groupId = meta?.groupId;
-    let isInCollection = false;
-    let isInYearGroup = false;
-
-    if (!groupId) {
-      // Orphaned/uncategorized lists can be moved
-      isInCollection = true;
-    } else if (getSortedGroups) {
-      // Check if the group is a collection (not a year-group)
-      const groups = getSortedGroups();
-      const group = groups.find((g) => g._id === groupId);
-      if (group) {
-        isInCollection = !group.isYearGroup;
-        isInYearGroup = group.isYearGroup;
-      }
-    }
-
-    // A list can have main status only if it's in a year-group or has a year directly
-    // Lists in collections cannot have main status
-    const hasYear = !!meta?.year || isInYearGroup;
-
-    return {
-      hasYear,
-      isMain: !!meta?.isMain,
-      mainToggleText: meta?.isMain ? 'Remove Main Status' : 'Set as Main',
-      mainIconClass: meta?.isMain ? 'fa-star' : 'fa-star',
-      musicServiceText,
-      hasSpotify,
-      hasTidal,
-      isInCollection,
-    };
-  }
-
-  /**
-   * Show move to list submenu for desktop
-   */
-  function showMoveToListSubmenu() {
-    const currentList = getCurrentList();
-    const lists = getLists();
-    const albumId = getContextAlbumId();
-
-    const submenu = document.getElementById('albumMoveSubmenu');
-    const moveOption = document.getElementById('moveAlbumOption');
-    const playSubmenu = document.getElementById('playAlbumSubmenu');
-    const playOption = document.getElementById('playAlbumOption');
-    const copySubmenu = document.getElementById('albumCopySubmenu');
-    const copyOption = document.getElementById('copyAlbumOption');
-
-    if (!submenu || !moveOption) return;
-
-    // Hide the other submenus first
-    if (playSubmenu) {
-      playSubmenu.classList.add('hidden');
-      playOption?.classList.remove('bg-gray-700', 'text-white');
-    }
-    if (copySubmenu) {
-      copySubmenu.classList.add('hidden');
-      copyOption?.classList.remove('bg-gray-700', 'text-white');
-    }
-
-    // Highlight the parent menu item
-    moveOption.classList.add('bg-gray-700', 'text-white');
-
-    // Get all list IDs except the current one
-    const listIds = Object.keys(lists).filter((id) => id !== currentList);
-
-    if (listIds.length === 0) {
-      submenu.innerHTML =
-        '<div class="px-4 py-2 text-sm text-gray-500">No other lists available</div>';
-    } else {
-      submenu.innerHTML = listIds
-        .map((listId) => {
-          const meta = getListMetadata(listId);
-          const listName = meta?.name || 'Unknown';
-          return `
-          <button class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap w-full" data-target-list="${listId}">
-            <span class="mr-2">•</span>${listName}
-          </button>
-        `;
-        })
-        .join('');
-
-      // Add click handlers to each list option
-      submenu.querySelectorAll('[data-target-list]').forEach((btn) => {
-        btn.addEventListener('click', (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const targetListId = btn.dataset.targetList;
-
-          // Hide both menus and remove highlight
-          document.getElementById('albumContextMenu')?.classList.add('hidden');
-          submenu.classList.add('hidden');
-          moveOption?.classList.remove('bg-gray-700', 'text-white');
-
-          // Show confirmation modal
-          showMoveConfirmation(albumId, targetListId);
-        });
-      });
-    }
-
-    // Position submenu next to the move option
-    const moveRect = moveOption.getBoundingClientRect();
-    const contextMenu = document.getElementById('albumContextMenu');
-    const menuRect = contextMenu.getBoundingClientRect();
-
-    submenu.style.left = `${menuRect.right}px`;
-    submenu.style.top = `${moveRect.top}px`;
-    submenu.classList.remove('hidden');
-  }
-
-  /**
-   * Show copy to list submenu for desktop
-   */
-  function showCopyToListSubmenu() {
-    const currentList = getCurrentList();
-    const lists = getLists();
-    const albumId = getContextAlbumId();
-
-    const submenu = document.getElementById('albumCopySubmenu');
-    const copyOption = document.getElementById('copyAlbumOption');
-    const playSubmenu = document.getElementById('playAlbumSubmenu');
-    const playOption = document.getElementById('playAlbumOption');
-    const moveSubmenu = document.getElementById('albumMoveSubmenu');
-    const moveOption = document.getElementById('moveAlbumOption');
-
-    if (!submenu || !copyOption) return;
-
-    // Hide other submenus first
-    if (playSubmenu) {
-      playSubmenu.classList.add('hidden');
-      playOption?.classList.remove('bg-gray-700', 'text-white');
-    }
-    if (moveSubmenu) {
-      moveSubmenu.classList.add('hidden');
-      moveOption?.classList.remove('bg-gray-700', 'text-white');
-    }
-
-    // Highlight the parent menu item
-    copyOption.classList.add('bg-gray-700', 'text-white');
-
-    // Get all list IDs except the current one
-    const listIds = Object.keys(lists).filter((id) => id !== currentList);
-
-    if (listIds.length === 0) {
-      submenu.innerHTML =
-        '<div class="px-4 py-2 text-sm text-gray-500">No other lists available</div>';
-    } else {
-      submenu.innerHTML = listIds
-        .map((listId) => {
-          const meta = getListMetadata(listId);
-          const listName = meta?.name || 'Unknown';
-          return `
-          <button class="block text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors whitespace-nowrap w-full" data-target-list="${listId}">
-            <span class="mr-2">&bull;</span>${listName}
-          </button>
-        `;
-        })
-        .join('');
-
-      // Add click handlers to each list option
-      submenu.querySelectorAll('[data-target-list]').forEach((btn) => {
-        btn.addEventListener('click', (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const targetListId = btn.dataset.targetList;
-
-          // Hide both menus and remove highlight
-          document.getElementById('albumContextMenu')?.classList.add('hidden');
-          submenu.classList.add('hidden');
-          copyOption?.classList.remove('bg-gray-700', 'text-white');
-
-          // Show confirmation modal
-          showCopyConfirmation(albumId, targetListId);
-        });
-      });
-    }
-
-    // Position submenu next to the copy option
-    const copyRect = copyOption.getBoundingClientRect();
-    const contextMenu = document.getElementById('albumContextMenu');
-    const menuRect = contextMenu.getBoundingClientRect();
-
-    submenu.style.left = `${menuRect.right}px`;
-    submenu.style.top = `${copyRect.top}px`;
-    submenu.classList.remove('hidden');
+    return buildListMenuConfig({
+      listMeta: getListMetadata(listName),
+      groups: getSortedGroups ? getSortedGroups() : [],
+      currentUser: getCurrentUser(),
+    });
   }
 
   /**
@@ -364,8 +151,7 @@ export function createContextMenus(deps = {}) {
         submenu.classList.add('hidden');
         downloadOption.classList.remove('bg-gray-700', 'text-white');
 
-        // Download the list
-        downloadListAsJSON(currentContextList);
+        listMenuActions.downloadList(currentContextList, 'json');
         setContextList(null);
       });
     }
@@ -382,8 +168,7 @@ export function createContextMenus(deps = {}) {
         submenu.classList.add('hidden');
         downloadOption.classList.remove('bg-gray-700', 'text-white');
 
-        // Download the list
-        downloadListAsPDF(currentContextList);
+        listMenuActions.downloadList(currentContextList, 'pdf');
         setContextList(null);
       });
     }
@@ -400,8 +185,7 @@ export function createContextMenus(deps = {}) {
         submenu.classList.add('hidden');
         downloadOption.classList.remove('bg-gray-700', 'text-white');
 
-        // Download the list
-        downloadListAsCSV(currentContextList);
+        listMenuActions.downloadList(currentContextList, 'csv');
         setContextList(null);
       });
     }
@@ -414,105 +198,6 @@ export function createContextMenus(deps = {}) {
     submenu.style.left = `${menuRect.right}px`;
     submenu.style.top = `${downloadRect.top}px`;
     submenu.classList.remove('hidden');
-  }
-
-  // Create transfer helpers (move/copy with confirmation dialogs)
-  const {
-    moveAlbumToList,
-    copyAlbumToList,
-    showMoveConfirmation,
-    showCopyConfirmation,
-  } = createTransferHelpers(
-    {
-      getCurrentList,
-      getLists,
-      getListData,
-      getListMetadata,
-      saveList,
-      selectList,
-      showToast,
-      apiCall,
-      findAlbumByIdentity,
-    },
-    {
-      showConfirmation,
-      showToast,
-      findAlbumByIdentity,
-      getCurrentList,
-      getListMetadata,
-    }
-  );
-
-  /**
-   * Hide submenus when mouse leaves the context menu area
-   */
-  function setupSubmenuHideOnLeave() {
-    const contextMenu = document.getElementById('albumContextMenu');
-    const moveSubmenu = document.getElementById('albumMoveSubmenu');
-    const copySubmenu = document.getElementById('albumCopySubmenu');
-    const playSubmenu = document.getElementById('playAlbumSubmenu');
-    const moveOption = document.getElementById('moveAlbumOption');
-    const copyOption = document.getElementById('copyAlbumOption');
-    const playOption = document.getElementById('playAlbumOption');
-
-    if (!contextMenu) return;
-
-    let submenuTimeout;
-
-    const hideSubmenus = () => {
-      submenuTimeout = setTimeout(() => {
-        if (moveSubmenu) {
-          moveSubmenu.classList.add('hidden');
-          moveOption?.classList.remove('bg-gray-700', 'text-white');
-        }
-        if (copySubmenu) {
-          copySubmenu.classList.add('hidden');
-          copyOption?.classList.remove('bg-gray-700', 'text-white');
-        }
-        if (playSubmenu) {
-          playSubmenu.classList.add('hidden');
-          playOption?.classList.remove('bg-gray-700', 'text-white');
-        }
-      }, 200);
-    };
-
-    const cancelHide = () => {
-      if (submenuTimeout) clearTimeout(submenuTimeout);
-    };
-
-    contextMenu.addEventListener('mouseleave', (e) => {
-      const toMoveSubmenu =
-        moveSubmenu &&
-        (e.relatedTarget === moveSubmenu ||
-          moveSubmenu.contains(e.relatedTarget));
-      const toCopySubmenu =
-        copySubmenu &&
-        (e.relatedTarget === copySubmenu ||
-          copySubmenu.contains(e.relatedTarget));
-      const toPlaySubmenu =
-        playSubmenu &&
-        (e.relatedTarget === playSubmenu ||
-          playSubmenu.contains(e.relatedTarget));
-
-      if (!toMoveSubmenu && !toCopySubmenu && !toPlaySubmenu) {
-        hideSubmenus();
-      }
-    });
-
-    if (moveSubmenu) {
-      moveSubmenu.addEventListener('mouseenter', cancelHide);
-      moveSubmenu.addEventListener('mouseleave', hideSubmenus);
-    }
-
-    if (copySubmenu) {
-      copySubmenu.addEventListener('mouseenter', cancelHide);
-      copySubmenu.addEventListener('mouseleave', hideSubmenus);
-    }
-
-    if (playSubmenu) {
-      playSubmenu.addEventListener('mouseenter', cancelHide);
-      playSubmenu.addEventListener('mouseleave', hideSubmenus);
-    }
   }
 
   /**
@@ -539,26 +224,6 @@ export function createContextMenus(deps = {}) {
     )
       return;
 
-    // Update the playlist option text based on user's music service
-    const updatePlaylistText = document.getElementById('updatePlaylistText');
-    if (updatePlaylistText) {
-      const musicService = window.currentUser?.musicService;
-      const hasSpotify = window.currentUser?.spotifyAuth;
-      const hasTidal = window.currentUser?.tidalAuth;
-
-      if (musicService === 'spotify' && hasSpotify) {
-        updatePlaylistText.textContent = 'Send to Spotify';
-      } else if (musicService === 'tidal' && hasTidal) {
-        updatePlaylistText.textContent = 'Send to Tidal';
-      } else if (hasSpotify && !hasTidal) {
-        updatePlaylistText.textContent = 'Send to Spotify';
-      } else if (hasTidal && !hasSpotify) {
-        updatePlaylistText.textContent = 'Send to Tidal';
-      } else {
-        updatePlaylistText.textContent = 'Send to Music Service';
-      }
-    }
-
     // Handle download option click - show submenu
     downloadOption.onclick = (e) => {
       e.preventDefault();
@@ -573,7 +238,7 @@ export function createContextMenus(deps = {}) {
 
       if (!currentContextList) return;
 
-      openRenameModal(currentContextList);
+      listMenuActions.renameList(currentContextList);
     };
 
     // Handle toggle main option click
@@ -583,7 +248,7 @@ export function createContextMenus(deps = {}) {
       setContextList(null);
 
       if (currentContextList) {
-        toggleMainStatus(currentContextList);
+        listMenuActions.toggleMainForList(currentContextList);
       }
     };
 
@@ -594,13 +259,7 @@ export function createContextMenus(deps = {}) {
 
       if (!currentContextList) return;
 
-      try {
-        // Pass both list name and list data for track validation
-        const listData = getListData(currentContextList) || [];
-        await updatePlaylist(currentContextList, listData);
-      } catch (err) {
-        console.error('Update playlist failed', err);
-      }
+      await listMenuActions.sendToMusicService(currentContextList);
 
       setContextList(null);
     };
@@ -637,8 +296,8 @@ export function createContextMenus(deps = {}) {
           delete lists[currentContextList];
 
           // Clean up snapshot from localStorage and memory
-          if (window.clearSnapshotFromStorage) {
-            window.clearSnapshotFromStorage(currentContextList);
+          if (typeof clearSnapshotFromStorage === 'function') {
+            clearSnapshotFromStorage(currentContextList);
           }
 
           if (currentList === currentContextList) {
@@ -935,13 +594,6 @@ export function createContextMenus(deps = {}) {
     hideAllContextMenus,
     getDeviceIcon,
     getListMenuConfig,
-    showMoveToListSubmenu,
-    showCopyToListSubmenu,
-    showMoveConfirmation,
-    showCopyConfirmation,
-    moveAlbumToList,
-    copyAlbumToList,
-    setupSubmenuHideOnLeave,
     showDownloadListSubmenu,
     initializeContextMenu,
   };

--- a/src/js/modules/list-menu-shared.js
+++ b/src/js/modules/list-menu-shared.js
@@ -1,0 +1,115 @@
+/**
+ * Shared list menu config and action helpers.
+ */
+
+function getMusicServiceText(currentUser = {}) {
+  const hasSpotify = !!currentUser.spotifyAuth;
+  const hasTidal = !!currentUser.tidalAuth;
+  const musicService = currentUser.musicService;
+
+  let musicServiceText = 'Send to Music Service';
+  if (musicService === 'spotify' && hasSpotify) {
+    musicServiceText = 'Send to Spotify';
+  } else if (musicService === 'tidal' && hasTidal) {
+    musicServiceText = 'Send to Tidal';
+  } else if (hasSpotify && !hasTidal) {
+    musicServiceText = 'Send to Spotify';
+  } else if (hasTidal && !hasSpotify) {
+    musicServiceText = 'Send to Tidal';
+  }
+
+  return { hasSpotify, hasTidal, musicServiceText };
+}
+
+export function buildListMenuConfig({
+  listMeta,
+  groups = [],
+  currentUser = {},
+} = {}) {
+  const meta = listMeta || {};
+  const groupId = meta.groupId;
+
+  let isInCollection = false;
+  let isInYearGroup = false;
+
+  if (!groupId) {
+    isInCollection = true;
+  } else {
+    const group = groups.find((candidate) => candidate._id === groupId);
+    if (group) {
+      isInCollection = !group.isYearGroup;
+      isInYearGroup = !!group.isYearGroup;
+    }
+  }
+
+  const hasYear = !!meta.year || isInYearGroup;
+  const { hasSpotify, hasTidal, musicServiceText } =
+    getMusicServiceText(currentUser);
+
+  return {
+    hasYear,
+    isMain: !!meta.isMain,
+    mainToggleText: meta.isMain ? 'Remove Main Status' : 'Set as Main',
+    mainIconClass: 'fa-star',
+    musicServiceText,
+    hasSpotify,
+    hasTidal,
+    isInCollection,
+  };
+}
+
+export function createListMenuActions(deps = {}) {
+  const {
+    getListData,
+    updatePlaylist,
+    downloadListAsJSON,
+    downloadListAsPDF,
+    downloadListAsCSV,
+    openRenameModal,
+    toggleMainStatus,
+    logger = console,
+  } = deps;
+
+  function renameList(listId) {
+    if (!listId) return;
+    openRenameModal(listId);
+  }
+
+  function toggleMainForList(listId) {
+    if (!listId) return;
+    toggleMainStatus(listId);
+  }
+
+  function downloadList(listId, format) {
+    if (!listId) return;
+    if (format === 'json') {
+      downloadListAsJSON(listId);
+      return;
+    }
+    if (format === 'pdf') {
+      downloadListAsPDF(listId);
+      return;
+    }
+    if (format === 'csv') {
+      downloadListAsCSV(listId);
+    }
+  }
+
+  async function sendToMusicService(listId) {
+    if (!listId) return;
+
+    try {
+      const listData = getListData(listId) || [];
+      await updatePlaylist(listId, listData);
+    } catch (error) {
+      logger.error('Update playlist failed', error);
+    }
+  }
+
+  return {
+    renameList,
+    toggleMainForList,
+    downloadList,
+    sendToMusicService,
+  };
+}

--- a/src/js/modules/list-nav.js
+++ b/src/js/modules/list-nav.js
@@ -7,6 +7,8 @@
  * @module list-nav
  */
 
+import { buildListMenuConfig } from './list-menu-shared.js';
+
 /**
  * Factory function to create the list navigation module with injected dependencies
  *
@@ -17,7 +19,6 @@
  * @param {Function} deps.getSortedGroups - Get groups sorted by sort_order
  * @param {Function} deps.getCurrentList - Get current list name
  * @param {Function} deps.selectList - Select a list
- * @param {Function} deps.getListMenuConfig - Get list menu configuration
  * @param {Function} deps.hideAllContextMenus - Hide all context menus
  * @param {Function} deps.positionContextMenu - Position a context menu
  * @param {Function} deps.toggleMobileLists - Toggle mobile list panel
@@ -27,6 +28,11 @@
  * @param {Function} deps.showToast - Show toast notifications
  * @param {Function} deps.refreshGroupsAndLists - Refresh groups and lists from server
  * @param {Function} deps.yearHasRecommendations - Check if a year has recommendations
+ * @param {Function} deps.getCurrentUser - Get authenticated frontend user
+ * @param {Function} deps.showMobileListMenu - Show mobile list menu action sheet
+ * @param {Function} deps.showMobileCategoryMenu - Show mobile category menu action sheet
+ * @param {Function} deps.selectRecommendations - Select recommendations for a year
+ * @param {Function} deps.getCurrentRecommendationsYear - Get active recommendations year
  * @returns {Object} List navigation module API
  */
 export function createListNav(deps = {}) {
@@ -37,7 +43,6 @@ export function createListNav(deps = {}) {
     getSortedGroups,
     getCurrentList,
     selectList,
-    getListMenuConfig,
     hideAllContextMenus,
     positionContextMenu,
     toggleMobileLists,
@@ -47,6 +52,11 @@ export function createListNav(deps = {}) {
     showToast,
     refreshGroupsAndLists,
     yearHasRecommendations,
+    getCurrentUser = () => window.currentUser || {},
+    showMobileListMenu,
+    showMobileCategoryMenu,
+    selectRecommendations,
+    getCurrentRecommendationsYear,
   } = deps;
 
   // Track sortable instances for cleanup
@@ -403,8 +413,11 @@ export function createListNav(deps = {}) {
       const contextMenu = document.getElementById('contextMenu');
       if (!contextMenu) return;
 
-      // Get shared menu configuration
-      const menuConfig = getListMenuConfig(listId);
+      const menuConfig = buildListMenuConfig({
+        listMeta: getListMetadata(listId),
+        groups: getSortedGroups ? getSortedGroups() : [],
+        currentUser: getCurrentUser(),
+      });
 
       // Update the playlist option text based on user's music service
       const updatePlaylistText = document.getElementById('updatePlaylistText');
@@ -472,8 +485,8 @@ export function createListNav(deps = {}) {
     menuButton.addEventListener('click', (e) => {
       e.stopPropagation();
       e.preventDefault();
-      if (window.showMobileListMenu) {
-        window.showMobileListMenu(listId);
+      if (typeof showMobileListMenu === 'function') {
+        showMobileListMenu(listId);
       }
     });
   }
@@ -585,7 +598,10 @@ export function createListNav(deps = {}) {
    */
   function createRecommendationsButton(year, isMobile) {
     // Check if recommendations is currently active for this year
-    const currentRecommendationsYear = window.currentRecommendationsYear;
+    const currentRecommendationsYear =
+      typeof getCurrentRecommendationsYear === 'function'
+        ? getCurrentRecommendationsYear()
+        : null;
     const isActive = currentRecommendationsYear === year;
 
     const li = document.createElement('li');
@@ -598,8 +614,8 @@ export function createListNav(deps = {}) {
 
     // Click handler for selecting recommendations
     button.onclick = () => {
-      if (window.selectRecommendations) {
-        window.selectRecommendations(year);
+      if (typeof selectRecommendations === 'function') {
+        selectRecommendations(year);
       }
       if (isMobile && toggleMobileLists) {
         toggleMobileLists();
@@ -697,8 +713,8 @@ export function createListNav(deps = {}) {
     menuButton.addEventListener('click', (e) => {
       e.stopPropagation();
       e.preventDefault();
-      if (window.showMobileCategoryMenu) {
-        window.showMobileCategoryMenu(groupId, groupName, isYearGroup);
+      if (typeof showMobileCategoryMenu === 'function') {
+        showMobileCategoryMenu(groupId, groupName, isYearGroup);
       }
     });
   }

--- a/src/js/modules/list-setup-wizard.js
+++ b/src/js/modules/list-setup-wizard.js
@@ -9,11 +9,15 @@ import { escapeHtml } from './html-utils.js';
 // State for the wizard
 let setupData = null;
 const pendingUpdates = new Map();
+let refreshLists = null;
 
 /**
  * Check if user needs to complete list setup and show wizard if needed
  */
-export async function checkListSetupStatus() {
+export async function checkListSetupStatus(options = {}) {
+  refreshLists =
+    typeof options.refreshLists === 'function' ? options.refreshLists : null;
+
   try {
     const status = await apiCall('/api/lists/setup-status');
 
@@ -315,8 +319,8 @@ async function handleSave() {
     hideWizard();
 
     // Refresh the lists in the sidebar
-    if (typeof window.loadLists === 'function') {
-      window.loadLists();
+    if (typeof refreshLists === 'function') {
+      refreshLists();
     }
   } catch (err) {
     console.error('Failed to save list updates:', err);

--- a/src/js/modules/mobile-ui.js
+++ b/src/js/modules/mobile-ui.js
@@ -15,6 +15,10 @@ import { fetchSpotifyDevices } from '../utils/playback-service.js';
 import { createMobileAlbumActions } from './mobile-ui/album-actions.js';
 import { createTrackPickService } from './track-pick-service.js';
 import { createAlbumIdentityFinder } from './mobile-ui/album-identity.js';
+import {
+  buildListMenuConfig,
+  createListMenuActions,
+} from './list-menu-shared.js';
 
 /**
  * Factory function to create the mobile UI module with injected dependencies
@@ -42,7 +46,6 @@ import { createAlbumIdentityFinder } from './mobile-ui/album-identity.js';
  * @param {Function} deps.updatePlaylist - Update playlist on music service
  * @param {Function} deps.toggleMainStatus - Toggle main status
  * @param {Function} deps.getDeviceIcon - Get icon for device type
- * @param {Function} deps.getListMenuConfig - Get list menu configuration
  * @param {Function} deps.getAvailableCountries - Get available countries list
  * @param {Function} deps.getAvailableGenres - Get available genres list
  * @param {Function} deps.setCurrentContextAlbum - Set current context album index
@@ -53,6 +56,8 @@ import { createAlbumIdentityFinder } from './mobile-ui/album-identity.js';
  * @param {Function} deps.refreshGroupsAndLists - Refresh groups and lists after changes
  * @param {Function} deps.isViewingRecommendations - Check if currently viewing recommendations
  * @param {Function} deps.recommendAlbum - Shared recommendation flow (reasoning modal + API)
+ * @param {Function} deps.openRenameCategoryModal - Open category rename modal
+ * @param {Function} deps.getCurrentUser - Get authenticated frontend user
  * @returns {Object} Mobile UI module API
  */
 export function createMobileUI(deps = {}) {
@@ -82,7 +87,6 @@ export function createMobileUI(deps = {}) {
     updatePlaylist,
     toggleMainStatus,
     getDeviceIcon,
-    getListMenuConfig,
     getAvailableCountries,
     getAvailableGenres,
     setCurrentContextAlbum,
@@ -93,11 +97,23 @@ export function createMobileUI(deps = {}) {
     refreshGroupsAndLists,
     isViewingRecommendations,
     recommendAlbum,
+    openRenameCategoryModal,
+    getCurrentUser = () => window.currentUser || {},
   } = deps;
   const trackPickService = createTrackPickService({ apiCall });
   const findAlbumByIdentity = createAlbumIdentityFinder({
     getCurrentList,
     getListData,
+  });
+  const listMenuActions = createListMenuActions({
+    getListData,
+    updatePlaylist,
+    downloadListAsJSON,
+    downloadListAsPDF,
+    downloadListAsCSV,
+    openRenameModal,
+    toggleMainStatus,
+    logger: console,
   });
 
   // Create transfer helpers (move/copy with confirmation dialogs)
@@ -161,7 +177,11 @@ export function createMobileUI(deps = {}) {
     const lists = getLists();
     const listMeta = getListMetadata(listId);
     const listName = listMeta?.name || listId;
-    const menuConfig = getListMenuConfig(listId);
+    const menuConfig = buildListMenuConfig({
+      listMeta,
+      groups: getSortedGroups ? getSortedGroups() : [],
+      currentUser: getCurrentUser(),
+    });
 
     const { sheet: actionSheet, close } = createActionSheet({
       contentHtml: `
@@ -302,28 +322,28 @@ export function createMobileUI(deps = {}) {
       e.preventDefault();
       e.stopPropagation();
       close();
-      downloadListAsJSON(listId);
+      listMenuActions.downloadList(listId, 'json');
     });
 
     downloadPdfBtn.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
       close();
-      downloadListAsPDF(listId);
+      listMenuActions.downloadList(listId, 'pdf');
     });
 
     downloadCsvBtn.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
       close();
-      downloadListAsCSV(listId);
+      listMenuActions.downloadList(listId, 'csv');
     });
 
     editBtn.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
       close();
-      openRenameModal(listId);
+      listMenuActions.renameList(listId);
     });
 
     if (toggleMainBtn) {
@@ -331,7 +351,7 @@ export function createMobileUI(deps = {}) {
         e.preventDefault();
         e.stopPropagation();
         close();
-        toggleMainStatus(listId);
+        listMenuActions.toggleMainForList(listId);
       });
     }
 
@@ -339,12 +359,7 @@ export function createMobileUI(deps = {}) {
       e.preventDefault();
       e.stopPropagation();
       close();
-      try {
-        const listData = getListData(listId) || [];
-        await updatePlaylist(listId, listData);
-      } catch (err) {
-        console.error('Update playlist failed', err);
-      }
+      await listMenuActions.sendToMusicService(listId);
     });
 
     // Handle move to collection button
@@ -571,18 +586,15 @@ export function createMobileUI(deps = {}) {
 
         // Year groups can't be renamed (shouldn't reach here due to UI)
         if (isYearGroup) {
-          if (window.showToast) {
-            window.showToast(
-              'Year groups cannot be renamed. The name matches the year.',
-              'info'
-            );
-          }
+          showToast(
+            'Year groups cannot be renamed. The name matches the year.',
+            'info'
+          );
           return;
         }
 
-        // Use the global function from app.js
-        if (window.openRenameCategoryModal) {
-          window.openRenameCategoryModal(groupId, groupName);
+        if (typeof openRenameCategoryModal === 'function') {
+          openRenameCategoryModal(groupId, groupName);
         }
       });
     }

--- a/src/js/modules/settings-drawer.js
+++ b/src/js/modules/settings-drawer.js
@@ -40,6 +40,7 @@ import { getCurrentListId } from './app-state.js';
  * @param {Function} deps.showToast - Toast notification function
  * @param {Function} deps.showConfirmation - Modal confirmation function
  * @param {Function} deps.apiCall - API call function
+ * @param {Function} deps.refreshLockedYearStatus - Refresh lock UI for one year
  */
 export function createSettingsDrawer(deps = {}) {
   const showToast = deps.showToast || (() => {});
@@ -47,6 +48,7 @@ export function createSettingsDrawer(deps = {}) {
     deps.showConfirmation || (() => Promise.resolve(false));
   const apiCall =
     deps.apiCall || (() => Promise.reject(new Error('apiCall not provided')));
+  const refreshLockedYearStatus = deps.refreshLockedYearStatus;
 
   let currentCategory = 'account';
   const categoryData = {};
@@ -257,6 +259,7 @@ export function createSettingsDrawer(deps = {}) {
     handleShowContributorManager,
     handleShowRecommenderManager,
     createSettingsModalBase,
+    refreshLockedYearStatus,
   });
 
   const { attachAdminHandlers } = createSettingsAdminHandlers({

--- a/src/js/modules/settings-drawer/handlers/aggregate-actions.js
+++ b/src/js/modules/settings-drawer/handlers/aggregate-actions.js
@@ -18,6 +18,7 @@ export function createSettingsAggregateActions(deps = {}) {
     handleShowContributorManager,
     handleShowRecommenderManager,
     createSettingsModalBase,
+    refreshLockedYearStatus,
   } = deps;
 
   async function handleConfirmAggregateReveal(year) {
@@ -144,8 +145,8 @@ export function createSettingsAggregateActions(deps = {}) {
       if (response.success) {
         await updateSingleYearLockStatus(year, !isCurrentlyLocked);
 
-        if (win?.refreshLockedYearStatus) {
-          await win.refreshLockedYearStatus(year);
+        if (typeof refreshLockedYearStatus === 'function') {
+          await refreshLockedYearStatus(year);
         }
       }
     } catch (error) {

--- a/src/js/musicbrainz.js
+++ b/src/js/musicbrainz.js
@@ -14,7 +14,17 @@ import {
   getListData,
   setListData,
   getListMetadata,
+  isViewingRecommendations,
+  getCurrentRecommendationsYear,
 } from './modules/app-state.js';
+import {
+  apiCall,
+  saveList,
+  selectList,
+  fetchTracksForAlbum,
+  selectRecommendations,
+  showReasoningModal,
+} from './app.js';
 
 const MUSICBRAINZ_PROXY = '/api/proxy/musicbrainz'; // Using our proxy
 const WIKIDATA_PROXY = '/api/proxy/wikidata'; // Using our proxy
@@ -29,7 +39,7 @@ const WIKIDATA_PROXY = '/api/proxy/wikidata'; // Using our proxy
  */
 async function mergeMetadataToCanonical(album) {
   try {
-    await window.apiCall('/api/albums/merge-metadata', {
+    await apiCall('/api/albums/merge-metadata', {
       method: 'POST',
       body: JSON.stringify({
         album_id: album.album_id,
@@ -1524,7 +1534,7 @@ async function finishManualAdd(album) {
         `"${album.album}" is already in this list${label}`,
         usedExisting ? 'info' : 'error'
       );
-      if (usedExisting && currentListId) window.selectList(currentListId);
+      if (usedExisting && currentListId) selectList(currentListId);
       return;
     }
 
@@ -1538,13 +1548,13 @@ async function finishManualAdd(album) {
 
     if (!Array.isArray(resolved.tracks) || resolved.tracks.length === 0) {
       try {
-        await window.fetchTracksForAlbum(resolved);
+        await fetchTracksForAlbum(resolved);
       } catch (_err) {
         // Auto track fetch failed - not critical
       }
     }
 
-    await window.saveList(currentListId, currentListData);
+    await saveList(currentListId, currentListData);
 
     // Force refresh from server to get merged album data
     const listMetadata = getListMetadata(currentListId);
@@ -1552,7 +1562,7 @@ async function finishManualAdd(album) {
       listMetadata._data = null;
     }
 
-    window.selectList(currentListId);
+    selectList(currentListId);
     closeAddAlbumModal();
 
     const suffix = usedExisting ? ' (using existing album)' : ' to the list';
@@ -2097,7 +2107,7 @@ async function addAlbumToList(releaseGroup) {
 
 async function addAlbumToCurrentList(album) {
   // Check if we're viewing recommendations - route to recommendations flow
-  if (window.isViewingRecommendations && window.isViewingRecommendations()) {
+  if (isViewingRecommendations()) {
     await addAlbumToRecommendations(album);
     return;
   }
@@ -2123,7 +2133,7 @@ async function addAlbumToCurrentList(album) {
         `"${album.album}" is already in this list${label}`,
         usedExisting ? 'info' : 'error'
       );
-      if (usedExisting && currentListId) window.selectList(currentListId);
+      if (usedExisting && currentListId) selectList(currentListId);
       return;
     }
 
@@ -2136,13 +2146,13 @@ async function addAlbumToCurrentList(album) {
 
     if (!Array.isArray(resolved.tracks) || resolved.tracks.length === 0) {
       try {
-        await window.fetchTracksForAlbum(resolved);
+        await fetchTracksForAlbum(resolved);
       } catch (_err) {
         // Auto track fetch failed - not critical
       }
     }
 
-    await window.saveList(currentListId, currentListData);
+    await saveList(currentListId, currentListData);
 
     // Force refresh from server to get merged album data
     const listMetadata = getListMetadata(currentListId);
@@ -2150,7 +2160,7 @@ async function addAlbumToCurrentList(album) {
       listMetadata._data = null;
     }
 
-    window.selectList(currentListId);
+    selectList(currentListId);
     closeAddAlbumModal();
 
     showToast(`Added "${resolved.album}" by ${resolved.artist} to the list`);
@@ -2172,7 +2182,7 @@ async function addAlbumToCurrentList(album) {
  * @param {Object} album - Album object with artist, album, etc.
  */
 async function addAlbumToRecommendations(album) {
-  const year = window.getCurrentRecommendationsYear();
+  const year = getCurrentRecommendationsYear();
   if (!year) {
     showToast('No recommendations year selected', 'error');
     return;
@@ -2182,14 +2192,14 @@ async function addAlbumToRecommendations(album) {
   closeAddAlbumModal();
 
   // Show reasoning modal
-  const reasoning = await window.showReasoningModal(album, year);
+  const reasoning = await showReasoningModal(album, year);
   if (!reasoning) {
     // User cancelled
     return;
   }
 
   try {
-    await window.apiCall(`/api/recommendations/${year}`, {
+    await apiCall(`/api/recommendations/${year}`, {
       method: 'POST',
       body: JSON.stringify({ album, reasoning }),
     });
@@ -2197,8 +2207,8 @@ async function addAlbumToRecommendations(album) {
     showToast(`Recommended "${album.album}" by ${album.artist}`, 'success');
 
     // Refresh recommendations display
-    if (window.selectRecommendations) {
-      window.selectRecommendations(year);
+    if (typeof selectRecommendations === 'function') {
+      selectRecommendations(year);
     }
   } catch (error) {
     if (error.status === 409) {

--- a/test/app-window-globals.test.js
+++ b/test/app-window-globals.test.js
@@ -9,72 +9,34 @@ describe('app-window-globals module', () => {
     registerAppWindowGlobals = module.registerAppWindowGlobals;
   });
 
-  it('registers legacy window bindings and playback wrapper', () => {
+  it('registers only legacy shell window bindings', () => {
     const win = {};
-    const playbackCalls = [];
-    const refreshLockedYearStatus = async () => {};
+    const selectList = () => {};
+    const updateListNav = () => {};
+    const collapseGroupsForActiveList = () => {};
+    const displayAlbums = () => {};
 
     registerAppWindowGlobals({
       win,
-      apiCall: () => {},
-      showToast: () => {},
-      showReasoningModal: () => {},
-      getListData: () => {},
-      setListData: () => {},
-      getListMetadata: () => {},
-      updateListMetadata: () => {},
-      isListDataLoaded: () => {},
-      saveList: () => {},
-      loadLists: () => {},
-      selectList: () => {},
-      updateListNav: () => {},
-      collapseGroupsForActiveList: () => {},
-      updatePlaylist: () => {},
-      toggleMainStatus: () => {},
-      displayAlbums: () => {},
-      getGroup: () => {},
-      updateGroupsFromServer: () => {},
-      getCurrentListName: () => {},
-      findListByName: () => {},
-      isViewingRecommendations: () => false,
-      getCurrentRecommendationsYear: () => null,
-      selectRecommendations: () => {},
-      clearSnapshotFromStorage: () => {},
-      showMobileAlbumMenu: () => {},
-      showMobileMoveToListSheet: () => {},
-      showMobileListMenu: () => {},
-      showMobileCategoryMenu: () => {},
-      showMobileEditForm: () => {},
-      showMobileEditFormSafe: () => {},
-      showMobileSummarySheet: () => {},
-      openRenameCategoryModal: () => {},
-      playAlbum: () => {},
-      playTrack: () => {},
-      getPlaybackModule: () => ({
-        playTrackSafe(albumId) {
-          playbackCalls.push(albumId);
-          return `played:${albumId}`;
-        },
-      }),
-      playSpecificTrack: () => {},
-      playAlbumSafe: () => {},
-      removeAlbumSafe: () => {},
-      fetchTracksForAlbum: () => {},
-      getTrackName: () => {},
-      getTrackLength: () => {},
-      formatTrackTime: () => {},
-      refreshLockedYearStatus,
+      selectList,
+      updateListNav,
+      collapseGroupsForActiveList,
+      displayAlbums,
     });
 
-    assert.strictEqual(typeof win.apiCall, 'function');
-    assert.strictEqual(typeof win.selectList, 'function');
-    assert.strictEqual(typeof win.updateListNav, 'function');
-    assert.strictEqual(typeof win.playTrackSafe, 'function');
-    assert.strictEqual(win.refreshLockedYearStatus, refreshLockedYearStatus);
+    assert.strictEqual(win.selectList, selectList);
+    assert.strictEqual(win.updateListNav, updateListNav);
+    assert.strictEqual(
+      win.collapseGroupsForActiveList,
+      collapseGroupsForActiveList
+    );
+    assert.strictEqual(win.displayAlbums, displayAlbums);
 
-    const playResult = win.playTrackSafe('album-1');
-    assert.strictEqual(playResult, 'played:album-1');
-    assert.deepStrictEqual(playbackCalls, ['album-1']);
+    assert.strictEqual(win.apiCall, undefined);
+    assert.strictEqual(win.saveList, undefined);
+    assert.strictEqual(win.playTrackSafe, undefined);
+    assert.strictEqual(win.showMobileListMenu, undefined);
+    assert.strictEqual(win.selectRecommendations, undefined);
   });
 
   it('no-ops safely when window object is unavailable', () => {

--- a/test/context-menus.test.js
+++ b/test/context-menus.test.js
@@ -24,24 +24,19 @@ describe('context-menus module', () => {
         getListMetadata: mock.fn(() => ({})),
         getCurrentList: mock.fn(() => 'test-list'),
         getLists: mock.fn(() => ({})),
-        saveList: mock.fn(),
         selectList: mock.fn(),
         showToast: mock.fn(),
         showConfirmation: mock.fn(),
         apiCall: mock.fn(),
-        findAlbumByIdentity: mock.fn(),
         downloadListAsJSON: mock.fn(),
+        downloadListAsPDF: mock.fn(),
+        downloadListAsCSV: mock.fn(),
         updatePlaylist: mock.fn(),
         openRenameModal: mock.fn(),
         updateListNav: mock.fn(),
-        showMobileEditForm: mock.fn(),
-        playAlbum: mock.fn(),
-        playAlbumSafe: mock.fn(),
-        loadLists: mock.fn(),
-        getContextAlbum: mock.fn(() => ({ index: null, albumId: null })),
-        setContextAlbum: mock.fn(),
         getContextList: mock.fn(() => null),
         setContextList: mock.fn(),
+        setCurrentList: mock.fn(),
         toggleMainStatus: mock.fn(),
       };
 
@@ -52,13 +47,8 @@ describe('context-menus module', () => {
       assert.strictEqual(typeof module.hideAllContextMenus, 'function');
       assert.strictEqual(typeof module.getDeviceIcon, 'function');
       assert.strictEqual(typeof module.getListMenuConfig, 'function');
-      assert.strictEqual(typeof module.showMoveToListSubmenu, 'function');
-      assert.strictEqual(typeof module.showCopyToListSubmenu, 'function');
-      assert.strictEqual(typeof module.showMoveConfirmation, 'function');
-      assert.strictEqual(typeof module.showCopyConfirmation, 'function');
-      assert.strictEqual(typeof module.moveAlbumToList, 'function');
-      assert.strictEqual(typeof module.copyAlbumToList, 'function');
-      assert.strictEqual(typeof module.setupSubmenuHideOnLeave, 'function');
+      assert.strictEqual(typeof module.showDownloadListSubmenu, 'function');
+      assert.strictEqual(typeof module.initializeContextMenu, 'function');
     });
 
     it('should handle empty dependencies gracefully', () => {
@@ -212,115 +202,6 @@ describe('context-menus module', () => {
       assert.strictEqual(config.hasSpotify, false);
       assert.strictEqual(config.hasTidal, false);
       assert.strictEqual(config.musicServiceText, 'Send to Music Service');
-    });
-  });
-
-  describe('moveAlbumToList', () => {
-    let createContextMenus;
-
-    beforeEach(async () => {
-      const module = await import('../src/js/modules/context-menus.js');
-      createContextMenus = module.createContextMenus;
-    });
-
-    it('should throw error for invalid source list', async () => {
-      const mockDeps = {
-        getCurrentList: mock.fn(() => 'source'),
-        getLists: mock.fn(() => ({})), // Empty lists
-        getListData: mock.fn(() => null),
-        showToast: mock.fn(),
-        findAlbumByIdentity: mock.fn(),
-      };
-
-      const module = createContextMenus(mockDeps);
-
-      await assert.rejects(
-        () => module.moveAlbumToList(0, 'album-id', 'target'),
-        { message: 'Invalid source or target list' }
-      );
-    });
-
-    it('should throw error when source list data not loaded', async () => {
-      const mockDeps = {
-        getCurrentList: mock.fn(() => 'source'),
-        getLists: mock.fn(() => ({ source: {}, target: {} })),
-        getListData: mock.fn(() => null),
-        showToast: mock.fn(),
-        findAlbumByIdentity: mock.fn(),
-      };
-
-      const module = createContextMenus(mockDeps);
-
-      await assert.rejects(
-        () => module.moveAlbumToList(0, 'album-id', 'target'),
-        { message: 'Source list data not loaded' }
-      );
-    });
-
-    it('should throw error when album not found', async () => {
-      const mockDeps = {
-        getCurrentList: mock.fn(() => 'source'),
-        getLists: mock.fn(() => ({ source: {}, target: {} })),
-        getListData: mock.fn((name) => {
-          if (name === 'source') return [];
-          return [];
-        }),
-        showToast: mock.fn(),
-        findAlbumByIdentity: mock.fn(),
-      };
-
-      const module = createContextMenus(mockDeps);
-
-      await assert.rejects(
-        () => module.moveAlbumToList(0, 'album-id', 'target'),
-        { message: 'Album not found' }
-      );
-    });
-  });
-
-  describe('copyAlbumToList', () => {
-    let createContextMenus;
-
-    beforeEach(async () => {
-      const module = await import('../src/js/modules/context-menus.js');
-      createContextMenus = module.createContextMenus;
-    });
-
-    it('should throw error for invalid source list', async () => {
-      const mockDeps = {
-        getCurrentList: mock.fn(() => 'source'),
-        getLists: mock.fn(() => ({})),
-        getListData: mock.fn(() => null),
-        showToast: mock.fn(),
-        findAlbumByIdentity: mock.fn(),
-      };
-
-      const module = createContextMenus(mockDeps);
-
-      await assert.rejects(
-        () => module.copyAlbumToList(0, 'album-id', 'target'),
-        { message: 'Invalid source or target list' }
-      );
-    });
-
-    it('should throw error when album not found', async () => {
-      const mockDeps = {
-        getCurrentList: mock.fn(() => 'source'),
-        getLists: mock.fn(() => ({ source: {}, target: {} })),
-        getListData: mock.fn((name) => {
-          if (name === 'source') return [];
-          return [];
-        }),
-        showToast: mock.fn(),
-        findAlbumByIdentity: mock.fn(),
-      };
-
-      const module = createContextMenus(mockDeps);
-
-      await assert.rejects(
-        () => module.copyAlbumToList(0, 'album-id', 'target'),
-        { message: 'Album not found' }
-      );
     });
   });
 

--- a/test/list-menu-shared.test.js
+++ b/test/list-menu-shared.test.js
@@ -1,0 +1,103 @@
+const { describe, it, beforeEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('list-menu-shared module', () => {
+  let buildListMenuConfig;
+  let createListMenuActions;
+
+  beforeEach(async () => {
+    const module = await import('../src/js/modules/list-menu-shared.js');
+    buildListMenuConfig = module.buildListMenuConfig;
+    createListMenuActions = module.createListMenuActions;
+  });
+
+  it('builds menu config with preferred music service label', () => {
+    const config = buildListMenuConfig({
+      listMeta: { year: 2024, isMain: false },
+      groups: [],
+      currentUser: {
+        spotifyAuth: true,
+        tidalAuth: false,
+        musicService: 'spotify',
+      },
+    });
+
+    assert.strictEqual(config.hasYear, true);
+    assert.strictEqual(config.mainToggleText, 'Set as Main');
+    assert.strictEqual(config.musicServiceText, 'Send to Spotify');
+    assert.strictEqual(config.hasSpotify, true);
+    assert.strictEqual(config.hasTidal, false);
+  });
+
+  it('derives year-group and collection flags from groups', () => {
+    const config = buildListMenuConfig({
+      listMeta: { groupId: 'group-2020' },
+      groups: [{ _id: 'group-2020', isYearGroup: true }],
+      currentUser: {},
+    });
+
+    assert.strictEqual(config.hasYear, true);
+    assert.strictEqual(config.isInCollection, false);
+  });
+
+  it('marks orphaned lists as movable between collections', () => {
+    const config = buildListMenuConfig({
+      listMeta: { groupId: null },
+      groups: [],
+      currentUser: {},
+    });
+
+    assert.strictEqual(config.isInCollection, true);
+  });
+
+  it('routes rename, toggle, and downloads through shared actions', async () => {
+    const calls = [];
+    const actions = createListMenuActions({
+      getListData: () => [{ album: 'One' }],
+      updatePlaylist: async (listId, listData) => {
+        calls.push(['updatePlaylist', listId, listData.length]);
+      },
+      downloadListAsJSON: (listId) => calls.push(['json', listId]),
+      downloadListAsPDF: (listId) => calls.push(['pdf', listId]),
+      downloadListAsCSV: (listId) => calls.push(['csv', listId]),
+      openRenameModal: (listId) => calls.push(['rename', listId]),
+      toggleMainStatus: (listId) => calls.push(['toggle-main', listId]),
+      logger: { error: () => {} },
+    });
+
+    actions.renameList('list-a');
+    actions.toggleMainForList('list-a');
+    actions.downloadList('list-a', 'json');
+    actions.downloadList('list-a', 'pdf');
+    actions.downloadList('list-a', 'csv');
+    await actions.sendToMusicService('list-a');
+
+    assert.deepStrictEqual(calls, [
+      ['rename', 'list-a'],
+      ['toggle-main', 'list-a'],
+      ['json', 'list-a'],
+      ['pdf', 'list-a'],
+      ['csv', 'list-a'],
+      ['updatePlaylist', 'list-a', 1],
+    ]);
+  });
+
+  it('logs send-to-service errors without throwing', async () => {
+    const logger = { error: mock.fn() };
+    const actions = createListMenuActions({
+      getListData: () => [],
+      updatePlaylist: async () => {
+        throw new Error('failed');
+      },
+      downloadListAsJSON: () => {},
+      downloadListAsPDF: () => {},
+      downloadListAsCSV: () => {},
+      openRenameModal: () => {},
+      toggleMainStatus: () => {},
+      logger,
+    });
+
+    await assert.doesNotReject(() => actions.sendToMusicService('list-a'));
+    assert.strictEqual(logger.error.mock.calls.length, 1);
+  });
+});

--- a/test/settings-aggregate-actions.test.js
+++ b/test/settings-aggregate-actions.test.js
@@ -206,10 +206,9 @@ describe('settings aggregate actions', () => {
       handleShowRecommenderManager: async () => {},
       createSettingsModalBase: () => ({ modal: createElement(), close() {} }),
       doc,
-      win: {
-        async refreshLockedYearStatus(year) {
-          refreshCalls.push(year);
-        },
+      win: {},
+      async refreshLockedYearStatus(year) {
+        refreshCalls.push(year);
       },
     });
 


### PR DESCRIPTION
## Summary
- remove most legacy app-level window bridges and keep only the shell compatibility hooks still used by the page layer (`selectList`, `updateListNav`, `collapseGroupsForActiveList`, `displayAlbums`)
- shift modules to explicit dependency wiring (list nav, mobile UI, album display, settings aggregate actions, list setup wizard, and musicbrainz) so internal flows no longer depend on `window.*` helpers
- introduce `list-menu-shared` to centralize list menu config + actions and use it across desktop and mobile, while dropping duplicated album-submenu responsibilities from `context-menus`

## Validation
- `node --test test/list-menu-shared.test.js`
- `node --test test/context-menus.test.js`
- `node --test test/album-context-menu-submenu.test.js`
- `node --test test/recommendations-context-menu.test.js`
- `node --test test/mobile-ui.test.js`
- `node --test test/list-nav.test.js`
- `node --test test/app-window-globals.test.js`
- `node --test test/settings-aggregate-actions.test.js`
- `npm run lint:strict`
- `npm run build`