### PR TITLE
Fix playcounts freezing on stale value (poll stops before refresh lands)

### DIFF
--- a/src/js/modules/album-display/playcount-sync.js
+++ b/src/js/modules/album-display/playcount-sync.js
@@ -183,14 +183,21 @@ export function createPlaycountSync(deps = {}) {
             (value) => value === null || (value && value.status === 'error')
           ).length;
 
+          // The server reports how many albums are still queued for a
+          // background refresh. We must keep polling while that is > 0 —
+          // otherwise a stale-but-cached value (which now displays instead of
+          // showing blank) looks "done" and we'd stop before the fresh value
+          // lands, freezing the UI on the stale number.
+          const stillRefreshing = (response.refreshing || 0) > 0;
+
           if (changedCount > 0) {
             logger.log(
-              `Playcounts updated: ${changedCount} changed, ${missingCount} missing`
+              `Playcounts updated: ${changedCount} changed, ${missingCount} missing, ${response.refreshing || 0} refreshing`
             );
           }
 
           if (
-            missingCount === 0 &&
+            !stillRefreshing &&
             changedCount === 0 &&
             pollCount >= MIN_POLLS
           ) {
@@ -201,7 +208,7 @@ export function createPlaycountSync(deps = {}) {
 
           if (pollCount < MAX_POLLS) {
             const interval =
-              changedCount > 0 || missingCount > 0
+              changedCount > 0 || stillRefreshing
                 ? POLL_INTERVAL
                 : POLL_INTERVAL * 1.5;
             schedule(poll, interval);

--- a/test/album-playcount-sync.test.js
+++ b/test/album-playcount-sync.test.js
@@ -227,6 +227,79 @@ describe('album-display playcount-sync module', () => {
     assert.strictEqual(apiCall.mock.calls.length, 1);
   });
 
+  it('keeps polling past MIN_POLLS while refreshing > 0, then shows the fresh value', async () => {
+    const desktopEl = createElement();
+    const doc = {
+      querySelector: (selector) =>
+        selector === '[data-playcount="item-1"]' ? desktopEl : null,
+    };
+
+    // Stale value displays first and stays stale across several polls (server
+    // still reports refreshing:1), then the fresh value lands with refreshing:0.
+    const responses = [
+      {
+        playcounts: { 'item-1': { playcount: 93, status: 'success' } },
+        refreshing: 1,
+      }, // initial fetch
+      {
+        playcounts: { 'item-1': { playcount: 93, status: 'success' } },
+        refreshing: 1,
+      }, // poll 1
+      {
+        playcounts: { 'item-1': { playcount: 93, status: 'success' } },
+        refreshing: 1,
+      }, // poll 2
+      {
+        playcounts: { 'item-1': { playcount: 93, status: 'success' } },
+        refreshing: 1,
+      }, // poll 3 (>= MIN_POLLS, unchanged)
+      {
+        playcounts: { 'item-1': { playcount: 116, status: 'success' } },
+        refreshing: 0,
+      }, // poll 4: fresh
+      {
+        playcounts: { 'item-1': { playcount: 116, status: 'success' } },
+        refreshing: 0,
+      }, // poll 5: stop
+    ];
+    let call = 0;
+    const apiCall = mock.fn(
+      async () => responses[Math.min(call++, responses.length - 1)]
+    );
+
+    const scheduled = [];
+    const sync = createPlaycountSync({
+      apiCall,
+      formatPlaycount: (value) => String(value),
+      doc,
+      win: { currentUser: { lastfmUsername: 'listener' } },
+      schedule: (callback) => {
+        scheduled.push(callback);
+        return scheduled.length;
+      },
+    });
+
+    await sync.fetchAndDisplayPlaycounts('list-1');
+
+    // Drive each scheduled poll callback in order (the array grows as polls
+    // schedule their successor).
+    let i = 0;
+    while (i < scheduled.length && i < 10) {
+      await scheduled[i]();
+      i++;
+    }
+
+    // The old stop heuristic (no nulls + no change + pollCount>=MIN_POLLS)
+    // would have stopped at poll 3 and frozen on 93. With the refreshing-aware
+    // condition it keeps polling and picks up 116.
+    assert.strictEqual(sync.getPlaycountCacheEntry('item-1').playcount, 116);
+    assert.match(desktopEl.innerHTML, /116/);
+    assert.ok(
+      apiCall.mock.calls.length >= 5,
+      `expected >=5 poll calls, got ${apiCall.mock.calls.length}`
+    );
+  });
+
   it('aborts polling controllers when cache is cleared', async () => {
     const controllers = [];
     const createAbortController = () => {


### PR DESCRIPTION
## Symptom

After logging in, an album shows a stale playcount (e.g. **93**) while Last.fm and the app's own `album.getInfo` lookup both report the current value (**116**). It stays frozen on 93 until a manual page reload.

## Root cause

This is a follow-on from #362 ("show the cached value while refreshing" instead of going blank). A stale-but-cached playcount now renders as a normal `success` value rather than `null`. But the poll loop's stop heuristic only kept polling while values were `null`/`error` or had just changed:

```
if (missingCount === 0 && changedCount === 0 && pollCount >= MIN_POLLS) stop
```

So once every album displays a cached value, `missingCount` is 0 and the poll **stops after ~3 polls (~9s)** — before the batched background refresh (5 albums / 1.1s) finishes writing the fresh number. The DB updates to 116, but the client already stopped polling and stays on 93 until a reload. (Verified the API and our `getAlbumInfo` both return 116, and list data does not carry the playcount — it comes only from the `list-playcounts` endpoint.)

## Fix

The `list-playcounts` response already returns `refreshing` (count of albums still queued for a background refresh). Keep polling while `refreshing > 0` (still capped by `MAX_POLLS`), so the fresh value is picked up without a manual reload.

## Testing

- Added a regression test that drives polls past `MIN_POLLS` with an unchanged stale value while `refreshing: 1`, then asserts the UI updates to the fresh value once `refreshing: 0`. The old heuristic stopped at poll 3 and froze on the stale value.
- Full unit suite green (2553 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)