### PR TITLE
chore: bump @anthropic-ai/sdk 0.74 -> 0.97 (additive only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.74.0",
+        "@anthropic-ai/sdk": "^0.97.1",
         "bcryptjs": "^3.0.2",
         "compression": "^1.7.4",
         "connect-pg-simple": "^10.0.0",
@@ -71,12 +71,13 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.74.0.tgz",
-      "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.97.1.tgz",
+      "integrity": "sha512-wOf7AUeJPitcVpvKO4UMu63mWH5SaVipkGd7OOQJt/G6VYGlV8D2Gp9dLxOrttDJh/9gqPqdaBwDGcBevumeAg==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -1696,6 +1697,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -4081,6 +4088,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fflate": {
       "version": "0.8.2",
@@ -8019,6 +8032,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint:structure:baseline": "node scripts/maintainability-report.js --max-js-files-over-300=90 --max-js-files-over-700=20 --max-legacy-markers=98"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.74.0",
+    "@anthropic-ai/sdk": "^0.97.1",
     "bcryptjs": "^3.0.2",
     "compression": "^1.7.4",
     "connect-pg-simple": "^10.0.0",


### PR DESCRIPTION
## Summary
- `@anthropic-ai/sdk` 0.74.0 → 0.97.1 (23 minor releases in the `0.x` line)
- Reviewed full CHANGELOG.md from 0.75 through 0.97.1: every change is additive or scoped to Managed Agents / Bedrock / Vertex / Memory tools / Zod / WIF — none of which this codebase uses.
- The actually-used surface (`messages.create` with `web_search_20250305` tool, `message.content`/`usage`, the error fields read in the handler) is unchanged.
- Note: Sonnet/Opus 4 base versions were marked deprecated in 0.89, but the repo's default model is `claude-sonnet-4-5` which is unaffected.

## Test plan
- [x] 28/28 dedicated `claude-summary` unit tests pass (exercise the constructor + messages.create surface via mocks)
- [x] Local docker compose rebuilt clean; app boots healthy
- [x] 2528/2528 full unit tests pass
- [x] 49/49 integration tests pass against the rebuilt stack with the live local database
- [x] `npm run typecheck` shows no new errors
- [x] `npm run format:check:source` passes
- [ ] CI green
- [ ] Manual sanity check against the live Claude API in a dev environment (recommended before merge if not covered by smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)