### PR TITLE
Finalize DB modernization consistency sweep

### DIFF
--- a/DB_MODERNIZATION_PLAN.tmp.txt
+++ b/DB_MODERNIZATION_PLAN.tmp.txt
@@ -82,9 +82,9 @@ Commit Log
 - 0c9533b: Moved DB-backed track fetch queue from `utils/` to `services/`
   and updated startup/API helper imports to remove the remaining
   utility-layer datastore seam.
-- in progress: Move DB-backed album canonical module from `utils/` to
-  `services/`, tighten it to canonical `deps.db` contract via `ensureDb`, and
-  extend factory-compat coverage for the new service path.
+- 86f4991: Moved DB-backed album canonical module from `utils/` to
+  `services/`, tightened it to canonical `deps.db` contract via `ensureDb`, and
+  extended factory-compat coverage for the new service path.
 
 Legend
 - [ ] pending

--- a/DB_MODERNIZATION_PLAN.tmp.txt
+++ b/DB_MODERNIZATION_PLAN.tmp.txt
@@ -17,7 +17,7 @@ Global Constraints
 Phases
 [x] P0 Freeze contract and add guardrails
 [x] P1 Split DB engine room responsibilities
-[~] P2 Extract repositories and move table/domain SQL
+[x] P2 Extract repositories and move table/domain SQL
 [x] P3 Centralize schema and row mapping
 [x] P4 Migrate auth/user stack to canonical surface
 [x] P5 Remove DB access from routes/middleware
@@ -25,7 +25,7 @@ Phases
 [x] P7 Clean composition root and dependency surface
 [x] P8 Standardize test harness on canonical DB contract
 [x] P9 Remove compatibility layers and dead code
-[~] P10 Final consistency sweep
+[x] P10 Final consistency sweep
 
 Execution Notes
 - Work in small, safe commits.
@@ -82,6 +82,9 @@ Commit Log
 - 0c9533b: Moved DB-backed track fetch queue from `utils/` to `services/`
   and updated startup/API helper imports to remove the remaining
   utility-layer datastore seam.
+- in progress: Move DB-backed album canonical module from `utils/` to
+  `services/`, tighten it to canonical `deps.db` contract via `ensureDb`, and
+  extend factory-compat coverage for the new service path.
 
 Legend
 - [ ] pending

--- a/routes/api/_helpers.js
+++ b/routes/api/_helpers.js
@@ -6,7 +6,7 @@
 
 // Import shared utilities
 const { createAggregateList } = require('../../services/aggregate-list');
-const { createAlbumCanonical } = require('../../utils/album-canonical');
+const { createAlbumCanonical } = require('../../services/album-canonical');
 const {
   LOCK_NAMESPACES,
   acquireTransactionLocks,

--- a/services/album-canonical.js
+++ b/services/album-canonical.js
@@ -1,5 +1,5 @@
 /**
- * Album Canonical Utilities
+ * Album Canonical Service
  *
  * Handles canonical album deduplication by ensuring only ONE entry per unique
  * artist/album combination exists in the albums table, regardless of the source
@@ -15,9 +15,13 @@
  */
 
 const crypto = require('crypto');
-const logger = require('./logger');
-const { resolveCountryCode } = require('./musicbrainz');
-const { sanitizeForStorage, normalizeForLookup } = require('./normalization');
+const logger = require('../utils/logger');
+const { resolveCountryCode } = require('../utils/musicbrainz');
+const {
+  sanitizeForStorage,
+  normalizeForLookup,
+} = require('../utils/normalization');
+const { ensureDb } = require('../db/postgres');
 
 /**
  * Generate a stable internal album ID for manually added albums
@@ -112,18 +116,8 @@ function chooseBetterTracks(existing, newTracks) {
 // eslint-disable-next-line max-lines-per-function -- Cohesive utility module with multiple related functions
 function createAlbumCanonical(deps = {}) {
   const log = deps.logger || logger;
-  const dbStore = deps.db;
-  if (!dbStore) {
-    throw new Error('album-canonical requires deps.db');
-  }
-
-  // Inner functions follow `const db = client || pool` and call `.query(...)`.
-  // Accept either the canonical datastore (with .raw) or a pg-like object with
-  // .query directly — this keeps tests that mock a bare { query } usable.
-  const pool =
-    typeof dbStore.query === 'function'
-      ? dbStore
-      : { query: (sql, params) => dbStore.raw(sql, params) };
+  const dbStore = ensureDb(deps.db, 'album-canonical');
+  const pool = { query: (sql, params) => dbStore.raw(sql, params) };
 
   /**
    * Find an existing canonical album by normalized artist and album name

--- a/test/album-canonical.test.js
+++ b/test/album-canonical.test.js
@@ -6,14 +6,22 @@ const { describe, it, mock, beforeEach } = require('node:test');
 const assert = require('node:assert');
 
 const {
-  createAlbumCanonical,
+  createAlbumCanonical: createAlbumCanonicalBase,
   sanitizeForStorage,
   normalizeForLookup,
   generateInternalAlbumId,
   isBetterCoverImage,
   chooseBetterText,
   chooseBetterTracks,
-} = require('../utils/album-canonical');
+} = require('../services/album-canonical');
+
+function createAlbumCanonical(deps = {}) {
+  const db = deps.db;
+  if (db && !db.raw && typeof db.query === 'function') {
+    return createAlbumCanonicalBase({ ...deps, db: { ...db, raw: db.query } });
+  }
+  return createAlbumCanonicalBase(deps);
+}
 
 // ============================================
 // HELPER FUNCTION TESTS

--- a/test/factory-compat.test.js
+++ b/test/factory-compat.test.js
@@ -39,6 +39,11 @@ const factories = [
     extra: () => ({ logger: createMockLogger() }),
   },
   {
+    name: 'album-canonical',
+    load: () => require('../services/album-canonical').createAlbumCanonical,
+    extra: () => ({ logger: createMockLogger() }),
+  },
+  {
     name: 'album-service',
     load: () => require('../services/album-service').createAlbumService,
     extra: () => ({


### PR DESCRIPTION
## Summary
- move the remaining DB-backed album canonical module from `utils/` to `services/` and update API helper wiring to keep DB-bound orchestration in the service layer
- tighten album canonical construction to the canonical `deps.db` contract via `ensureDb`, removing the query-only compatibility seam
- extend factory compatibility coverage for `album-canonical` and record the milestone in the modernization tracker while closing remaining phase statuses

## Validation
- `npm run lint:strict`
- `node --test test/album-canonical.test.js test/factory-compat.test.js test/track-fetch-queue.test.js test/cover-fetch-queue.test.js`
- `node -e "require('./routes/api/_helpers.js'); require('./services/album-canonical.js'); console.log('ok')"`