### PR TITLE
Restore prod-override-only observability metrics into the repo

### DIFF
--- a/middleware/rate-limit.js
+++ b/middleware/rate-limit.js
@@ -14,6 +14,7 @@
 
 const rateLimit = require('express-rate-limit');
 const logger = require('../utils/logger');
+const { incRateLimitHit } = require('../utils/metrics');
 
 // Check if rate limiting is disabled globally
 const isRateLimitingDisabled = process.env.DISABLE_RATE_LIMITING === 'true';
@@ -24,6 +25,7 @@ const noopMiddleware = (_req, _res, next) => next();
 // Helper to create standardized rate limit handler
 function createRateLimitHandler(message) {
   return (_req, res) => {
+    incRateLimitHit(_req.path);
     logger.warn('Rate limit exceeded', {
       ip: _req.ip,
       path: _req.path,

--- a/middleware/response-cache.js
+++ b/middleware/response-cache.js
@@ -1,4 +1,5 @@
 const logger = require('../utils/logger');
+const { incCacheHit, incCacheMiss } = require('../utils/metrics');
 
 class ResponseCache {
   constructor(options = {}) {
@@ -125,6 +126,7 @@ function createCacheMiddleware(options = {}) {
 
     if (cached) {
       // Cache hit
+      incCacheHit();
       if (onHit) onHit(req, cacheKey);
 
       // Set cache headers
@@ -140,6 +142,7 @@ function createCacheMiddleware(options = {}) {
     }
 
     // Cache miss - intercept response
+    incCacheMiss();
     if (onMiss) onMiss(req, cacheKey);
 
     const originalJson = res.json;

--- a/services/cover-fetch-queue.js
+++ b/services/cover-fetch-queue.js
@@ -26,6 +26,11 @@ const {
   processImage,
   upscaleItunesArtworkUrl,
 } = require('../utils/image-processing');
+const {
+  incQueueItems,
+  incQueueItemsProcessed,
+  incQueueItemsFailed,
+} = require('../utils/metrics');
 
 // Per-provider timeout in milliseconds
 const PROVIDER_TIMEOUT_MS = 5000;
@@ -313,11 +318,14 @@ function createCoverFetchQueue(deps = {}) {
     }
 
     logger.debug('Queueing cover fetch', { albumId, artist, album });
+    incQueueItems('cover');
 
     return queue.add(async () => {
       try {
         await fetchAndStoreCover(albumId, artist, album);
+        incQueueItemsProcessed('cover');
       } catch (error) {
+        incQueueItemsFailed('cover');
         logger.warn('Cover fetch failed', {
           albumId,
           artist,

--- a/services/playcount-sync-service.js
+++ b/services/playcount-sync-service.js
@@ -15,6 +15,7 @@ const {
   normalizeForLastfm,
 } = require('../utils/lastfm-auth');
 const { normalizeAlbumKey } = require('../utils/fuzzy-match');
+const { recordPlaycountSync } = require('../utils/metrics');
 const {
   createExternalIdentityService,
 } = require('./external-identity-service');
@@ -552,9 +553,11 @@ function createPlaycountSyncService(deps = {}) {
         totalAlbums: results.totalAlbums,
         duration: `${cycleDuration}ms`,
       });
+      recordPlaycountSync('success', results.totalAlbums);
     } catch (err) {
       log.error('Playcount sync cycle failed', { error: err.message });
       results.errors.push({ source: 'cycle', error: err.message });
+      recordPlaycountSync('error', 0);
     } finally {
       isRunning = false;
     }

--- a/services/track-fetch-queue.js
+++ b/services/track-fetch-queue.js
@@ -13,6 +13,11 @@ const { RequestQueue } = require('../utils/request-queue');
 const logger = require('../utils/logger');
 const { normalizeForExternalApi } = require('../utils/normalization');
 const { ensureDb } = require('../db/postgres');
+const {
+  incQueueItems,
+  incQueueItemsProcessed,
+  incQueueItemsFailed,
+} = require('../utils/metrics');
 
 /**
  * Sanitize search query string for API requests
@@ -66,11 +71,14 @@ function createTrackFetchQueue(deps = {}) {
     }
 
     log.debug('Queueing track fetch', { albumId, artist, album });
+    incQueueItems('track');
 
     return queue.add(async () => {
       try {
         await fetchAndStoreTracks(albumId, artist, album);
+        incQueueItemsProcessed('track');
       } catch (error) {
+        incQueueItemsFailed('track');
         log.warn('Track fetch failed', {
           albumId,
           artist,

--- a/utils/metrics.js
+++ b/utils/metrics.js
@@ -207,12 +207,22 @@ const dbPoolSize = new client.Gauge({
 // ============================================
 
 /**
- * Active user sessions gauge
+ * Active user sessions gauge - pull-based via collect callback querying the DB
  */
 const userSessionsActive = new client.Gauge({
   name: 'sushe_user_sessions_active',
   help: 'Number of active user sessions',
   registers: [register],
+  async collect() {
+    if (_pool) {
+      try {
+        const result = await _pool.query('SELECT COUNT(*) AS cnt FROM session');
+        this.set(parseInt(result.rows[0].cnt, 10) || 0);
+      } catch {
+        // Table may not exist or pool not ready - silently skip
+      }
+    }
+  },
 });
 
 /**
@@ -259,6 +269,113 @@ const claudeRequestsTotal = new client.Counter({
   name: 'sushe_claude_requests_total',
   help: 'Total number of Claude API requests',
   labelNames: ['model', 'status'], // status: 'success', 'error', 'rate_limited'
+  registers: [register],
+});
+
+// ============================================
+// Background Queue Metrics
+// ============================================
+
+/**
+ * Cover/track fetch queue: items added
+ */
+const queueItemsTotal = new client.Counter({
+  name: 'sushe_queue_items_total',
+  help: 'Total items added to background fetch queues',
+  labelNames: ['queue'], // 'cover', 'track'
+  registers: [register],
+});
+
+/**
+ * Cover/track fetch queue: items completed successfully
+ */
+const queueItemsProcessedTotal = new client.Counter({
+  name: 'sushe_queue_items_processed_total',
+  help: 'Total items successfully processed by background fetch queues',
+  labelNames: ['queue'],
+  registers: [register],
+});
+
+/**
+ * Cover/track fetch queue: items failed
+ */
+const queueItemsFailedTotal = new client.Counter({
+  name: 'sushe_queue_items_failed_total',
+  help: 'Total items that failed in background fetch queues',
+  labelNames: ['queue'],
+  registers: [register],
+});
+
+// ============================================
+// Response Cache Metrics
+// ============================================
+
+/**
+ * Response cache hits
+ */
+const cacheHitsTotal = new client.Counter({
+  name: 'sushe_cache_hits_total',
+  help: 'Total response cache hits',
+  registers: [register],
+});
+
+/**
+ * Response cache misses
+ */
+const cacheMissesTotal = new client.Counter({
+  name: 'sushe_cache_misses_total',
+  help: 'Total response cache misses',
+  registers: [register],
+});
+
+// ============================================
+// Rate Limit Metrics
+// ============================================
+
+/**
+ * Rate limit hits counter
+ */
+const rateLimitHitsTotal = new client.Counter({
+  name: 'sushe_rate_limit_hits_total',
+  help: 'Total number of requests blocked by rate limiting',
+  labelNames: ['endpoint'],
+  registers: [register],
+});
+
+// ============================================
+// WebSocket Event Metrics
+// ============================================
+
+/**
+ * WebSocket events emitted counter
+ */
+const websocketEventsTotal = new client.Counter({
+  name: 'sushe_websocket_events_total',
+  help: 'Total WebSocket events broadcast to clients',
+  labelNames: ['event'],
+  registers: [register],
+});
+
+// ============================================
+// Playcount Sync Metrics
+// ============================================
+
+/**
+ * Playcount sync runs counter
+ */
+const playcountSyncRunsTotal = new client.Counter({
+  name: 'sushe_playcount_sync_runs_total',
+  help: 'Total playcount sync job runs',
+  labelNames: ['result'], // 'success', 'error'
+  registers: [register],
+});
+
+/**
+ * Albums synced per playcount run
+ */
+const playcountSyncAlbumsTotal = new client.Counter({
+  name: 'sushe_playcount_sync_albums_total',
+  help: 'Total albums synced by the playcount sync job',
   registers: [register],
 });
 
@@ -379,6 +496,72 @@ function recordAuthAttempt(type, result) {
 }
 
 /**
+ * Increment background queue items added
+ * @param {'cover'|'track'} queue
+ */
+function incQueueItems(queue) {
+  queueItemsTotal.labels(queue).inc();
+}
+
+/**
+ * Increment background queue items processed
+ * @param {'cover'|'track'} queue
+ */
+function incQueueItemsProcessed(queue) {
+  queueItemsProcessedTotal.labels(queue).inc();
+}
+
+/**
+ * Increment background queue items failed
+ * @param {'cover'|'track'} queue
+ */
+function incQueueItemsFailed(queue) {
+  queueItemsFailedTotal.labels(queue).inc();
+}
+
+/**
+ * Increment cache hit counter
+ */
+function incCacheHit() {
+  cacheHitsTotal.inc();
+}
+
+/**
+ * Increment cache miss counter
+ */
+function incCacheMiss() {
+  cacheMissesTotal.inc();
+}
+
+/**
+ * Increment rate limit hit counter
+ * @param {string} endpoint
+ */
+function incRateLimitHit(endpoint) {
+  rateLimitHitsTotal.labels(endpoint || 'unknown').inc();
+}
+
+/**
+ * Increment WebSocket event counter
+ * @param {string} event
+ */
+function incWebsocketEvent(event) {
+  websocketEventsTotal.labels(event).inc();
+}
+
+/**
+ * Record a playcount sync run result
+ * @param {'success'|'error'} result
+ * @param {number} albumsProcessed
+ */
+function recordPlaycountSync(result, albumsProcessed = 0) {
+  playcountSyncRunsTotal.labels(result).inc();
+  if (albumsProcessed > 0) {
+    playcountSyncAlbumsTotal.inc(albumsProcessed);
+  }
+}
+
+/**
  * Increment WebSocket connection count
  */
 function incWebsocketConnections() {
@@ -492,6 +675,15 @@ module.exports = {
   claudeRequestsTotal,
   appInfo,
   appUptime,
+  queueItemsTotal,
+  queueItemsProcessedTotal,
+  queueItemsFailedTotal,
+  cacheHitsTotal,
+  cacheMissesTotal,
+  rateLimitHitsTotal,
+  websocketEventsTotal,
+  playcountSyncRunsTotal,
+  playcountSyncAlbumsTotal,
 
   // Middleware
   metricsMiddleware,
@@ -510,6 +702,14 @@ module.exports = {
   recordClaudeUsage,
   incWebsocketConnections,
   decWebsocketConnections,
+  incQueueItems,
+  incQueueItemsProcessed,
+  incQueueItemsFailed,
+  incCacheHit,
+  incCacheMiss,
+  incRateLimitHit,
+  incWebsocketEvent,
+  recordPlaycountSync,
   setPoolReference,
   updateDbPoolMetrics,
   updateUptime,

--- a/utils/websocket.js
+++ b/utils/websocket.js
@@ -7,6 +7,7 @@ const { Server } = require('socket.io');
 const {
   incWebsocketConnections,
   decWebsocketConnections,
+  incWebsocketEvent,
 } = require('./metrics');
 const {
   isAllowedOrigin,
@@ -32,6 +33,7 @@ function createBroadcast(getIO, logger) {
     } else {
       io.to(userRoom).emit(event, payload);
     }
+    incWebsocketEvent(event);
   }
 
   return {
@@ -119,6 +121,7 @@ function createBroadcast(getIO, logger) {
       const room = io.sockets.adapter.rooms.get(userRoom);
       const clientCount = room ? room.size : 0;
       io.to(userRoom).emit('album:summary-updated', payload);
+      incWebsocketEvent('album:summary-updated');
       logger.info('Broadcast album:summary-updated', {
         userId,
         albumId,


### PR DESCRIPTION
## Background — the real root cause of the stale playcounts

Production runs on Unraid via compose.manager, and its `docker-compose.override.yml` bind-mounts **8 files read-only from a host `overrides/` dir dated March 11** over the image:

```
overrides/services/playcount-sync-service.js → /app/services/playcount-sync-service.js
overrides/utils/oauth-token-manager.js       → /app/utils/oauth-token-manager.js
overrides/utils/metrics.js, websocket.js, track-fetch-queue.js
overrides/middleware/rate-limit.js, response-cache.js
overrides/services/cover-fetch-queue.js
```

These shadowed the image for those files for ~2.5 months. So every merge/build/deploy was silently overridden for `playcount-sync-service.js` — which is why playcounts never updated regardless of what we shipped (the host file ran pre-Postgres-refactor `pool.query` / `usersDb.update` against the current runtime → `pool.query is not a function` on every album).

We want to **delete those overrides** so prod runs the current image. But the override `metrics.js` carried an observability feature **never merged to main** (queue / cache / rate-limit / websocket-event / playcount-sync Prometheus metrics) used by the host's Grafana/Prometheus stack. Dropping the overrides naively would lose those metrics — a regression.

## This PR

Ports that metrics feature into the repo so the image itself carries it, reconciled with main's existing DB metrics (no name collisions):

- `utils/metrics.js`: adds the 5 metric families + helpers; makes `user_sessions_active` pull-based via `collect()`. Coexists with `recordDbError`/`recordDbRetry`/`observeDbTransaction`/`recordDbSlowQuery`.
- Re-adds call sites in the **current** files: `incRateLimitHit`, `incCacheHit/Miss`, `incQueueItems*` (cover + track queues), `incWebsocketEvent`, `recordPlaycountSync`.

Verified: 2553/2553 unit tests pass; eslint + prettier clean; metrics module loads with no duplicate-registration error and renders all families (`sushe_queue_items_total`, `sushe_cache_hits_total`, `sushe_rate_limit_hits_total`, `sushe_websocket_events_total`, `sushe_playcount_sync_runs_total`, alongside `sushe_db_errors_total`).

## Deploy (after merge → image build)

On the prod host, remove the 8 volume mounts from `docker-compose.override.yml` (keep the Unraid labels), then `docker compose pull && docker compose up -d --force-recreate`. Result: current code everywhere (playcounts fixed) **and** all Grafana metrics preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)