### PR TITLE
Close remaining DB contract compatibility seams

### DIFF
--- a/DB_MODERNIZATION_PLAN.tmp.txt
+++ b/DB_MODERNIZATION_PLAN.tmp.txt
@@ -85,6 +85,9 @@ Commit Log
 - 86f4991: Moved DB-backed album canonical module from `utils/` to
   `services/`, tightened it to canonical `deps.db` contract via `ensureDb`, and
   extended factory-compat coverage for the new service path.
+- 6f885ff: Tightened remaining service contract seams by requiring canonical
+  `deps.db` in auth-utils/stats/list fetchers and simplifying year-lock
+  queryable handling for transaction clients.
 
 Legend
 - [ ] pending

--- a/services/auth-utils-service.js
+++ b/services/auth-utils-service.js
@@ -5,14 +5,7 @@
  */
 
 const crypto = require('crypto');
-
-function asDb(db) {
-  if (db && typeof db.raw === 'function') return db;
-  if (db && typeof db.query === 'function') {
-    return { raw: (sql, params) => db.query(sql, params) };
-  }
-  throw new Error('asDb(): expected a datastore with .raw() or .query()');
-}
+const { ensureDb } = require('../db/postgres');
 
 function createAuthUtils(deps = {}) {
   const logger = deps.logger || require('../utils/logger');
@@ -45,14 +38,14 @@ function createAuthUtils(deps = {}) {
     return true;
   }
 
-  async function validateExtensionToken(token, dbOrPool) {
+  async function validateExtensionToken(token, db) {
     if (!isValidExtensionToken(token)) {
       return null;
     }
-    const db = asDb(dbOrPool);
+    const datastore = ensureDb(db, 'auth-utils.validateExtensionToken');
 
     try {
-      const result = await db.raw(
+      const result = await datastore.raw(
         `SELECT user_id, expires_at, is_revoked
          FROM extension_tokens
          WHERE token = $1`,
@@ -73,7 +66,7 @@ function createAuthUtils(deps = {}) {
         return null;
       }
 
-      await db.raw(
+      await datastore.raw(
         `UPDATE extension_tokens
          SET last_used_at = NOW()
          WHERE token = $1`,
@@ -90,10 +83,10 @@ function createAuthUtils(deps = {}) {
     }
   }
 
-  async function cleanupExpiredTokens(dbOrPool) {
-    const db = asDb(dbOrPool);
+  async function cleanupExpiredTokens(db) {
+    const datastore = ensureDb(db, 'auth-utils.cleanupExpiredTokens');
     try {
-      const result = await db.raw(
+      const result = await datastore.raw(
         `DELETE FROM extension_tokens
          WHERE expires_at < NOW()
          OR is_revoked = TRUE`,

--- a/services/list/fetchers.js
+++ b/services/list/fetchers.js
@@ -2,13 +2,13 @@ const {
   mapListRowToItem,
   mapAlbumDataItemToResponse,
 } = require('./item-mapper');
+const { ensureDb } = require('../../db/postgres');
 
 // eslint-disable-next-line max-lines-per-function -- List fetchers keep related read-path SQL together for shared mapping behavior
 function createListFetchers(deps = {}) {
-  const { db, fetchRecommendationMaps, findListById, getPointsForPosition } =
-    deps;
+  const { fetchRecommendationMaps, findListById, getPointsForPosition } = deps;
+  const db = ensureDb(deps.db, 'list/fetchers');
 
-  if (!db) throw new Error('db is required');
   if (!fetchRecommendationMaps) {
     throw new Error('fetchRecommendationMaps is required');
   }

--- a/services/stats-service.js
+++ b/services/stats-service.js
@@ -14,10 +14,10 @@
  * @param {import('../db/types').DbFacade} deps.db - Canonical datastore
  * @returns {Object} Stats service methods
  */
-function createStatsService(deps = {}) {
-  const db = deps.db;
+const { ensureDb } = require('../db/postgres');
 
-  if (!db) throw new Error('db is required for StatsService');
+function createStatsService(deps = {}) {
+  const db = ensureDb(deps.db, 'stats-service');
 
   /**
    * Get public stats visible to all authenticated users.

--- a/services/year-lock-service.js
+++ b/services/year-lock-service.js
@@ -11,21 +11,23 @@ function createYearLock(deps = {}) {
   const { LOCK_NAMESPACES, acquireTransactionLocks } =
     deps.advisoryLocks || require('../db/advisory-locks');
 
-  function asDb(db) {
-    if (db && typeof db.raw === 'function') return db;
-    if (db && typeof db.query === 'function') {
-      return { raw: (sql, params) => db.query(sql, params) };
+  function asQueryable(queryable) {
+    if (queryable && typeof queryable.raw === 'function') return queryable;
+    if (queryable && typeof queryable.query === 'function') {
+      return { raw: (sql, params) => queryable.query(sql, params) };
     }
-    throw new Error('year-lock: expected a datastore with .raw() or .query()');
+    throw new Error(
+      'year-lock: expected DbFacade.raw() or transaction client.query()'
+    );
   }
 
-  async function isYearLocked(dbOrPool, year, opts = {}) {
+  async function isYearLocked(queryable, year, opts = {}) {
     if (!year) return false;
 
     const failOpen = opts.failOpen !== false;
 
     try {
-      const db = asDb(dbOrPool);
+      const db = asQueryable(queryable);
       const result = await db.raw(
         'SELECT locked FROM master_lists WHERE year = $1',
         [year],

--- a/test/auth-utils.test.js
+++ b/test/auth-utils.test.js
@@ -149,7 +149,7 @@ test('generateExtensionToken should generate unique tokens', () => {
 // =============================================================================
 
 test('validateExtensionToken should return null for invalid token format', async () => {
-  const mockPool = { query: async () => ({ rows: [] }) };
+  const mockPool = { raw: async () => ({ rows: [] }) };
 
   // null/undefined
   assert.strictEqual(await validateExtensionToken(null, mockPool), null);
@@ -179,7 +179,7 @@ test('validateExtensionToken should return null for invalid token format', async
 
 test('validateExtensionToken should return null for token not found in database', async () => {
   const mockPool = {
-    query: async () => ({ rows: [] }),
+    raw: async () => ({ rows: [] }),
   };
 
   const validFormatToken = generateExtensionToken();
@@ -189,7 +189,7 @@ test('validateExtensionToken should return null for token not found in database'
 
 test('validateExtensionToken should return null for revoked token', async () => {
   const mockPool = {
-    query: async () => ({
+    raw: async () => ({
       rows: [
         {
           user_id: 123,
@@ -207,7 +207,7 @@ test('validateExtensionToken should return null for revoked token', async () => 
 
 test('validateExtensionToken should return null for expired token', async () => {
   const mockPool = {
-    query: async () => ({
+    raw: async () => ({
       rows: [
         {
           user_id: 123,
@@ -226,7 +226,7 @@ test('validateExtensionToken should return null for expired token', async () => 
 test('validateExtensionToken should return user_id for valid token and update last_used_at', async () => {
   let updateCalled = false;
   const mockPool = {
-    query: async (sql) => {
+    raw: async (sql) => {
       if (sql.includes('SELECT')) {
         return {
           rows: [
@@ -254,7 +254,7 @@ test('validateExtensionToken should return user_id for valid token and update la
 
 test('validateExtensionToken should return null on database error', async () => {
   const mockPool = {
-    query: async () => {
+    raw: async () => {
       throw new Error('Database connection failed');
     },
   };
@@ -270,7 +270,7 @@ test('validateExtensionToken should return null on database error', async () => 
 
 test('cleanupExpiredTokens should return rowCount on success', async () => {
   const mockPool = {
-    query: async () => ({ rowCount: 5 }),
+    raw: async () => ({ rowCount: 5 }),
   };
 
   const result = await cleanupExpiredTokens(mockPool);
@@ -279,7 +279,7 @@ test('cleanupExpiredTokens should return rowCount on success', async () => {
 
 test('cleanupExpiredTokens should return 0 when no tokens deleted', async () => {
   const mockPool = {
-    query: async () => ({ rowCount: 0 }),
+    raw: async () => ({ rowCount: 0 }),
   };
 
   const result = await cleanupExpiredTokens(mockPool);
@@ -288,7 +288,7 @@ test('cleanupExpiredTokens should return 0 when no tokens deleted', async () => 
 
 test('cleanupExpiredTokens should return 0 on database error', async () => {
   const mockPool = {
-    query: async () => {
+    raw: async () => {
       throw new Error('Database error');
     },
   };
@@ -305,7 +305,7 @@ test('validateExtensionToken should log error on database failure', async () => 
   const logger = createMockLogger();
   const { validateExtensionToken: validate } = createAuthUtils({ logger });
   const mockPool = {
-    query: async () => {
+    raw: async () => {
       throw new Error('Connection refused');
     },
   };
@@ -323,7 +323,7 @@ test('cleanupExpiredTokens should log error on database failure', async () => {
   const logger = createMockLogger();
   const { cleanupExpiredTokens: cleanup } = createAuthUtils({ logger });
   const mockPool = {
-    query: async () => {
+    raw: async () => {
       throw new Error('Timeout');
     },
   };


### PR DESCRIPTION
## Summary
- remove remaining query-compat entry-point behavior in `auth-utils-service` by requiring canonical `deps.db` via `ensureDb`
- enforce canonical db contract in `stats-service` and `list/fetchers` to keep service construction consistent
- keep transaction-client handling explicit in year-lock/list flows while removing legacy naming (`dbOrPool` / `asDb`) and record the cleanup milestone in the modernization tracker

## Validation
- `npm run lint:strict`
- `node --test test/auth-utils.test.js test/year-lock-utils.test.js test/list-service.test.js test/factory-compat.test.js`

## Verification Sweep
- no runtime matches for legacy async datastores: `usersAsync|listsAsync|listItemsAsync|albumsAsync|listGroupsAsync`
- no runtime imports of retired DB-backed utility modules (`utils/auth-utils`, `utils/year-lock`, `utils/user-preferences`, `utils/track-fetch-queue`, `utils/album-canonical`)
- no direct DB calls/imports from routes or middleware (`db.raw/query/withTransaction/withClient`)