### PR TITLE
Phase 1: Preserve root-cause errors in withTransaction

### DIFF
--- a/db/transaction.js
+++ b/db/transaction.js
@@ -24,6 +24,8 @@
  *   }
  */
 
+const logger = require('../utils/logger');
+
 /**
  * Lightweight class for expected transaction failures (validation errors, not-found, etc.)
  * Throwing this inside withTransaction() will trigger ROLLBACK and propagate
@@ -46,6 +48,10 @@ class TransactionAbort {
  * and COMMITs on success. On any error (including TransactionAbort),
  * it ROLLBACKs and re-throws. The client is always released.
  *
+ * If ROLLBACK itself fails, the original error is still thrown — the
+ * rollback failure is logged and the client is released with the error
+ * so pg discards it rather than returning a poisoned connection to the pool.
+ *
  * @param {import('pg').Pool} pool - PostgreSQL connection pool
  * @param {function(import('pg').PoolClient): Promise<*>} callback - Async function receiving the transaction client
  * @returns {Promise<*>} - The return value of the callback
@@ -54,16 +60,27 @@ class TransactionAbort {
  */
 async function withTransaction(pool, callback) {
   const client = await pool.connect();
+  let releaseError;
   try {
     await client.query('BEGIN');
     const result = await callback(client);
     await client.query('COMMIT');
     return result;
   } catch (err) {
-    await client.query('ROLLBACK');
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackErr) {
+      releaseError = rollbackErr;
+      logger.error('ROLLBACK failed after transaction error', {
+        originalError: err?.message,
+        originalCode: err?.code,
+        rollbackError: rollbackErr?.message,
+        rollbackCode: rollbackErr?.code,
+      });
+    }
     throw err;
   } finally {
-    client.release();
+    client.release(releaseError);
   }
 }
 

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -187,5 +187,117 @@ test('Transaction Utilities', async (t) => {
         assert.strictEqual(calls[3].arguments[0], 'COMMIT');
       }
     );
+
+    // ============================================
+    // ROLLBACK failure preservation
+    // ============================================
+
+    await t.test(
+      'should preserve original error when ROLLBACK itself fails',
+      async () => {
+        // Build a mock where BEGIN succeeds, ROLLBACK fails.
+        const mockClient = {
+          query: mock.fn(async (sql) => {
+            if (sql === 'ROLLBACK') {
+              const rollbackErr = new Error('connection terminated');
+              rollbackErr.code = '08006';
+              throw rollbackErr;
+            }
+            return { rows: [], rowCount: 0 };
+          }),
+          release: mock.fn(),
+        };
+        const mockPool = { connect: mock.fn(async () => mockClient) };
+        const originalError = new Error('business logic failed');
+        originalError.code = 'CUSTOM_BUSINESS_ERROR';
+
+        await assert.rejects(
+          () =>
+            withTransaction(mockPool, async () => {
+              throw originalError;
+            }),
+          (err) => {
+            // MUST be the original error, not the rollback error
+            assert.strictEqual(err, originalError);
+            assert.strictEqual(err.code, 'CUSTOM_BUSINESS_ERROR');
+            return true;
+          }
+        );
+
+        // Confirm ROLLBACK was actually attempted
+        const calls = mockClient.query.mock.calls;
+        assert.strictEqual(calls[0].arguments[0], 'BEGIN');
+        assert.strictEqual(calls[1].arguments[0], 'ROLLBACK');
+      }
+    );
+
+    await t.test(
+      'should release client with the rollback error so pg discards the connection',
+      async () => {
+        const mockClient = {
+          query: mock.fn(async (sql) => {
+            if (sql === 'ROLLBACK') {
+              const rollbackErr = new Error('connection terminated');
+              rollbackErr.code = '08006';
+              throw rollbackErr;
+            }
+            return { rows: [], rowCount: 0 };
+          }),
+          release: mock.fn(),
+        };
+        const mockPool = { connect: mock.fn(async () => mockClient) };
+
+        await assert.rejects(() =>
+          withTransaction(mockPool, async () => {
+            throw new Error('anything');
+          })
+        );
+
+        // release() must be called exactly once, with the rollback error
+        // as its argument — this tells pg the connection is poisoned.
+        assert.strictEqual(mockClient.release.mock.calls.length, 1);
+        const releaseArg = mockClient.release.mock.calls[0].arguments[0];
+        assert.ok(
+          releaseArg instanceof Error,
+          'release should receive the rollback error'
+        );
+        assert.strictEqual(releaseArg.code, '08006');
+      }
+    );
+
+    await t.test(
+      'should release client without error when ROLLBACK succeeds',
+      async () => {
+        const { mockPool, mockClient } = createMockPool();
+
+        await assert.rejects(() =>
+          withTransaction(mockPool, async () => {
+            throw new Error('business error');
+          })
+        );
+
+        // release() called with undefined (no error) since ROLLBACK succeeded
+        assert.strictEqual(mockClient.release.mock.calls.length, 1);
+        assert.strictEqual(
+          mockClient.release.mock.calls[0].arguments[0],
+          undefined
+        );
+      }
+    );
+
+    await t.test(
+      'should release client without error on happy path (COMMIT success)',
+      async () => {
+        const { mockPool, mockClient } = createMockPool();
+
+        await withTransaction(mockPool, async () => 'ok');
+
+        assert.strictEqual(mockClient.release.mock.calls.length, 1);
+        assert.strictEqual(
+          mockClient.release.mock.calls[0].arguments[0],
+          undefined
+        );
+      }
+    );
   });
 });


### PR DESCRIPTION
## Summary

Part 1 of the DB layer unification plan. Fixes a subtle bug in [db/transaction.js](db/transaction.js) where a failing ROLLBACK would mask the original business error.

- When ROLLBACK itself throws, the original error is still re-thrown (the rollback failure is logged separately).
- The poisoned pg client is released with the rollback error as argument, so pg discards the connection rather than returning it to the pool.

No behavior change for the happy path or for cases where ROLLBACK succeeds.

## Test plan

- [x] All existing 10 transaction test cases still pass unchanged.
- [x] New: ROLLBACK throws → original business error surfaces to caller.
- [x] New: ROLLBACK throws → `client.release(err)` is called with the rollback error.
- [x] New: ROLLBACK succeeds after callback error → `client.release()` called without error argument.
- [x] New: happy path → `client.release()` called without error argument.
- [x] Full unit suite: 2506 pass / 0 fail (baseline was 2502, +4 net new tests).
- [x] `eslint` clean, `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)