### PR TITLE
Harden album merge integrity across admin flows

### DIFF
--- a/db/migrations/migrations/057_add_album_reference_foreign_keys.js
+++ b/db/migrations/migrations/057_add_album_reference_foreign_keys.js
@@ -1,0 +1,125 @@
+const logger = require('../../../utils/logger');
+
+/**
+ * Enforce album reference integrity.
+ *
+ * Adds:
+ * - list_items.album_id -> albums.album_id (ON DELETE RESTRICT)
+ * - album_distinct_pairs.album_id_1 -> albums.album_id (ON DELETE CASCADE)
+ * - album_distinct_pairs.album_id_2 -> albums.album_id (ON DELETE CASCADE)
+ *
+ * Before adding constraints we remove rows that already violate these
+ * relationships so the migration can be applied safely in production.
+ */
+async function up(pool) {
+  logger.info('Cleaning orphan album references before adding foreign keys...');
+
+  const blankAlbumIdsResult = await pool.query(`
+    UPDATE list_items
+    SET album_id = NULL
+    WHERE album_id = ''
+  `);
+
+  const orphanListItemsDelete = await pool.query(`
+    DELETE FROM list_items li
+    WHERE li.album_id IS NOT NULL
+      AND li.album_id != ''
+      AND NOT EXISTS (
+        SELECT 1
+        FROM albums a
+        WHERE a.album_id = li.album_id
+      )
+  `);
+
+  const orphanDistinctPairsDelete = await pool.query(`
+    DELETE FROM album_distinct_pairs adp
+    WHERE NOT EXISTS (
+            SELECT 1 FROM albums a WHERE a.album_id = adp.album_id_1
+          )
+       OR NOT EXISTS (
+            SELECT 1 FROM albums a WHERE a.album_id = adp.album_id_2
+          )
+  `);
+
+  logger.info('Orphan cleanup complete', {
+    blankAlbumIdsNormalized: blankAlbumIdsResult.rowCount,
+    deletedListItems: orphanListItemsDelete.rowCount,
+    deletedDistinctPairs: orphanDistinctPairsDelete.rowCount,
+  });
+
+  await pool.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_list_items_album_id'
+      ) THEN
+        ALTER TABLE list_items
+        ADD CONSTRAINT fk_list_items_album_id
+        FOREIGN KEY (album_id)
+        REFERENCES albums(album_id)
+        ON DELETE RESTRICT;
+      END IF;
+    END $$;
+  `);
+
+  await pool.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_album_distinct_pairs_album_1'
+      ) THEN
+        ALTER TABLE album_distinct_pairs
+        ADD CONSTRAINT fk_album_distinct_pairs_album_1
+        FOREIGN KEY (album_id_1)
+        REFERENCES albums(album_id)
+        ON DELETE CASCADE;
+      END IF;
+    END $$;
+  `);
+
+  await pool.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_album_distinct_pairs_album_2'
+      ) THEN
+        ALTER TABLE album_distinct_pairs
+        ADD CONSTRAINT fk_album_distinct_pairs_album_2
+        FOREIGN KEY (album_id_2)
+        REFERENCES albums(album_id)
+        ON DELETE CASCADE;
+      END IF;
+    END $$;
+  `);
+
+  logger.info('Album reference foreign keys added successfully');
+}
+
+async function down(pool) {
+  logger.info('Dropping album reference foreign keys...');
+
+  await pool.query(`
+    ALTER TABLE list_items
+    DROP CONSTRAINT IF EXISTS fk_list_items_album_id
+  `);
+
+  await pool.query(`
+    ALTER TABLE album_distinct_pairs
+    DROP CONSTRAINT IF EXISTS fk_album_distinct_pairs_album_1
+  `);
+
+  await pool.query(`
+    ALTER TABLE album_distinct_pairs
+    DROP CONSTRAINT IF EXISTS fk_album_distinct_pairs_album_2
+  `);
+
+  logger.info('Album reference foreign keys dropped');
+}
+
+module.exports = { up, down };

--- a/routes/admin/audit.js
+++ b/routes/admin/audit.js
@@ -11,7 +11,11 @@ module.exports = (app, deps) => {
   const logger = require('../../utils/logger');
 
   // Create aggregate audit instance
-  const aggregateAudit = createAggregateAudit({ pool: deps.pool, logger });
+  const aggregateAudit = createAggregateAudit({
+    pool: deps.pool,
+    logger,
+    duplicateService: deps.duplicateService,
+  });
 
   // Shared helper: recompute aggregate lists for affected years
   async function recomputeAffectedYears(affectedYears) {

--- a/services/aggregate-audit.js
+++ b/services/aggregate-audit.js
@@ -20,6 +20,7 @@ const {
 const {
   createManualReconciliationService,
 } = require('./aggregate-audit/manual-reconciliation');
+const { createDuplicateService } = require('./duplicate-service');
 
 function createAggregateAudit(deps = {}) {
   const log = deps.logger || logger;
@@ -37,12 +38,16 @@ function createAggregateAudit(deps = {}) {
     withTransaction,
   });
 
+  const duplicateService =
+    deps.duplicateService || createDuplicateService({ pool, logger: log });
+
   const manualReconciliation = createManualReconciliationService({
     pool,
     log,
     normalizeAlbumKey,
     findPotentialDuplicates,
     withTransaction,
+    duplicateService,
   });
 
   return {

--- a/services/aggregate-audit/manual-reconciliation.js
+++ b/services/aggregate-audit/manual-reconciliation.js
@@ -287,7 +287,7 @@ async function mergeManualAlbum(
   canonicalAlbumId,
   options = {}
 ) {
-  const { pool, log, withTransaction } = ctx;
+  const { pool, log, duplicateService } = ctx;
   const { syncMetadata = true, adminUserId = null } = options;
 
   log.info(`Merging manual album ${manualAlbumId} into ${canonicalAlbumId}`);
@@ -300,6 +300,9 @@ async function mergeManualAlbum(
   }
   if (manualAlbumId === canonicalAlbumId) {
     throw new Error('Cannot merge album into itself');
+  }
+  if (!duplicateService || typeof duplicateService.mergeAlbums !== 'function') {
+    throw new Error('duplicateService.mergeAlbums is required');
   }
 
   const canonicalResult = await pool.query(
@@ -331,24 +334,18 @@ async function mergeManualAlbum(
   const affectedLists = affectedResult.rows;
   const affectedYears = [...new Set(affectedLists.map((list) => list.year))];
 
-  let updatedCount = 0;
+  const mergeResult = await duplicateService.mergeAlbums(
+    canonicalAlbumId,
+    manualAlbumId,
+    {
+      mergeMetadata: syncMetadata,
+    }
+  );
 
-  await withTransaction(pool, async (client) => {
-    const updateResult = await client.query(
-      `
-      UPDATE list_items
-      SET album_id = $1, updated_at = NOW()
-      WHERE album_id = $2
-    `,
-      [canonicalAlbumId, manualAlbumId]
-    );
-    updatedCount = updateResult.rowCount;
+  const updatedCount = mergeResult.listItemsUpdated || 0;
 
-    await client.query(`DELETE FROM albums WHERE album_id = $1`, [
-      manualAlbumId,
-    ]);
-
-    await client.query(
+  try {
+    await pool.query(
       `
       INSERT INTO admin_events (event_type, event_data, created_by)
       VALUES ($1, $2, $3)
@@ -364,11 +361,18 @@ async function mergeManualAlbum(
           updatedListItems: updatedCount,
           affectedLists: affectedLists.map((list) => list.list_name),
           affectedYears,
+          mergeResult,
         }),
         adminUserId,
       ]
     );
-  });
+  } catch (error) {
+    log.warn('Manual merge completed but admin event insert failed', {
+      error: error.message,
+      manualAlbumId,
+      canonicalAlbumId,
+    });
+  }
 
   log.info(
     `Merged manual album: ${updatedCount} list_items updated, ` +
@@ -393,6 +397,7 @@ async function mergeManualAlbum(
           album: canonicalAlbum.album,
         }
       : null,
+    mergeResult,
   };
 }
 
@@ -477,7 +482,7 @@ function createManualReconciliationService(deps = {}) {
     log: deps.log,
     normalizeAlbumKey: deps.normalizeAlbumKey,
     findPotentialDuplicates: deps.findPotentialDuplicates,
-    withTransaction: deps.withTransaction,
+    duplicateService: deps.duplicateService,
   };
 
   return {

--- a/services/duplicate-service.js
+++ b/services/duplicate-service.js
@@ -22,6 +22,18 @@ const DEFAULT_PAIR_LIMIT = 100;
 const DEFAULT_CLUSTER_PAGE = 1;
 const DEFAULT_CLUSTER_PAGE_SIZE = 25;
 const MAX_CLUSTER_PAGE_SIZE = 100;
+const DEPENDENT_MERGE_TABLES = [
+  'recommendations',
+  'album_service_mappings',
+  'artist_service_aliases',
+  'user_album_stats',
+  'album_distinct_pairs',
+];
+
+function toRowCount(value) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
 
 function clampNumber(value, min, max, fallback) {
   const parsed = Number.parseInt(value, 10);
@@ -537,6 +549,230 @@ function createDuplicateService(deps = {}) {
     return nextAlbum;
   }
 
+  async function getExistingDependentMergeTables(client) {
+    const result = await client.query(
+      `SELECT tablename
+       FROM pg_tables
+       WHERE schemaname = 'public'
+         AND tablename = ANY($1::text[])`,
+      [DEPENDENT_MERGE_TABLES]
+    );
+
+    return new Set(result.rows.map((row) => row.tablename));
+  }
+
+  async function acquireMergeLocks(client, albumIds) {
+    const lockIds = [...new Set(albumIds.map(normalizeText).filter(Boolean))]
+      .sort()
+      .slice(0, 1000);
+
+    for (const albumId of lockIds) {
+      await client.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [
+        albumId,
+      ]);
+    }
+
+    if (lockIds.length > 0) {
+      await client.query(
+        `SELECT album_id
+         FROM albums
+         WHERE album_id = ANY($1::text[])
+         ORDER BY album_id
+         FOR UPDATE`,
+        [lockIds]
+      );
+    }
+  }
+
+  function emptyDependentRemapStats() {
+    return {
+      recommendationsUpdated: 0,
+      recommendationsConflictsRemoved: 0,
+      albumMappingsUpdated: 0,
+      albumMappingsConflictsRemoved: 0,
+      artistAliasSourcesUpdated: 0,
+      userAlbumStatsUpdated: 0,
+      distinctPairsRemapped: 0,
+      distinctPairsRemoved: 0,
+    };
+  }
+
+  function sumDependentRemapStats(target, source) {
+    for (const [key, value] of Object.entries(source)) {
+      target[key] = (target[key] || 0) + toRowCount(value);
+    }
+  }
+
+  async function remapRecommendations(client, keepAlbumId, deleteAlbumId) {
+    const conflictDeleteResult = await client.query(
+      `DELETE FROM recommendations retiring
+       USING recommendations canonical
+       WHERE retiring.album_id = $2
+         AND canonical.album_id = $1
+         AND canonical.year = retiring.year`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    const updateResult = await client.query(
+      `UPDATE recommendations
+       SET album_id = $1
+       WHERE album_id = $2`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    return {
+      recommendationsUpdated: updateResult.rowCount,
+      recommendationsConflictsRemoved: conflictDeleteResult.rowCount,
+    };
+  }
+
+  async function remapAlbumServiceMappings(client, keepAlbumId, deleteAlbumId) {
+    const conflictDeleteResult = await client.query(
+      `DELETE FROM album_service_mappings retiring
+       USING album_service_mappings canonical
+       WHERE retiring.album_id = $2
+         AND canonical.album_id = $1
+         AND canonical.service = retiring.service`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    const updateResult = await client.query(
+      `UPDATE album_service_mappings
+       SET album_id = $1,
+           updated_at = NOW()
+       WHERE album_id = $2`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    return {
+      albumMappingsUpdated: updateResult.rowCount,
+      albumMappingsConflictsRemoved: conflictDeleteResult.rowCount,
+    };
+  }
+
+  async function remapArtistAliasSources(client, keepAlbumId, deleteAlbumId) {
+    const updateResult = await client.query(
+      `UPDATE artist_service_aliases
+       SET source_album_id = $1,
+           updated_at = NOW()
+       WHERE source_album_id = $2`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    return {
+      artistAliasSourcesUpdated: updateResult.rowCount,
+    };
+  }
+
+  async function remapUserAlbumStats(client, keepAlbumId, deleteAlbumId) {
+    const updateResult = await client.query(
+      `UPDATE user_album_stats
+       SET album_id = $1,
+           updated_at = NOW()
+       WHERE album_id = $2`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    return {
+      userAlbumStatsUpdated: updateResult.rowCount,
+    };
+  }
+
+  async function remapDistinctPairs(client, keepAlbumId, deleteAlbumId) {
+    const insertResult = await client.query(
+      `WITH affected AS (
+         SELECT
+           CASE WHEN album_id_1 = $2 THEN $1 ELSE album_id_1 END AS id_1,
+           CASE WHEN album_id_2 = $2 THEN $1 ELSE album_id_2 END AS id_2,
+           created_by,
+           created_at
+         FROM album_distinct_pairs
+         WHERE album_id_1 = $2 OR album_id_2 = $2
+       ),
+       normalized AS (
+         SELECT
+           LEAST(id_1, id_2) AS album_id_1,
+           GREATEST(id_1, id_2) AS album_id_2,
+           created_by,
+           created_at
+         FROM affected
+         WHERE id_1 <> id_2
+       ),
+       inserted AS (
+         INSERT INTO album_distinct_pairs (
+           album_id_1,
+           album_id_2,
+           created_by,
+           created_at
+         )
+         SELECT album_id_1, album_id_2, created_by, created_at
+         FROM normalized
+         ON CONFLICT (album_id_1, album_id_2) DO NOTHING
+         RETURNING id
+       )
+       SELECT COUNT(*)::int AS inserted_count
+       FROM inserted`,
+      [keepAlbumId, deleteAlbumId]
+    );
+
+    const deleteResult = await client.query(
+      `DELETE FROM album_distinct_pairs
+       WHERE album_id_1 = $1 OR album_id_2 = $1`,
+      [deleteAlbumId]
+    );
+
+    return {
+      distinctPairsRemapped: toRowCount(insertResult.rows[0]?.inserted_count),
+      distinctPairsRemoved: deleteResult.rowCount,
+    };
+  }
+
+  async function remapDependentReferences(
+    client,
+    existingTables,
+    keepAlbumId,
+    deleteAlbumId
+  ) {
+    const stats = emptyDependentRemapStats();
+
+    if (existingTables.has('recommendations')) {
+      sumDependentRemapStats(
+        stats,
+        await remapRecommendations(client, keepAlbumId, deleteAlbumId)
+      );
+    }
+
+    if (existingTables.has('album_service_mappings')) {
+      sumDependentRemapStats(
+        stats,
+        await remapAlbumServiceMappings(client, keepAlbumId, deleteAlbumId)
+      );
+    }
+
+    if (existingTables.has('artist_service_aliases')) {
+      sumDependentRemapStats(
+        stats,
+        await remapArtistAliasSources(client, keepAlbumId, deleteAlbumId)
+      );
+    }
+
+    if (existingTables.has('user_album_stats')) {
+      sumDependentRemapStats(
+        stats,
+        await remapUserAlbumStats(client, keepAlbumId, deleteAlbumId)
+      );
+    }
+
+    if (existingTables.has('album_distinct_pairs')) {
+      sumDependentRemapStats(
+        stats,
+        await remapDistinctPairs(client, keepAlbumId, deleteAlbumId)
+      );
+    }
+
+    return stats;
+  }
+
   async function resolveListItemCollisions(client, keepAlbumId, deleteAlbumId) {
     const rowsResult = await client.query(
       `SELECT _id, list_id, album_id, position, comments, comments_2,
@@ -626,8 +862,14 @@ function createDuplicateService(deps = {}) {
   async function mergeAlbumsWithinTransaction(
     client,
     keepAlbumId,
-    deleteAlbumId
+    deleteAlbumId,
+    options = {}
   ) {
+    const mergeMetadata = options.mergeMetadata !== false;
+
+    await acquireMergeLocks(client, [keepAlbumId, deleteAlbumId]);
+    const existingTables = await getExistingDependentMergeTables(client);
+
     const albumsResult = await client.query(
       `SELECT album_id, artist, album, release_date, country,
               genre_1, genre_2, tracks, cover_image, cover_image_format,
@@ -647,8 +889,9 @@ function createDuplicateService(deps = {}) {
 
     let metadataMerged = false;
     let mergedFieldNames = [];
+    const dependentRemaps = emptyDependentRemapStats();
 
-    if (deleteAlbum) {
+    if (deleteAlbum && mergeMetadata) {
       const { fieldsToMerge, fieldNames, values } = buildMergeFields(
         keepAlbum,
         deleteAlbum
@@ -671,6 +914,18 @@ function createDuplicateService(deps = {}) {
       deleteAlbumId
     );
 
+    if (deleteAlbum) {
+      sumDependentRemapStats(
+        dependentRemaps,
+        await remapDependentReferences(
+          client,
+          existingTables,
+          keepAlbumId,
+          deleteAlbumId
+        )
+      );
+    }
+
     const updateResult = await client.query(
       `UPDATE list_items SET album_id = $1, updated_at = NOW() WHERE album_id = $2`,
       [keepAlbumId, deleteAlbumId]
@@ -678,11 +933,6 @@ function createDuplicateService(deps = {}) {
 
     const deleteResult = await client.query(
       `DELETE FROM albums WHERE album_id = $1`,
-      [deleteAlbumId]
-    );
-
-    await client.query(
-      `DELETE FROM album_distinct_pairs WHERE album_id_1 = $1 OR album_id_2 = $1`,
       [deleteAlbumId]
     );
 
@@ -697,6 +947,7 @@ function createDuplicateService(deps = {}) {
       mergedFieldCount: mergedFieldNames.length,
       collisionsResolved: collisionStats.collisionsResolved,
       collisionRowsDeleted: collisionStats.rowsDeleted,
+      dependentRemaps,
     });
 
     return {
@@ -706,6 +957,7 @@ function createDuplicateService(deps = {}) {
       mergedFieldNames,
       collisionsResolved: collisionStats.collisionsResolved,
       collisionRowsDeleted: collisionStats.rowsDeleted,
+      dependentRemaps,
     };
   }
 
@@ -733,6 +985,116 @@ function createDuplicateService(deps = {}) {
     }
 
     return cleaned;
+  }
+
+  function emptyDependentImpactPreview() {
+    return {
+      recommendationsRowsToUpdate: 0,
+      recommendationsConflictsToDrop: 0,
+      albumMappingRowsToUpdate: 0,
+      albumMappingConflictsToDrop: 0,
+      artistAliasSourcesToUpdate: 0,
+      userAlbumStatsRowsToUpdate: 0,
+      distinctPairsRowsToRewrite: 0,
+    };
+  }
+
+  async function previewDependentReferenceImpacts(
+    queryable,
+    existingTables,
+    canonicalAlbumId,
+    retireAlbumIds
+  ) {
+    const impacts = emptyDependentImpactPreview();
+
+    if (existingTables.has('recommendations')) {
+      const updateCountResult = await queryable.query(
+        `SELECT COUNT(*)::int AS count
+         FROM recommendations
+         WHERE album_id = ANY($1::text[])`,
+        [retireAlbumIds]
+      );
+      impacts.recommendationsRowsToUpdate = toRowCount(
+        updateCountResult.rows[0]?.count
+      );
+
+      const conflictCountResult = await queryable.query(
+        `SELECT COUNT(*)::int AS count
+         FROM recommendations retiring
+         JOIN recommendations canonical
+           ON canonical.year = retiring.year
+          AND canonical.album_id = $1
+         WHERE retiring.album_id = ANY($2::text[])`,
+        [canonicalAlbumId, retireAlbumIds]
+      );
+      impacts.recommendationsConflictsToDrop = toRowCount(
+        conflictCountResult.rows[0]?.count
+      );
+    }
+
+    if (existingTables.has('album_service_mappings')) {
+      const updateCountResult = await queryable.query(
+        `SELECT COUNT(*)::int AS count
+         FROM album_service_mappings
+         WHERE album_id = ANY($1::text[])`,
+        [retireAlbumIds]
+      );
+      impacts.albumMappingRowsToUpdate = toRowCount(
+        updateCountResult.rows[0]?.count
+      );
+
+      const conflictCountResult = await queryable.query(
+        `SELECT COUNT(*)::int AS count
+         FROM album_service_mappings retiring
+         JOIN album_service_mappings canonical
+           ON canonical.service = retiring.service
+          AND canonical.album_id = $1
+         WHERE retiring.album_id = ANY($2::text[])`,
+        [canonicalAlbumId, retireAlbumIds]
+      );
+      impacts.albumMappingConflictsToDrop = toRowCount(
+        conflictCountResult.rows[0]?.count
+      );
+    }
+
+    if (existingTables.has('artist_service_aliases')) {
+      const countResult = await queryable.query(
+        `SELECT COUNT(*)::int AS count
+         FROM artist_service_aliases
+         WHERE source_album_id = ANY($1::text[])`,
+        [retireAlbumIds]
+      );
+      impacts.artistAliasSourcesToUpdate = toRowCount(
+        countResult.rows[0]?.count
+      );
+    }
+
+    if (existingTables.has('user_album_stats')) {
+      const countResult = await queryable.query(
+        `SELECT COUNT(*)::int AS count
+         FROM user_album_stats
+         WHERE album_id = ANY($1::text[])`,
+        [retireAlbumIds]
+      );
+      impacts.userAlbumStatsRowsToUpdate = toRowCount(
+        countResult.rows[0]?.count
+      );
+    }
+
+    if (existingTables.has('album_distinct_pairs')) {
+      const countResult = await queryable.query(
+        `SELECT COUNT(*)::int AS count
+         FROM album_distinct_pairs
+         WHERE album_id_1 = ANY($1::text[])
+            OR album_id_2 = ANY($1::text[])`,
+        [retireAlbumIds]
+      );
+      impacts.distinctPairsRowsToRewrite = toRowCount(
+        countResult.rows[0]?.count
+      );
+    }
+
+    return impacts;
   }
 
   /**
@@ -915,7 +1277,7 @@ function createDuplicateService(deps = {}) {
    * @returns {Promise<Object>} merge result
    * @throws {TransactionAbort} on validation failure
    */
-  async function mergeAlbums(keepAlbumId, deleteAlbumId) {
+  async function mergeAlbums(keepAlbumId, deleteAlbumId, options = {}) {
     if (!keepAlbumId || !deleteAlbumId) {
       throw new TransactionAbort(400, {
         error: 'keepAlbumId and deleteAlbumId are required',
@@ -929,7 +1291,12 @@ function createDuplicateService(deps = {}) {
     }
 
     return withTransaction(pool, async (client) => {
-      return mergeAlbumsWithinTransaction(client, keepAlbumId, deleteAlbumId);
+      return mergeAlbumsWithinTransaction(
+        client,
+        keepAlbumId,
+        deleteAlbumId,
+        options
+      );
     });
   }
 
@@ -948,8 +1315,12 @@ function createDuplicateService(deps = {}) {
       });
     }
 
-    const retireIds = normalizeRetireAlbumIds(canonicalId, retireAlbumIds);
+    const retireIds = normalizeRetireAlbumIds(
+      canonicalId,
+      retireAlbumIds
+    ).sort();
     const allIds = [canonicalId, ...retireIds];
+    const existingTables = await getExistingDependentMergeTables(pool);
 
     const albumsResult = await pool.query(
       `SELECT album_id, artist, album, release_date, country,
@@ -1036,6 +1407,13 @@ function createDuplicateService(deps = {}) {
       );
     }
 
+    const dependentImpacts = await previewDependentReferenceImpacts(
+      pool,
+      existingTables,
+      canonicalId,
+      existingRetireIds
+    );
+
     return {
       canonicalAlbumId: canonicalId,
       retireAlbumIds: existingRetireIds,
@@ -1045,6 +1423,7 @@ function createDuplicateService(deps = {}) {
       collisionCount: collisions.length,
       collisions: collisions.slice(0, 100),
       metadataFieldsLikelyMerged: [...mergedFieldNames].sort(),
+      dependentImpacts,
     };
   }
 
@@ -1063,7 +1442,10 @@ function createDuplicateService(deps = {}) {
       });
     }
 
-    const retireIds = normalizeRetireAlbumIds(canonicalId, retireAlbumIds);
+    const retireIds = normalizeRetireAlbumIds(
+      canonicalId,
+      retireAlbumIds
+    ).sort();
 
     return withTransaction(pool, async (client) => {
       const aggregate = {
@@ -1077,6 +1459,7 @@ function createDuplicateService(deps = {}) {
         mergedFieldNames: new Set(),
         collisionsResolved: 0,
         collisionRowsDeleted: 0,
+        dependentRemaps: emptyDependentRemapStats(),
         results: [],
       };
 
@@ -1084,7 +1467,8 @@ function createDuplicateService(deps = {}) {
         const result = await mergeAlbumsWithinTransaction(
           client,
           canonicalId,
-          retireId
+          retireId,
+          { mergeMetadata: true }
         );
 
         aggregate.results.push({ retireAlbumId: retireId, ...result });
@@ -1092,6 +1476,10 @@ function createDuplicateService(deps = {}) {
         aggregate.albumsDeleted += result.albumsDeleted;
         aggregate.collisionsResolved += result.collisionsResolved;
         aggregate.collisionRowsDeleted += result.collisionRowsDeleted;
+        sumDependentRemapStats(
+          aggregate.dependentRemaps,
+          result.dependentRemaps || emptyDependentRemapStats()
+        );
 
         if (result.albumsDeleted > 0) {
           aggregate.mergedAlbums++;
@@ -1119,6 +1507,7 @@ function createDuplicateService(deps = {}) {
         mergedFieldNames: [...aggregate.mergedFieldNames].sort(),
         collisionsResolved: aggregate.collisionsResolved,
         collisionRowsDeleted: aggregate.collisionRowsDeleted,
+        dependentRemaps: aggregate.dependentRemaps,
         results: aggregate.results,
       };
     });

--- a/src/js/modules/duplicate-review-modal.js
+++ b/src/js/modules/duplicate-review-modal.js
@@ -391,6 +391,43 @@ function renderPreview(preview) {
   const panel = modalElement.querySelector('#clusterPreviewPanel');
   if (!panel) return;
 
+  const dependentImpacts = preview.dependentImpacts || {};
+  const dependentLines = [
+    {
+      label: 'Recommendations to update',
+      value: dependentImpacts.recommendationsRowsToUpdate,
+    },
+    {
+      label: 'Recommendation conflicts to drop',
+      value: dependentImpacts.recommendationsConflictsToDrop,
+    },
+    {
+      label: 'External mappings to update',
+      value: dependentImpacts.albumMappingRowsToUpdate,
+    },
+    {
+      label: 'Mapping conflicts to drop',
+      value: dependentImpacts.albumMappingConflictsToDrop,
+    },
+    {
+      label: 'Alias source refs to update',
+      value: dependentImpacts.artistAliasSourcesToUpdate,
+    },
+    {
+      label: 'User album stats to update',
+      value: dependentImpacts.userAlbumStatsRowsToUpdate,
+    },
+    {
+      label: 'Distinct pairs to rewrite',
+      value: dependentImpacts.distinctPairsRowsToRewrite,
+    },
+  ]
+    .filter((entry) => Number.isFinite(entry.value) && entry.value > 0)
+    .map((entry) => {
+      return `<div>${entry.label}: ${entry.value}</div>`;
+    })
+    .join('');
+
   panel.classList.remove('hidden');
   panel.innerHTML = `
     <div class="font-medium text-gray-100 mb-2">Dry-run impact</div>
@@ -404,6 +441,11 @@ function renderPreview(preview) {
             .join(', ')
         : 'none'
     }</div>
+    ${
+      dependentLines
+        ? `<div class="mt-2 text-gray-400">${dependentLines}</div>`
+        : ''
+    }
     ${
       preview.missingRetireAlbumIds?.length
         ? `<div class="mt-2 text-yellow-400">Already missing: ${preview.missingRetireAlbumIds.map((id) => escapeHtml(id)).join(', ')}</div>`
@@ -457,9 +499,22 @@ async function handleMergeCluster() {
     const fieldsSummary = Array.isArray(result.mergedFieldNames)
       ? result.mergedFieldNames.length
       : 0;
+    const remapSummary = result.dependentRemaps || {};
+    const totalDependentChanges = [
+      remapSummary.recommendationsUpdated,
+      remapSummary.recommendationsConflictsRemoved,
+      remapSummary.albumMappingsUpdated,
+      remapSummary.albumMappingsConflictsRemoved,
+      remapSummary.artistAliasSourcesUpdated,
+      remapSummary.userAlbumStatsUpdated,
+      remapSummary.distinctPairsRemapped,
+      remapSummary.distinctPairsRemoved,
+    ].reduce((sum, value) => {
+      return sum + (Number.isFinite(value) ? value : 0);
+    }, 0);
 
     showToast(
-      `Merged ${result.mergedAlbums} album variants, updated ${result.listItemsUpdated} list references${fieldsSummary ? `, ${fieldsSummary} metadata fields` : ''}`,
+      `Merged ${result.mergedAlbums} album variants, updated ${result.listItemsUpdated} list references${fieldsSummary ? `, ${fieldsSummary} metadata fields` : ''}${totalDependentChanges ? `, ${totalDependentChanges} dependent refs` : ''}`,
       'success'
     );
 

--- a/test/aggregate-audit.test.js
+++ b/test/aggregate-audit.test.js
@@ -693,7 +693,10 @@ describe('aggregate-audit', () => {
     it('should throw error when manual album ID is invalid', async () => {
       const pool = createMockPool([]);
       const logger = createMockLogger();
-      const audit = createAggregateAudit({ pool, logger });
+      const duplicateService = {
+        mergeAlbums: mock.fn(async () => ({ listItemsUpdated: 0 })),
+      };
+      const audit = createAggregateAudit({ pool, logger, duplicateService });
 
       await assert.rejects(
         async () => {
@@ -709,7 +712,10 @@ describe('aggregate-audit', () => {
         { rows: [] },
       ]);
       const logger = createMockLogger();
-      const audit = createAggregateAudit({ pool, logger });
+      const duplicateService = {
+        mergeAlbums: mock.fn(async () => ({ listItemsUpdated: 0 })),
+      };
+      const audit = createAggregateAudit({ pool, logger, duplicateService });
 
       await assert.rejects(
         async () => {
@@ -720,16 +726,10 @@ describe('aggregate-audit', () => {
     });
 
     it('should successfully merge manual album into canonical', async () => {
-      // Create a more sophisticated mock for this test
-      let queryIndex = 0;
       const queryResults = [
-        // Query 1: Check manual album exists
-        { rows: [{ count: '1' }] },
-        // Query 2: Check canonical album exists
-        { rows: [{ count: '1' }] },
-        // Query 3: Get canonical album metadata
+        // Query 1: Get canonical album metadata
         { rows: [{ artist: 'Radiohead', album: 'OK Computer' }] },
-        // Query 4: Get affected lists
+        // Query 2: Get affected lists
         {
           rows: [
             {
@@ -740,11 +740,7 @@ describe('aggregate-audit', () => {
             },
           ],
         },
-        // Query 5: Update list_items (UPDATE query)
-        { rowCount: 1 },
-        // Query 6: Delete manual album
-        { rowCount: 1 },
-        // Query 7: Insert admin event (returns the inserted event)
+        // Query 3: Insert admin event
         {
           rows: [
             {
@@ -756,20 +752,31 @@ describe('aggregate-audit', () => {
         },
       ];
 
-      const pool = {
-        query: mock.fn(async () => {
-          const result = queryResults[queryIndex] || { rows: [] };
-          queryIndex++;
-          return result;
-        }),
-        connect: mock.fn(async () => ({
-          query: mock.fn(async () => ({ rowCount: 1 })),
-          release: mock.fn(),
+      const pool = createMockPool(queryResults);
+
+      const duplicateService = {
+        mergeAlbums: mock.fn(async () => ({
+          listItemsUpdated: 1,
+          albumsDeleted: 1,
+          metadataMerged: true,
+          mergedFieldNames: ['artist', 'album'],
+          collisionsResolved: 0,
+          collisionRowsDeleted: 0,
+          dependentRemaps: {
+            recommendationsUpdated: 0,
+            recommendationsConflictsRemoved: 0,
+            albumMappingsUpdated: 0,
+            albumMappingsConflictsRemoved: 0,
+            artistAliasSourcesUpdated: 0,
+            userAlbumStatsUpdated: 0,
+            distinctPairsRemapped: 0,
+            distinctPairsRemoved: 0,
+          },
         })),
       };
 
       const logger = createMockLogger();
-      const audit = createAggregateAudit({ pool, logger });
+      const audit = createAggregateAudit({ pool, logger, duplicateService });
 
       const result = await audit.mergeManualAlbum(
         'manual-123',
@@ -783,6 +790,7 @@ describe('aggregate-audit', () => {
       assert.strictEqual(result.success, true);
       assert.strictEqual(result.updatedListItems, 1);
       assert.ok(result.affectedLists.length > 0);
+      assert.strictEqual(duplicateService.mergeAlbums.mock.calls.length, 1);
     });
   });
 });

--- a/test/duplicate-service.test.js
+++ b/test/duplicate-service.test.js
@@ -365,4 +365,255 @@ describe('duplicate-service', () => {
     assert.ok(updates.length >= 1);
     assert.ok(deletions.length >= 1);
   });
+
+  it('mergeAlbums should remap dependent references safely', async () => {
+    const client = {
+      query: async (sql) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('pg_advisory_xact_lock')) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('FROM pg_tables')) {
+          return {
+            rows: [
+              { tablename: 'recommendations' },
+              { tablename: 'album_service_mappings' },
+              { tablename: 'artist_service_aliases' },
+              { tablename: 'user_album_stats' },
+              { tablename: 'album_distinct_pairs' },
+            ],
+            rowCount: 5,
+          };
+        }
+
+        if (sql.includes('ORDER BY album_id') && sql.includes('FOR UPDATE')) {
+          return { rows: [{ album_id: 'del1' }, { album_id: 'keep1' }] };
+        }
+
+        if (sql.includes('FROM albums WHERE album_id = $1 OR album_id = $2')) {
+          return {
+            rows: [
+              {
+                album_id: 'keep1',
+                artist: 'Artist',
+                album: 'Canonical Album',
+                release_date: '2020-01-01',
+                country: 'US',
+                genre_1: 'Rock',
+                genre_2: null,
+                tracks: null,
+                cover_image: null,
+                cover_image_format: null,
+                summary: null,
+                summary_source: null,
+                summary_fetched_at: null,
+              },
+              {
+                album_id: 'del1',
+                artist: 'Artist',
+                album: 'Album',
+                release_date: '2020-01-01',
+                country: 'US',
+                genre_1: 'Rock',
+                genre_2: null,
+                tracks: null,
+                cover_image: null,
+                cover_image_format: null,
+                summary: null,
+                summary_source: null,
+                summary_fetched_at: null,
+              },
+            ],
+            rowCount: 2,
+          };
+        }
+
+        if (
+          sql.includes('FROM list_items') &&
+          sql.includes('ORDER BY list_id')
+        ) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('DELETE FROM recommendations retiring')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        if (sql.includes('UPDATE recommendations')) {
+          return { rows: [], rowCount: 2 };
+        }
+
+        if (sql.includes('DELETE FROM album_service_mappings retiring')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        if (sql.includes('UPDATE album_service_mappings')) {
+          return { rows: [], rowCount: 3 };
+        }
+
+        if (sql.includes('UPDATE artist_service_aliases')) {
+          return { rows: [], rowCount: 4 };
+        }
+
+        if (sql.includes('UPDATE user_album_stats')) {
+          return { rows: [], rowCount: 5 };
+        }
+
+        if (sql.includes('WITH affected AS')) {
+          return { rows: [{ inserted_count: 2 }], rowCount: 1 };
+        }
+
+        if (
+          sql.includes('DELETE FROM album_distinct_pairs') &&
+          sql.includes('album_id_1 = $1 OR album_id_2 = $1')
+        ) {
+          return { rows: [], rowCount: 2 };
+        }
+
+        if (
+          sql.includes(
+            'UPDATE list_items SET album_id = $1, updated_at = NOW() WHERE album_id = $2'
+          )
+        ) {
+          return { rows: [], rowCount: 6 };
+        }
+
+        if (sql.includes('DELETE FROM albums WHERE album_id = $1')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        return { rows: [], rowCount: 0 };
+      },
+      release: mock.fn(),
+    };
+
+    const pool = {
+      connect: mock.fn(async () => client),
+      query: mock.fn(async () => ({ rows: [], rowCount: 0 })),
+    };
+
+    const service = createDuplicateService({
+      pool,
+      logger: createMockLogger(),
+    });
+
+    const result = await service.mergeAlbums('keep1', 'del1');
+
+    assert.strictEqual(result.dependentRemaps.recommendationsUpdated, 2);
+    assert.strictEqual(
+      result.dependentRemaps.recommendationsConflictsRemoved,
+      1
+    );
+    assert.strictEqual(result.dependentRemaps.albumMappingsUpdated, 3);
+    assert.strictEqual(result.dependentRemaps.albumMappingsConflictsRemoved, 1);
+    assert.strictEqual(result.dependentRemaps.artistAliasSourcesUpdated, 4);
+    assert.strictEqual(result.dependentRemaps.userAlbumStatsUpdated, 5);
+    assert.strictEqual(result.dependentRemaps.distinctPairsRemapped, 2);
+    assert.strictEqual(result.dependentRemaps.distinctPairsRemoved, 2);
+  });
+
+  it('mergeAlbums should allow metadata merge to be skipped', async () => {
+    const callLog = [];
+
+    const client = {
+      query: async (sql) => {
+        callLog.push(sql);
+
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('pg_advisory_xact_lock')) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('FROM pg_tables')) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('ORDER BY album_id') && sql.includes('FOR UPDATE')) {
+          return { rows: [] };
+        }
+
+        if (sql.includes('FROM albums WHERE album_id = $1 OR album_id = $2')) {
+          return {
+            rows: [
+              {
+                album_id: 'keep1',
+                artist: 'Artist',
+                album: 'Album',
+                release_date: null,
+                country: null,
+                genre_1: null,
+                genre_2: null,
+                tracks: null,
+                cover_image: null,
+                cover_image_format: null,
+                summary: null,
+                summary_source: null,
+                summary_fetched_at: null,
+              },
+              {
+                album_id: 'del1',
+                artist: 'Artist (Deluxe Edition)',
+                album: 'Album (Deluxe Edition)',
+                release_date: '2024-01-01',
+                country: 'US',
+                genre_1: 'Rock',
+                genre_2: 'Alt',
+                tracks: null,
+                cover_image: null,
+                cover_image_format: null,
+                summary: 'Long summary',
+                summary_source: 'test',
+                summary_fetched_at: null,
+              },
+            ],
+          };
+        }
+
+        if (
+          sql.includes('FROM list_items') &&
+          sql.includes('ORDER BY list_id')
+        ) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        if (sql.includes('UPDATE list_items SET album_id')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        if (sql.includes('DELETE FROM albums WHERE album_id = $1')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        return { rows: [], rowCount: 0 };
+      },
+      release: mock.fn(),
+    };
+
+    const pool = {
+      connect: mock.fn(async () => client),
+      query: mock.fn(async () => ({ rows: [], rowCount: 0 })),
+    };
+
+    const service = createDuplicateService({
+      pool,
+      logger: createMockLogger(),
+    });
+
+    const result = await service.mergeAlbums('keep1', 'del1', {
+      mergeMetadata: false,
+    });
+
+    assert.strictEqual(result.metadataMerged, false);
+    const hasMetadataUpdate = callLog.some((sql) =>
+      sql.includes('UPDATE albums SET')
+    );
+    assert.strictEqual(hasMetadataUpdate, false);
+  });
 });


### PR DESCRIPTION
## Summary
- unify manual album reconciliation with the duplicate merge engine so all admin merge paths use the same transactional merge workflow
- remap dependent album references (`recommendations`, `album_service_mappings`, `artist_service_aliases`, `user_album_stats`, and `album_distinct_pairs`) before album deletion, add merge locking, and expose dependent-impact stats in dry-run and merge responses/UI
- add migration `057_add_album_reference_foreign_keys` to clean existing orphan album references and enforce foreign keys for `list_items.album_id` and `album_distinct_pairs` album IDs

## Testing
- npm run lint:strict
- npm run build
- node --test test/duplicate-service.test.js
- node --test test/aggregate-audit.test.js
- node --test test/admin-routes.test.js
- node --test test/settings-audit-handlers.test.js