### PR TITLE
Always re-pull :latest on prod deploy (pull_policy: always)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   app:
     image: ghcr.io/magnusoverli/sushe-online:latest
+    # Always re-pull :latest on `up` so a deploy can never silently run a
+    # stale cached image (the CI only builds/pushes; deploy is manual).
+    pull_policy: always
     container_name: sushe-online
     ports:
       - '3000:3000'


### PR DESCRIPTION
## Why

CI (`docker-build.yml`) only builds and pushes the image to ghcr.io — there is no deploy step, so deploying to prod is manual. Prod pins a floating `image: ...:latest`, and `docker compose up -d` does **not** re-pull `:latest` when an image with that tag already exists on the host. As a result, deploys could silently keep running a stale cached image — which is why merged Last.fm playcount fixes had no effect in production while the same code worked locally.

## Change

Set `pull_policy: always` on the prod `app` service so a plain `docker compose up -d` always fetches the freshly-built image.

## Deploy note

After this is on the prod host (it bind-mounts repo files, so `git pull` there picks it up), deploying is just:

```
docker compose up -d
```

For the immediate rollout of the current image, run once:

```
docker compose pull && docker compose up -d
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)