### PR TITLE
Fix Last.fm playcounts disappearing from list views

### DIFF
--- a/routes/api/lastfm.js
+++ b/routes/api/lastfm.js
@@ -13,6 +13,7 @@
 
 const { createAsyncHandler } = require('../../middleware/async-handler');
 const { createPlaycountService } = require('../../services/playcount-service');
+const { normalizeForExternalApi } = require('../../utils/normalization');
 
 /**
  * Register Last.fm routes
@@ -39,6 +40,14 @@ module.exports = (app, deps) => {
 
   const asyncHandler = createAsyncHandler(logger);
   const playcountService = createPlaycountService();
+
+  // Canonical album key consistent with the playcount cache write path, so
+  // accented/special-char names (e.g. "Sigur Rós") match reliably.
+  const canonicalAlbumKey = (artist, album) =>
+    normalizeAlbumKey(
+      normalizeForExternalApi(artist).toLowerCase().trim(),
+      normalizeForExternalApi(album).toLowerCase().trim()
+    );
 
   function getLastfmWriteConfigError() {
     if (!process.env.LASTFM_API_KEY || !process.env.LASTFM_SECRET) {
@@ -113,7 +122,7 @@ module.exports = (app, deps) => {
     }
 
     try {
-      const targetKey = normalizeAlbumKey(artist, album);
+      const targetKey = canonicalAlbumKey(artist, album);
       const result = await db.raw(
         `SELECT li._id AS "itemId", a.album_id, a.artist, a.album
          FROM list_items li
@@ -126,7 +135,7 @@ module.exports = (app, deps) => {
       );
 
       const matchingAlbums = result.rows
-        .filter((row) => normalizeAlbumKey(row.artist, row.album) === targetKey)
+        .filter((row) => canonicalAlbumKey(row.artist, row.album) === targetKey)
         .map((row) => ({
           itemId: row.itemId,
           artist: row.artist,

--- a/routes/oauth/lastfm.js
+++ b/routes/oauth/lastfm.js
@@ -133,7 +133,10 @@ module.exports = (app, deps) => {
         lastfmAuth,
         sessionData.username
       );
-      await clearCachedPlaycounts(req.user._id);
+      // Re-sync fresh playcounts in the background WITHOUT wiping the cache
+      // first — deleting up front made every list view blank until the
+      // (slow, rate-limited) full refresh finished. Existing values keep
+      // showing and are overwritten per-album as fresh data arrives.
       triggerFullPlaycountRefresh(req.user._id, sessionData.username);
 
       log.info('Last.fm connected', {

--- a/services/playcount-service.js
+++ b/services/playcount-service.js
@@ -11,9 +11,33 @@
  * Tests can inject a mock refreshAlbumPlaycount; production uses the default.
  */
 
-/** Staleness threshold for values shown in list views. */
+/**
+ * Staleness threshold for triggering a background refresh. Cached values are
+ * ALWAYS displayed regardless of age — this only controls how often we ask
+ * Last.fm for fresher numbers.
+ */
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 const { ensureDb } = require('../db/postgres');
+const { normalizeForExternalApi } = require('../utils/normalization');
+
+/**
+ * Build the canonical cache key for a list item, matching exactly how the
+ * write path (upsertPlaycount) computes `normalized_key`: canonicalize for
+ * external APIs (strips diacritics, normalizes punctuation), lowercase, then
+ * apply normalizeAlbumKey. Without this, accented names like "Sigur Rós" are
+ * stored under one key but looked up under another and never match.
+ *
+ * @param {Function} normalizeAlbumKey - Album key function
+ * @param {string} artist
+ * @param {string} album
+ * @returns {string}
+ */
+function buildCanonicalKey(normalizeAlbumKey, artist, album) {
+  return normalizeAlbumKey(
+    normalizeForExternalApi(artist).toLowerCase().trim(),
+    normalizeForExternalApi(album).toLowerCase().trim()
+  );
+}
 
 /**
  * Build a lookup map of normalized artist+album keys to cached stats.
@@ -79,7 +103,10 @@ function matchAndFindStale(
       cached.lastfm_status === 'error' ||
       new Date(cached.lastfm_updated_at) < staleThreshold;
 
-    if (cached && !needsRefresh) {
+    // Always show the last-known cached value (even if stale) while a refresh
+    // happens in the background. Hiding stale values made the list go blank on
+    // every load older than the staleness window.
+    if (cached) {
       playcounts[item._id] = {
         playcount: cached.lastfm_playcount,
         status: cached.lastfm_status || null,
@@ -139,6 +166,11 @@ function createPlaycountService(deps = {}) {
   const refreshAlbumPlaycount =
     deps.refreshAlbumPlaycount ||
     require('./playcount-sync-service').refreshAlbumPlaycount;
+
+  // Tracks albums currently being refreshed (keyed by `${userId}::${cacheKey}`)
+  // so repeated list views / poll cycles don't spawn duplicate, overlapping
+  // background refreshes that thrash the Last.fm rate limit.
+  const inFlightRefreshes = new Set();
 
   /**
    * Refresh playcounts for albums in background
@@ -250,6 +282,11 @@ function createPlaycountService(deps = {}) {
   }) {
     const datastore = ensureDb(db, 'playcount-service.getListPlaycounts');
 
+    // Canonical key used for both cache lookups and de-dup, kept consistent
+    // with the write path so accented/special-char names match.
+    const keyOf = (artist, album) =>
+      buildCanonicalKey(normalizeAlbumKey, artist, album);
+
     // Verify list exists
     const list = await datastore.raw(
       `SELECT _id FROM lists WHERE _id = $1 AND user_id = $2`,
@@ -276,7 +313,7 @@ function createPlaycountService(deps = {}) {
     // Fetch only cached playcounts relevant to albums in this list.
     const { albumIds, normalizedKeys } = buildStatsLookupInputs(
       listItems,
-      normalizeAlbumKey
+      keyOf
     );
 
     let statsRows = [];
@@ -308,31 +345,51 @@ function createPlaycountService(deps = {}) {
       statsRows = statsResult.rows;
     }
 
-    const statsMap = buildStatsMap(statsRows, normalizeAlbumKey);
+    const statsMap = buildStatsMap(statsRows, keyOf);
     const { playcounts, albumsToRefresh } = matchAndFindStale(
       listItems,
       statsMap,
-      normalizeAlbumKey,
+      keyOf,
       forceRefresh
     );
 
-    if (albumsToRefresh.length > 0) {
+    // Skip albums already being refreshed so concurrent list views / poll
+    // cycles don't pile up duplicate Last.fm fetches.
+    const albumsToLaunch = albumsToRefresh.filter((album) => {
+      const inflightKey = `${userId}::${keyOf(album.artist, album.album)}`;
+      if (inFlightRefreshes.has(inflightKey)) return false;
+      inFlightRefreshes.add(inflightKey);
+      return true;
+    });
+
+    if (albumsToLaunch.length > 0) {
       logger.debug('Triggering background playcount refresh for stale albums', {
         staleCount: albumsToRefresh.length,
+        launching: albumsToLaunch.length,
         totalCount: listItems.length,
         lastfmUsername,
       });
       refreshPlaycountsInBackground(
         userId,
         lastfmUsername,
-        albumsToRefresh,
+        albumsToLaunch,
         datastore,
         logger
-      ).catch((err) => {
-        logger.error('Background playcount refresh failed:', err);
-      });
+      )
+        .catch((err) => {
+          logger.error('Background playcount refresh failed:', err);
+        })
+        .finally(() => {
+          for (const album of albumsToLaunch) {
+            inFlightRefreshes.delete(
+              `${userId}::${keyOf(album.artist, album.album)}`
+            );
+          }
+        });
     }
 
+    // Report the full stale count (not just what we launched) so the client
+    // keeps polling until in-flight refreshes from any caller complete.
     return { playcounts, refreshing: albumsToRefresh.length };
   }
 

--- a/services/playcount-sync-service.js
+++ b/services/playcount-sync-service.js
@@ -133,11 +133,17 @@ async function invalidateUserPlaycounts(db, log, userId) {
  * @param {number|null} playcount - Playcount value (null for not_found)
  * @param {string} status - 'success' or 'not_found'
  */
-async function upsertPlaycount(db, userId, album, playcount, status) {
+function canonicalizeAlbum(album) {
   const canonicalArtist = normalizeForLastfm(album.artist).toLowerCase().trim();
   const canonicalAlbum = normalizeForLastfm(album.album).toLowerCase().trim();
   const normalizedKey = normalizeAlbumKey(canonicalArtist, canonicalAlbum);
   const albumId = album.album_id || album.albumId || null;
+  return { canonicalArtist, canonicalAlbum, normalizedKey, albumId };
+}
+
+async function upsertPlaycount(db, userId, album, playcount, status) {
+  const { canonicalArtist, canonicalAlbum, normalizedKey, albumId } =
+    canonicalizeAlbum(album);
 
   await db.raw(
     `INSERT INTO user_album_stats (user_id, album_id, artist, album_name, normalized_key, lastfm_playcount, lastfm_status, lastfm_updated_at, updated_at)
@@ -159,6 +165,30 @@ async function upsertPlaycount(db, userId, album, playcount, status) {
       playcount,
       status,
     ]
+  );
+}
+
+/**
+ * Record a transient fetch failure WITHOUT clobbering a previously cached
+ * value. If a row already exists (success/not_found/error) it is left
+ * untouched so the last-known playcount keeps displaying; only brand-new
+ * albums get an 'error' marker so they stay eligible for retry. This prevents
+ * a momentary Last.fm hiccup from wiping good playcounts.
+ *
+ * @param {Object} db - Canonical datastore
+ * @param {string} userId - User ID
+ * @param {Object} album - Album object
+ */
+async function upsertPlaycountError(db, userId, album) {
+  const { canonicalArtist, canonicalAlbum, normalizedKey, albumId } =
+    canonicalizeAlbum(album);
+
+  await db.raw(
+    `INSERT INTO user_album_stats (user_id, album_id, artist, album_name, normalized_key, lastfm_playcount, lastfm_status, lastfm_updated_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, NULL, 'error', NOW(), NOW())
+     ON CONFLICT (user_id, LOWER(artist), LOWER(album_name))
+     DO NOTHING`,
+    [userId, albumId, canonicalArtist, canonicalAlbum, normalizedKey]
   );
 }
 
@@ -318,13 +348,14 @@ async function refreshAlbumPlaycount(db, log, userId, lastfmUsername, album) {
       error: err.message,
     });
 
-    // Store as error state so we retry later
+    // Mark as errored so we retry later — but preserve any existing cached
+    // value rather than overwriting it with null.
     try {
       const datastore = ensureDb(
         db,
         'playcount-sync-service.refreshAlbumPlaycount'
       );
-      await upsertPlaycount(datastore, userId, album, null, 'error');
+      await upsertPlaycountError(datastore, userId, album);
     } catch (dbErr) {
       log.error('Failed to store error status', {
         error: dbErr.message,

--- a/test/lastfm-oauth-routes.test.js
+++ b/test/lastfm-oauth-routes.test.js
@@ -129,10 +129,11 @@ test('Last.fm callback rejects invalid auth state', async () => {
   assert.match(flashes[0][1], /invalid state/);
 });
 
-test('Last.fm callback invalidates cache and starts a full playcount refresh', async () => {
+test('Last.fm callback starts a full playcount refresh without wiping the cache', async () => {
   const app = createAppRecorder();
   const calls = [];
   const flashes = [];
+  let invalidateCalls = 0;
   registerLastfmRoutes(app, {
     ensureAuth: (_req, _res, next) => next(),
     db: {},
@@ -140,8 +141,8 @@ test('Last.fm callback invalidates cache and starts a full playcount refresh', a
       session_key: 'session-key',
       username: 'listener',
     }),
-    invalidateUserPlaycounts: async (_db, _logger, userId) => {
-      calls.push(['invalidate', userId]);
+    invalidateUserPlaycounts: async () => {
+      invalidateCalls++;
       return 2;
     },
     syncUserPlaycounts: async (_db, _logger, user) => {
@@ -169,14 +170,15 @@ test('Last.fm callback invalidates cache and starts a full playcount refresh', a
   await runHandlers(route.handlers, req, res);
 
   assert.strictEqual(res.redirectedTo, '/');
+  // Reconnect must NOT delete cached playcounts (that caused a blank gap).
+  assert.strictEqual(invalidateCalls, 0);
   assert.deepStrictEqual(calls[0], [
     'setAuth',
     'user1',
     'session-key',
     'listener',
   ]);
-  assert.deepStrictEqual(calls[1], ['invalidate', 'user1']);
-  assert.deepStrictEqual(calls[2], [
+  assert.deepStrictEqual(calls[1], [
     'sync',
     {
       _id: 'user1',

--- a/test/playcount-service.test.js
+++ b/test/playcount-service.test.js
@@ -465,7 +465,8 @@ describe('playcount-service', () => {
       });
 
       assert.strictEqual(result.refreshing, 1);
-      assert.strictEqual(result.playcounts.item1, null);
+      // forceRefresh queues a refresh but the cached value is still shown.
+      assert.strictEqual(result.playcounts.item1.playcount, 42);
       assert.strictEqual(mockRefresh.mock.calls.length, 1);
       assert.strictEqual(
         mockRefresh.mock.calls[0].arguments[4].album_id,
@@ -473,7 +474,7 @@ describe('playcount-service', () => {
       );
     });
 
-    it('should not display stale cached stats while refreshing', async () => {
+    it('should display stale cached stats while refreshing in the background', async () => {
       const mockLogger = createMockLogger();
       const staleUpdatedAt = new Date(
         Date.now() - 10 * 60 * 1000
@@ -496,7 +497,7 @@ describe('playcount-service', () => {
               artist: 'marianas rest',
               album_name: 'the bereaved',
               album_id: 'album-1',
-              normalized_key: 'marianas rest::bereaved',
+              normalized_key: 'marianas rest::the bereaved',
               lastfm_playcount: 93,
               lastfm_status: 'success',
               lastfm_updated_at: staleUpdatedAt,
@@ -523,8 +524,9 @@ describe('playcount-service', () => {
           `${artist}`.toLowerCase() + `::${album}`.toLowerCase(),
       });
 
+      // Stale value is still shown immediately, and a refresh is queued.
       assert.strictEqual(result.refreshing, 1);
-      assert.strictEqual(result.playcounts.item1, null);
+      assert.strictEqual(result.playcounts.item1.playcount, 93);
       assert.strictEqual(mockRefresh.mock.calls.length, 1);
     });
 


### PR DESCRIPTION
﻿## Problem

Last.fm playcounts stopped showing in list views. The most recent change made `matchAndFindStale` return `null` for any cached value older than 5 minutes (which the browser skips when rendering), and reconnect deleted the entire playcount cache — so lists went blank until a slow, rate-limited background re-sync finished. The net effect was "stale counts" turning into "no counts at all".

## Fixes

- **Restore cached display while refreshing** — always show the last-known playcount and refresh stale ones in the background, instead of returning `null`.
- **Preserve values on transient errors** — a momentary Last.fm failure no longer overwrites a good cached count with `null`/`error` (non-destructive `ON CONFLICT DO NOTHING` upsert).
- **De-dupe in-flight refreshes** — concurrent list views / poll cycles no longer pile up overlapping Last.fm fetches that trip the rate limit and produce permanent `error` rows.
- **Fix accented-name key mismatch** — the cache lookup key is now canonicalized with `normalizeForExternalApi` (diacritic-stripping) to match the write path, so albums like "Sigur Rós" / "Mötley Crüe" match.
- **Stop wiping the cache on reconnect** — reconnect triggers a background re-sync without deleting first, so existing values keep showing. Disconnect still clears the cache.

## Testing

- 2552/2552 unit tests pass; ESLint clean.
- Updated the 3 tests that had encoded the old hide-stale / wipe-on-reconnect behavior.
- (The only failures in a full `node --test` run are the `test/e2e/*.spec.js` Playwright specs, which require a live Postgres/server and are out of scope for the unit suite.)

## Note

`STALE_THRESHOLD_MS` is left at 5 minutes. It's now safe with show-cached + de-dup, but it does mean each list view older than 5 min re-fetches its albums. Since the scrobble path already refreshes the playing album immediately, this can be raised (e.g. 30–60 min) later to cut Last.fm load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
