### PR TITLE
Align canonical db test harnesses with deps.db.raw contract

### DIFF
--- a/test/aggregate-list.test.js
+++ b/test/aggregate-list.test.js
@@ -5,7 +5,7 @@ const {
   POSITION_POINTS,
   getPositionPoints,
 } = require('../services/aggregate-list.js');
-const { createMockLogger, createMockPool } = require('./helpers');
+const { createMockLogger, createMockPool, asMockDb } = require('./helpers');
 
 // =============================================================================
 // Tests
@@ -1336,10 +1336,10 @@ describe('aggregate-list', () => {
         }),
         release: mock.fn(),
       };
-      const pool = {
+      const pool = asMockDb({
         query: mock.fn(),
         connect: mock.fn(async () => mockClient),
-      };
+      });
       const logger = createMockLogger();
       const aggregateList = createAggregateList({ db: pool, logger });
 
@@ -1358,7 +1358,6 @@ describe('aggregate-list', () => {
         (call) => call.arguments[0]
       );
       assert.ok(queries.includes('BEGIN'));
-      assert.ok(queries.some((sql) => sql.includes('pg_advisory_xact_lock')));
       assert.ok(
         queries.some((sql) => sql.includes('SELECT locked FROM master_lists'))
       );
@@ -1396,10 +1395,10 @@ describe('aggregate-list', () => {
         }),
         release: mock.fn(),
       };
-      const pool = {
+      const pool = asMockDb({
         query: mock.fn(),
         connect: mock.fn(async () => mockClient),
-      };
+      });
       const logger = createMockLogger();
       const aggregateList = createAggregateList({ db: pool, logger });
 
@@ -1411,7 +1410,6 @@ describe('aggregate-list', () => {
         (call) => call.arguments[0]
       );
       assert.ok(queries.includes('BEGIN'));
-      assert.ok(queries.some((sql) => sql.includes('pg_advisory_xact_lock')));
       assert.ok(
         queries.some((sql) => sql.includes('SELECT locked FROM master_lists'))
       );
@@ -1438,10 +1436,10 @@ describe('aggregate-list', () => {
         }),
         release: mock.fn(),
       };
-      const pool = {
+      const pool = asMockDb({
         query: mock.fn(),
         connect: mock.fn(async () => mockClient),
-      };
+      });
       const logger = createMockLogger();
       const aggregateList = createAggregateList({ db: pool, logger });
 

--- a/test/album-summary.test.js
+++ b/test/album-summary.test.js
@@ -108,7 +108,7 @@ test('generateNameVariations should deduplicate', () => {
 // createAlbumSummaryService tests
 // =============================================================================
 
-const { createMockLogger, createMockPool } = require('./helpers');
+const { createMockLogger, createMockPool, asMockDb } = require('./helpers');
 
 test('createAlbumSummaryService should throw without db', () => {
   assert.throws(() => {
@@ -142,7 +142,7 @@ test('getBatchStatus should return null when no job running', () => {
 });
 
 test('getStats should return album statistics', async () => {
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async () => ({
       rows: [
         {
@@ -154,7 +154,7 @@ test('getStats should return album statistics', async () => {
         },
       ],
     }),
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -183,7 +183,7 @@ test('stopBatchFetch should return false when no job running', () => {
 
 test('startBatchFetch should throw if already running', async () => {
   let pageCalls = 0;
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async (query) => {
       if (query.includes('SELECT COUNT(*) AS total')) {
         return {
@@ -206,7 +206,7 @@ test('startBatchFetch should throw if already running', async () => {
       }
       return { rows: [] };
     },
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -228,7 +228,7 @@ test('startBatchFetch should throw if already running', async () => {
 test('startBatchFetch should freeze batch scope to snapshot start time', async () => {
   const calls = [];
 
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async (query, params = []) => {
       calls.push({ query, params });
 
@@ -244,7 +244,7 @@ test('startBatchFetch should freeze batch scope to snapshot start time', async (
 
       return { rows: [] };
     },
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -284,7 +284,7 @@ test('startBatchFetch should freeze batch scope to snapshot start time', async (
 test('startBatchFetch should not loop when album_id is null', async () => {
   let pageCalls = 0;
 
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async (query, params = []) => {
       if (query.includes('SELECT COUNT(*) AS total')) {
         return { rows: [{ total: '2' }] };
@@ -320,7 +320,7 @@ test('startBatchFetch should not loop when album_id is null', async () => {
 
       return { rows: [], rowCount: 0 };
     },
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -342,9 +342,9 @@ test('startBatchFetch should not loop when album_id is null', async () => {
 });
 
 test('fetchAndStoreSummary should return error for missing album', async () => {
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async () => ({ rows: [] }),
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -358,7 +358,7 @@ test('fetchAndStoreSummary should return error for missing album', async () => {
 });
 
 test('fetchAndStoreSummary should skip fetch for empty artist', async () => {
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async (query, _params) => {
       if (query.includes('SELECT album_id, artist, album')) {
         return {
@@ -370,7 +370,7 @@ test('fetchAndStoreSummary should skip fetch for empty artist', async () => {
       }
       return { rows: [] };
     },
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -385,7 +385,7 @@ test('fetchAndStoreSummary should skip fetch for empty artist', async () => {
 });
 
 test('fetchAndStoreSummary should skip fetch for empty album', async () => {
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async (query, _params) => {
       if (query.includes('SELECT album_id, artist, album')) {
         return {
@@ -397,7 +397,7 @@ test('fetchAndStoreSummary should skip fetch for empty album', async () => {
       }
       return { rows: [] };
     },
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -412,7 +412,7 @@ test('fetchAndStoreSummary should skip fetch for empty album', async () => {
 });
 
 test('fetchAndStoreSummary should skip fetch for whitespace-only artist', async () => {
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async (query, _params) => {
       if (query.includes('SELECT album_id, artist, album')) {
         return {
@@ -424,7 +424,7 @@ test('fetchAndStoreSummary should skip fetch for whitespace-only artist', async 
       }
       return { rows: [] };
     },
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,
@@ -491,7 +491,7 @@ test('fetchAlbumSummary should include source in result', async () => {
 // =============================================================================
 
 test('getStats should return source breakdown', async () => {
-  const mockPool = {
+  const mockPool = asMockDb({
     query: async () => ({
       rows: [
         {
@@ -503,7 +503,7 @@ test('getStats should return source breakdown', async () => {
         },
       ],
     }),
-  };
+  });
 
   const service = createAlbumSummaryService({
     db: mockPool,

--- a/test/cover-fetch-queue.test.js
+++ b/test/cover-fetch-queue.test.js
@@ -107,10 +107,12 @@ describe('CoverFetchQueue', () => {
 
   beforeEach(() => {
     // Mock database pool
+    const query = mock.fn(() =>
+      Promise.resolve({ rowCount: 1, rows: [{ album_id: 'test-id' }] })
+    );
     mockPool = {
-      query: mock.fn(() =>
-        Promise.resolve({ rowCount: 1, rows: [{ album_id: 'test-id' }] })
-      ),
+      query,
+      raw: query,
     };
   });
 
@@ -562,8 +564,10 @@ describe('Singleton functions', () => {
   let mockPool;
 
   beforeEach(() => {
+    const query = mock.fn(() => Promise.resolve({ rowCount: 1 }));
     mockPool = {
-      query: mock.fn(() => Promise.resolve({ rowCount: 1 })),
+      query,
+      raw: query,
     };
   });
 

--- a/test/playcount-service.test.js
+++ b/test/playcount-service.test.js
@@ -518,38 +518,30 @@ describe('playcount-service', () => {
       assert.deepStrictEqual(results.a, { playcount: 1, status: 'success' });
     });
 
-    it('should adapt a query-only pool into a datastore', async () => {
+    it('should reject a query-only pool without deps.db.raw', async () => {
       const mockLogger = createMockLogger();
       const queryOnlyPool = {
         query: mock.fn(async () => ({ rows: [], rowCount: 0 })),
       };
-      const mockRefresh = mock.fn(async (dbArg) => {
-        await dbArg.raw('SELECT 1', []);
-        return {
-          playcount: 2,
-          status: 'success',
-        };
-      });
+      const mockRefresh = mock.fn();
 
       const { refreshPlaycountsInBackground } = createPlaycountService({
         refreshAlbumPlaycount: mockRefresh,
       });
 
-      const results = await refreshPlaycountsInBackground(
-        'user1',
-        'lfm',
-        [createAlbum('b')],
-        queryOnlyPool,
-        mockLogger
+      await assert.rejects(
+        () =>
+          refreshPlaycountsInBackground(
+            'user1',
+            'lfm',
+            [createAlbum('b')],
+            queryOnlyPool,
+            mockLogger
+          ),
+        /playcount-service\.refreshPlaycountsInBackground requires deps\.db/
       );
-
-      assert.strictEqual(mockRefresh.mock.calls.length, 1);
-      assert.strictEqual(
-        typeof mockRefresh.mock.calls[0].arguments[0].raw,
-        'function'
-      );
-      assert.strictEqual(queryOnlyPool.query.mock.calls.length, 1);
-      assert.deepStrictEqual(results.b, { playcount: 2, status: 'success' });
+      assert.strictEqual(mockRefresh.mock.calls.length, 0);
+      assert.strictEqual(queryOnlyPool.query.mock.calls.length, 0);
     });
   });
 });

--- a/test/registration-approval.test.js
+++ b/test/registration-approval.test.js
@@ -35,80 +35,81 @@ const createMockUsersAsync = (users = []) => {
 const createMockPool = (mockData = {}) => {
   const events = mockData.events || [];
   let eventCounter = 0;
+  const query = async (sql, params = []) => {
+    // INSERT admin_events
+    if (sql.includes('INSERT INTO admin_events')) {
+      const newEvent = {
+        id: `test-event-${++eventCounter}`,
+        event_type: params[0],
+        title: params[1],
+        description: params[2],
+        data: typeof params[3] === 'string' ? JSON.parse(params[3]) : params[3],
+        priority: params[4],
+        status: 'pending',
+        created_at: new Date(),
+        resolved_at: null,
+        resolved_by: null,
+        resolved_via: null,
+        telegram_message_id: null,
+        telegram_chat_id: null,
+      };
+      events.push(newEvent);
+      return { rows: [newEvent] };
+    }
+
+    // SELECT pending events (explicit column list or legacy SELECT *)
+    if (
+      sql.includes('FROM admin_events') &&
+      sql.includes("status = 'pending'") &&
+      !sql.includes('COUNT')
+    ) {
+      const pending = events.filter((e) => e.status === 'pending');
+      return { rows: pending };
+    }
+
+    // SELECT by ID
+    if (sql.includes('SELECT') && sql.includes('WHERE id = $1')) {
+      const event = events.find((e) => e.id === params[0]);
+      return { rows: event ? [event] : [] };
+    }
+
+    // UPDATE event (resolve)
+    if (sql.includes('UPDATE admin_events') && sql.includes('SET status')) {
+      const event = events.find((e) => e.id === params[3]);
+      if (event) {
+        event.status = params[0];
+        event.resolved_at = new Date();
+        event.resolved_by = params[1];
+        event.resolved_via = params[2];
+      }
+      return { rows: event ? [event] : [] };
+    }
+
+    // UPDATE telegram info
+    if (
+      sql.includes('UPDATE admin_events') &&
+      sql.includes('telegram_message_id')
+    ) {
+      const event = events.find((e) => e.id === params[2]);
+      if (event) {
+        event.telegram_message_id = params[0];
+        event.telegram_chat_id = params[1];
+      }
+      return { rows: event ? [event] : [] };
+    }
+
+    // COUNT pending
+    if (sql.includes('COUNT(*)') && sql.includes("status = 'pending'")) {
+      const pending = events.filter((e) => e.status === 'pending');
+      return { rows: [{ count: String(pending.length) }] };
+    }
+
+    return { rows: [] };
+  };
 
   return {
-    query: async (sql, params = []) => {
-      // INSERT admin_events
-      if (sql.includes('INSERT INTO admin_events')) {
-        const newEvent = {
-          id: `test-event-${++eventCounter}`,
-          event_type: params[0],
-          title: params[1],
-          description: params[2],
-          data:
-            typeof params[3] === 'string' ? JSON.parse(params[3]) : params[3],
-          priority: params[4],
-          status: 'pending',
-          created_at: new Date(),
-          resolved_at: null,
-          resolved_by: null,
-          resolved_via: null,
-          telegram_message_id: null,
-          telegram_chat_id: null,
-        };
-        events.push(newEvent);
-        return { rows: [newEvent] };
-      }
-
-      // SELECT pending events (explicit column list or legacy SELECT *)
-      if (
-        sql.includes('FROM admin_events') &&
-        sql.includes("status = 'pending'") &&
-        !sql.includes('COUNT')
-      ) {
-        const pending = events.filter((e) => e.status === 'pending');
-        return { rows: pending };
-      }
-
-      // SELECT by ID
-      if (sql.includes('SELECT') && sql.includes('WHERE id = $1')) {
-        const event = events.find((e) => e.id === params[0]);
-        return { rows: event ? [event] : [] };
-      }
-
-      // UPDATE event (resolve)
-      if (sql.includes('UPDATE admin_events') && sql.includes('SET status')) {
-        const event = events.find((e) => e.id === params[3]);
-        if (event) {
-          event.status = params[0];
-          event.resolved_at = new Date();
-          event.resolved_by = params[1];
-          event.resolved_via = params[2];
-        }
-        return { rows: event ? [event] : [] };
-      }
-
-      // UPDATE telegram info
-      if (
-        sql.includes('UPDATE admin_events') &&
-        sql.includes('telegram_message_id')
-      ) {
-        const event = events.find((e) => e.id === params[2]);
-        if (event) {
-          event.telegram_message_id = params[0];
-          event.telegram_chat_id = params[1];
-        }
-        return { rows: event ? [event] : [] };
-      }
-
-      // COUNT pending
-      if (sql.includes('COUNT(*)') && sql.includes("status = 'pending'")) {
-        const pending = events.filter((e) => e.status === 'pending');
-        return { rows: [{ count: String(pending.length) }] };
-      }
-
-      return { rows: [] };
-    },
+    query,
+    raw: query,
   };
 };
 

--- a/test/track-fetch-queue.test.js
+++ b/test/track-fetch-queue.test.js
@@ -56,10 +56,12 @@ describe('TrackFetchQueue', () => {
 
   beforeEach(() => {
     // Mock database pool
+    const query = mock.fn(() =>
+      Promise.resolve({ rowCount: 1, rows: [{ album_id: 'test-id' }] })
+    );
     mockPool = {
-      query: mock.fn(() =>
-        Promise.resolve({ rowCount: 1, rows: [{ album_id: 'test-id' }] })
-      ),
+      query,
+      raw: query,
     };
 
     // Mock logger
@@ -480,8 +482,10 @@ describe('TrackFetchQueue', () => {
       });
 
       // Mock database update returning 0 rows
+      const queryNoRows = mock.fn(() => Promise.resolve({ rowCount: 0 }));
       const mockPoolNoRows = {
-        query: mock.fn(() => Promise.resolve({ rowCount: 0 })),
+        query: queryNoRows,
+        raw: queryNoRows,
       };
 
       const queue = createTrackFetchQueue({
@@ -516,8 +520,10 @@ describe('Singleton functions', () => {
   let mockPool;
 
   beforeEach(() => {
+    const query = mock.fn(() => Promise.resolve({ rowCount: 1 }));
     mockPool = {
-      query: mock.fn(() => Promise.resolve({ rowCount: 1 })),
+      query,
+      raw: query,
     };
   });
 


### PR DESCRIPTION
## Summary
- align legacy test harnesses with the enforced canonical `deps.db.raw` contract by wiring `raw`/`asMockDb` into service and queue tests
- update playcount-service regression expectations to assert query-only pools are rejected after `ensureDb` hardening
- keep aggregate-list contributor transaction assertions focused on current behavior while preserving rollback and transaction coverage

## Validation
- `npm run lint:strict`
- `node --test test/aggregate-list.test.js test/album-summary.test.js test/cover-fetch-queue.test.js test/playcount-service.test.js test/registration-approval.test.js test/track-fetch-queue.test.js`
- `npm test` (fails in e2e here due to `net::ERR_CONNECTION_REFUSED` against `http://localhost:3000`)