### PR TITLE
Identify and store per-album streaming-platform availability (backend)

### DIFF
--- a/config/startup-services.js
+++ b/config/startup-services.js
@@ -34,6 +34,11 @@ function initializeQueues(db) {
     initializeNativeNameQueue,
   } = require('../services/native-name-queue');
   initializeNativeNameQueue(db);
+
+  const {
+    initializeAvailabilityFetchQueue,
+  } = require('../services/availability-fetch-queue');
+  initializeAvailabilityFetchQueue(db);
 }
 
 /**

--- a/db/migrations/migrations/063_add_album_service_url_and_relax_service_check.js
+++ b/db/migrations/migrations/063_add_album_service_url_and_relax_service_check.js
@@ -1,0 +1,59 @@
+/**
+ * Album service availability metadata.
+ *
+ * 1. Adds `external_url` to album_service_mappings so a per-platform deep link
+ *    can be stored directly (the table previously only held an external id).
+ * 2. Removes the `service IN ('spotify','tidal','lastfm')` CHECK so the set of
+ *    platforms becomes an application-layer allowlist (see
+ *    services/availability/platforms.js). Adding a platform then needs no
+ *    migration. The repository still validates the service name on read/write.
+ *
+ * The CHECK is dropped by discovery (its auto-generated name is environment
+ * dependent), so this is robust regardless of how Postgres named it.
+ */
+module.exports = {
+  async up(pool) {
+    await pool.query(`
+      ALTER TABLE album_service_mappings
+      ADD COLUMN IF NOT EXISTS external_url TEXT
+    `);
+
+    await pool.query(`
+      DO $$
+      DECLARE constraint_name text;
+      BEGIN
+        SELECT conname INTO constraint_name
+        FROM pg_constraint
+        WHERE conrelid = 'album_service_mappings'::regclass
+          AND contype = 'c'
+          AND pg_get_constraintdef(oid) ILIKE '%service%';
+        IF constraint_name IS NOT NULL THEN
+          EXECUTE format(
+            'ALTER TABLE album_service_mappings DROP CONSTRAINT %I',
+            constraint_name
+          );
+        END IF;
+      END $$;
+    `);
+  },
+
+  async down(pool) {
+    await pool.query(`
+      ALTER TABLE album_service_mappings
+      DROP COLUMN IF EXISTS external_url
+    `);
+
+    // Restore the original three-service CHECK. Existing rows for services
+    // outside this set must be removed first or the constraint would fail.
+    await pool.query(`
+      DELETE FROM album_service_mappings
+      WHERE service NOT IN ('spotify', 'tidal', 'lastfm')
+    `);
+
+    await pool.query(`
+      ALTER TABLE album_service_mappings
+      ADD CONSTRAINT album_service_mappings_service_check
+      CHECK (service IN ('spotify', 'tidal', 'lastfm'))
+    `);
+  },
+};

--- a/routes/api/_helpers.js
+++ b/routes/api/_helpers.js
@@ -193,6 +193,25 @@ function createHelpers(deps) {
       }
     }
 
+    // Resolve which platforms provide this album (cached; one-time per album).
+    if (album.artist && album.album) {
+      const {
+        getAvailabilityFetchQueue,
+      } = require('../../services/availability-fetch-queue');
+      try {
+        getAvailabilityFetchQueue().add(
+          result.albumId,
+          album.artist,
+          album.album
+        );
+      } catch (error) {
+        logger.warn('Availability fetch queue not available', {
+          albumId: result.albumId,
+          error: error.message,
+        });
+      }
+    }
+
     return result.albumId;
   }
 
@@ -236,9 +255,13 @@ function createHelpers(deps) {
     const { getCoverFetchQueue } = require('../../services/cover-fetch-queue');
     const { getTrackFetchQueue } = require('../../services/track-fetch-queue');
     const { getNativeNameQueue } = require('../../services/native-name-queue');
+    const {
+      getAvailabilityFetchQueue,
+    } = require('../../services/availability-fetch-queue');
     let coverQueue;
     let trackQueue;
     let nativeNameQueue;
+    let availabilityQueue;
     try {
       coverQueue = getCoverFetchQueue();
     } catch (error) {
@@ -257,6 +280,13 @@ function createHelpers(deps) {
       nativeNameQueue = getNativeNameQueue();
     } catch (error) {
       logger.warn('Native name queue not available for batch', {
+        error: error.message,
+      });
+    }
+    try {
+      availabilityQueue = getAvailabilityFetchQueue();
+    } catch (error) {
+      logger.warn('Availability fetch queue not available for batch', {
         error: error.message,
       });
     }
@@ -289,6 +319,11 @@ function createHelpers(deps) {
       // name looks slug-folded and the id is a MusicBrainz UUID).
       if (result.wasInserted && artist && album && nativeNameQueue) {
         nativeNameQueue.add(result.albumId, artist, album);
+      }
+
+      // Resolve platform availability (cached; one-time per album).
+      if (artist && album && availabilityQueue) {
+        availabilityQueue.add(result.albumId, artist, album);
       }
     });
 

--- a/scripts/backfill-availability.js
+++ b/scripts/backfill-availability.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/**
+ * Backfill platform-availability metadata for albums already in the database.
+ *
+ * For every album not yet availability-resolved, seed it (existing mapping /
+ * MusicBrainz / public search), expand via Odesli, union with MusicBrainz
+ * direct links and store one album_service_mappings row per platform. Shares the
+ * exact resolution service the live queue uses.
+ *
+ * Dry-run by default (resolves and prints, writes nothing); pass --apply to
+ * write. --limit=N bounds the candidate set (handy for a quick check).
+ *
+ * Self-paced by Odesli's rate limit; TRANSIENT skips (network / 429 / 5xx) are
+ * retried in bounded rounds. Legitimate skips (no seed, no links) are reported.
+ *
+ *   node scripts/backfill-availability.js                 # dry-run
+ *   node scripts/backfill-availability.js --apply         # write
+ *   node scripts/backfill-availability.js --limit=10      # bound candidates
+ */
+
+require('dotenv').config();
+const { Pool } = require('pg');
+const logger = require('../utils/logger');
+const { MusicBrainzQueue, createMbFetch } = require('../utils/request-queue');
+const { ODESLI_RATE_LIMIT_MS } = require('../services/availability/platforms');
+const {
+  createExternalIdentityService,
+} = require('../services/external-identity-service');
+const {
+  createOdesliClient,
+} = require('../services/availability/odesli-client');
+const {
+  createMbUrlRelsSource,
+} = require('../services/availability/mb-url-rels-source');
+const {
+  createSeedProviders,
+} = require('../services/availability/seed-providers');
+const {
+  createAvailabilityResolutionService,
+} = require('../services/availability-resolution-service');
+
+const MAX_RETRY_ROUNDS = 5;
+const RETRY_PAUSE_MS = 8000;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isTransientSkip(res) {
+  return res && res.action === 'skip' && res.transient === true;
+}
+
+function parseLimit() {
+  const arg = process.argv.find((a) => a.startsWith('--limit='));
+  if (!arg) return null;
+  const n = parseInt(arg.split('=')[1], 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function buildResolution(pool) {
+  const db = { raw: (sql, params) => pool.query(sql, params) };
+  const fetchFn = fetch;
+  const mbFetch = createMbFetch(new MusicBrainzQueue({ fetch: fetchFn }));
+  const externalIdentityService = createExternalIdentityService({ db, logger });
+  return createAvailabilityResolutionService({
+    logger,
+    externalIdentityService,
+    odesliClient: createOdesliClient({ fetch: fetchFn, logger }),
+    mbUrlRelsSource: createMbUrlRelsSource({ mbFetch, logger }),
+    seedProviders: createSeedProviders({
+      fetch: fetchFn,
+      logger,
+      externalIdentityService,
+    }),
+  });
+}
+
+async function resolveOne(resolution, row, apply) {
+  try {
+    return await resolution.resolveAvailability(
+      { albumId: row.album_id, artist: row.artist, album: row.album },
+      { persist: apply }
+    );
+  } catch (err) {
+    return {
+      action: 'skip',
+      reason: 'error',
+      transient: true,
+      error: err.message,
+    };
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const limit = parseLimit();
+
+  if (!process.env.DATABASE_URL) {
+    logger.error('DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const resolution = buildResolution(pool);
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT a.album_id, a.artist, a.album
+         FROM albums a
+        WHERE a.artist IS NOT NULL AND a.album IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM album_service_mappings m
+             WHERE m.album_id = a.album_id
+               AND m.strategy LIKE 'availability:%'
+          )
+        ORDER BY a.artist, a.album
+        ${limit ? `LIMIT ${limit}` : ''}`
+    );
+
+    console.log(
+      `\nResolving availability for ${rows.length} album(s) ` +
+        `(${apply ? 'APPLY' : 'DRY-RUN'})...\n`
+    );
+
+    const entries = rows.map((row) => ({ row, res: null }));
+    for (let i = 0; i < entries.length; i++) {
+      entries[i].res = await resolveOne(resolution, entries[i].row, apply);
+      const r = entries[i].res;
+      console.log(
+        `  ${i + 1}/${entries.length}  ${r.action}` +
+          (r.services ? ` [${r.services.join(', ')}]` : '') +
+          (r.reason ? ` (${r.reason})` : '') +
+          `  ${entries[i].row.artist} — ${entries[i].row.album}`
+      );
+      await sleep(ODESLI_RATE_LIMIT_MS);
+    }
+
+    for (let round = 1; round <= MAX_RETRY_ROUNDS; round++) {
+      const pending = entries.filter((e) => isTransientSkip(e.res));
+      if (pending.length === 0) break;
+      console.log(
+        `\nRetry round ${round}/${MAX_RETRY_ROUNDS}: ${pending.length} transient skip(s)...`
+      );
+      await sleep(RETRY_PAUSE_MS);
+      for (const entry of pending) {
+        entry.res = await resolveOne(resolution, entry.row, apply);
+        await sleep(ODESLI_RATE_LIMIT_MS);
+      }
+    }
+
+    const count = (action) =>
+      entries.filter((e) => e.res.action === action).length;
+    const transientLeft = entries.filter((e) => isTransientSkip(e.res)).length;
+
+    console.log('\n=== Summary ===');
+    console.log(`  checked:  ${entries.length}`);
+    console.log(
+      `  resolved: ${count('resolved')}${apply ? ' (written)' : ' (dry-run)'}`
+    );
+    console.log(`  skipped:  ${count('skip')} (transient ${transientLeft})`);
+    if (!apply && count('resolved') > 0) {
+      console.log('\nRe-run with --apply to write these mappings.');
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  logger.error('backfill-availability failed', { error: err.message });
+  process.exit(1);
+});

--- a/services/availability-fetch-queue.js
+++ b/services/availability-fetch-queue.js
@@ -1,0 +1,151 @@
+/**
+ * Availability Fetch Queue
+ *
+ * Background queue that resolves which platforms provide a freshly-added album
+ * (via the availability resolution service) and caches the result. Runs off the
+ * request path like the cover/track/native-name queues, serialized and paced to
+ * stay within Odesli's free-tier rate limit. Already-resolved albums short-
+ * circuit without a network call (and without consuming the pacing delay).
+ */
+
+const {
+  RequestQueue,
+  MusicBrainzQueue,
+  createMbFetch,
+} = require('../utils/request-queue');
+const logger = require('../utils/logger');
+const { ensureDb } = require('../db/postgres');
+const { ODESLI_RATE_LIMIT_MS } = require('./availability/platforms');
+const {
+  createExternalIdentityService,
+} = require('./external-identity-service');
+const { createOdesliClient } = require('./availability/odesli-client');
+const { createMbUrlRelsSource } = require('./availability/mb-url-rels-source');
+const { createSeedProviders } = require('./availability/seed-providers');
+const {
+  createAvailabilityResolutionService,
+} = require('./availability-resolution-service');
+
+function createAvailabilityFetchQueue(deps = {}) {
+  const maxConcurrent = deps.maxConcurrent || 1; // serialize for the Odesli limit
+  const queue = new RequestQueue(maxConcurrent);
+  const fetchFn = deps.fetch || fetch;
+  const log = deps.logger || logger;
+  const rateLimitMs =
+    deps.rateLimitMs === undefined ? ODESLI_RATE_LIMIT_MS : deps.rateLimitMs;
+  const db =
+    deps.db !== undefined && deps.db !== null
+      ? ensureDb(deps.db, 'availability-fetch-queue')
+      : null;
+  const mbFetch =
+    deps.mbFetch || createMbFetch(new MusicBrainzQueue({ fetch: fetchFn }));
+
+  // Tests may inject a ready-made repository + resolution service; otherwise the
+  // dependency graph is assembled from db (production startup path).
+  const externalIdentityService =
+    deps.externalIdentityService ||
+    (db ? createExternalIdentityService({ db, logger: log }) : null);
+  const resolutionService =
+    deps.resolutionService ||
+    (externalIdentityService
+      ? createAvailabilityResolutionService({
+          logger: log,
+          externalIdentityService,
+          odesliClient: createOdesliClient({ fetch: fetchFn, logger: log }),
+          mbUrlRelsSource: createMbUrlRelsSource({ mbFetch, logger: log }),
+          seedProviders: createSeedProviders({
+            fetch: fetchFn,
+            logger: log,
+            externalIdentityService,
+          }),
+        })
+      : null);
+
+  async function pace() {
+    if (rateLimitMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, rateLimitMs));
+    }
+  }
+
+  /**
+   * Enqueue availability resolution for an album. No-op when fields are missing
+   * or the dependency graph is not configured.
+   */
+  function add(albumId, artist, album) {
+    if (!albumId || !artist || !album) return;
+    if (!externalIdentityService || !resolutionService) return;
+
+    return queue.add(async () => {
+      try {
+        const existing =
+          await externalIdentityService.getAlbumAvailability(albumId);
+        // Skip only when availability was already resolved here. A prior
+        // Spotify/Tidal identity mapping (from playback/export) does not count.
+        const alreadyResolved = existing.some((row) =>
+          String(row.strategy || '').startsWith('availability:')
+        );
+        if (alreadyResolved) return;
+      } catch (err) {
+        log.warn('Availability pre-check failed', {
+          albumId,
+          error: err.message,
+        });
+        return;
+      }
+
+      try {
+        const result = await resolutionService.resolveAvailability({
+          albumId,
+          artist,
+          album,
+        });
+        if (result.action === 'resolved') {
+          log.info('Resolved album availability', {
+            albumId,
+            services: result.services,
+          });
+        }
+      } catch (err) {
+        log.warn('Availability resolution failed', {
+          albumId,
+          error: err.message,
+        });
+      } finally {
+        await pace(); // only reached when an actual resolution was attempted
+      }
+    });
+  }
+
+  return {
+    add,
+    get length() {
+      return queue.length;
+    },
+  };
+}
+
+// Singleton (initialized with db at startup)
+let availabilityFetchQueue = null;
+
+function initializeAvailabilityFetchQueue(db) {
+  if (!availabilityFetchQueue) {
+    availabilityFetchQueue = createAvailabilityFetchQueue({ db });
+    logger.info('Availability fetch queue initialized');
+  }
+  return availabilityFetchQueue;
+}
+
+function getAvailabilityFetchQueue() {
+  if (!availabilityFetchQueue) {
+    throw new Error(
+      'Availability fetch queue not initialized. Call initializeAvailabilityFetchQueue(db) first.'
+    );
+  }
+  return availabilityFetchQueue;
+}
+
+module.exports = {
+  createAvailabilityFetchQueue,
+  initializeAvailabilityFetchQueue,
+  getAvailabilityFetchQueue,
+};

--- a/services/availability-resolution-service.js
+++ b/services/availability-resolution-service.js
@@ -1,0 +1,149 @@
+/**
+ * Availability resolution orchestration.
+ *
+ * Seeds an album (existing mapping / MusicBrainz / public search), expands the
+ * seed via Odesli, unions the result with MusicBrainz direct links, gates by
+ * confidence, and persists one album_service_mappings row per platform.
+ *
+ * Pure orchestration: no SQL and no HTTP of its own — it composes the injected
+ * strategy modules and the external-identity repository.
+ */
+
+const defaultLogger = require('../utils/logger');
+const {
+  normalizeOdesliPlatform,
+  AVAILABILITY_CONFIDENCE_FLOOR,
+} = require('./availability/platforms');
+
+const MB_LINK_CONFIDENCE = 0.9; // MusicBrainz url-rels are identity-confirmed
+
+function isTransientStatus(status) {
+  return !status || status === 429 || status >= 500;
+}
+
+/**
+ * Union Odesli platform links with MusicBrainz direct links into one row per
+ * canonical service, keeping the higher-confidence source on a conflict.
+ */
+function mergeLinks(odesliLinks, mbLinks, seedKind, seedConfidence) {
+  const byService = new Map();
+
+  const consider = (service, url, confidence, strategy) => {
+    if (!service || !url) return;
+    const existing = byService.get(service);
+    if (!existing || confidence > existing.confidence) {
+      byService.set(service, { service, url, confidence, strategy });
+    }
+  };
+
+  for (const link of odesliLinks) {
+    consider(
+      normalizeOdesliPlatform(link.platform),
+      link.url,
+      seedConfidence,
+      `availability:${seedKind}`
+    );
+  }
+  for (const link of mbLinks) {
+    consider(
+      link.service,
+      link.url,
+      MB_LINK_CONFIDENCE,
+      'availability:musicbrainz'
+    );
+  }
+
+  return [...byService.values()].filter(
+    (row) => row.confidence >= AVAILABILITY_CONFIDENCE_FLOOR
+  );
+}
+
+function createAvailabilityResolutionService(deps = {}) {
+  const logger = deps.logger || defaultLogger;
+  const externalIdentityService = deps.externalIdentityService;
+  const odesliClient = deps.odesliClient;
+  const mbUrlRelsSource = deps.mbUrlRelsSource;
+  const seedProviders = deps.seedProviders;
+
+  async function getMusicbrainz(albumId) {
+    try {
+      return await mbUrlRelsSource.getDirectLinks(albumId);
+    } catch (err) {
+      logger.debug?.('MusicBrainz url-rels lookup failed', {
+        albumId,
+        error: err.message,
+      });
+      return { seedUrl: null, links: [] };
+    }
+  }
+
+  /**
+   * @param {{albumId:string, artist:string, album:string}} album
+   * @param {{persist?:boolean}} [options]
+   * @returns {Promise<{action:string, reason?:string, transient?:boolean,
+   *   services?:string[]}>}
+   */
+  async function resolveAvailability(album, options = {}) {
+    const { persist = true } = options;
+    const mb = await getMusicbrainz(album.albumId);
+    const seedResult = await seedProviders.acquireSeed(album, mb.seedUrl);
+
+    if (!seedResult && mb.links.length === 0) {
+      return { action: 'skip', reason: 'no-seed', transient: false };
+    }
+
+    let odesliLinks = [];
+    if (seedResult) {
+      try {
+        odesliLinks = await odesliClient.fetchLinksBySeed(seedResult.seed);
+      } catch (err) {
+        if (mb.links.length === 0) {
+          return {
+            action: 'skip',
+            reason: 'odesli-error',
+            transient: isTransientStatus(err.status),
+          };
+        }
+        logger.debug?.(
+          'Odesli expansion failed; using MusicBrainz links only',
+          {
+            albumId: album.albumId,
+            error: err.message,
+          }
+        );
+      }
+    }
+
+    const rows = mergeLinks(
+      odesliLinks,
+      mb.links,
+      seedResult ? seedResult.kind : 'musicbrainz',
+      seedResult ? seedResult.confidence : MB_LINK_CONFIDENCE
+    );
+
+    if (rows.length === 0) {
+      return { action: 'skip', reason: 'no-links', transient: false };
+    }
+
+    if (persist) {
+      for (const row of rows) {
+        await externalIdentityService.upsertAlbumServiceMapping({
+          albumId: album.albumId,
+          service: row.service,
+          externalUrl: row.url,
+          confidence: row.confidence,
+          strategy: row.strategy,
+        });
+      }
+    }
+
+    return { action: 'resolved', services: rows.map((r) => r.service) };
+  }
+
+  return { resolveAvailability };
+}
+
+module.exports = {
+  createAvailabilityResolutionService,
+  mergeLinks,
+};

--- a/services/availability/mb-url-rels-source.js
+++ b/services/availability/mb-url-rels-source.js
@@ -1,0 +1,90 @@
+/**
+ * MusicBrainz url-rels availability source.
+ *
+ * url-rels (streaming / purchase links) live at the RELEASE level, so a
+ * release-group id is first resolved to a representative release. Returns the
+ * recognized direct links plus a high-confidence streaming url that doubles as
+ * an Odesli seed. Reuses the injected, rate-limited `mbFetch` (shared MB queue).
+ */
+
+const defaultLogger = require('../../utils/logger');
+const { SUSHE_USER_AGENT } = require('../../utils/musicbrainz-helpers');
+const { isMusicbrainzId } = require('../native-name-service');
+const { normalizeMusicbrainzUrl } = require('./platforms');
+
+const MB_BASE = 'https://musicbrainz.org/ws/2';
+const HEADERS = { 'User-Agent': SUSHE_USER_AGENT, Accept: 'application/json' };
+
+function createMbUrlRelsSource(deps = {}) {
+  const mbFetch = deps.mbFetch;
+  const logger = deps.logger || defaultLogger;
+
+  async function mbJson(url) {
+    const resp = await mbFetch(url, { headers: HEADERS }, 'low');
+    if (!resp.ok) {
+      const err = new Error(`MusicBrainz responded ${resp.status}`);
+      err.status = resp.status;
+      throw err;
+    }
+    return resp.json();
+  }
+
+  async function resolveReleaseId(albumId) {
+    try {
+      const rg = await mbJson(
+        `${MB_BASE}/release-group/${albumId}?inc=releases&fmt=json`
+      );
+      const releases = rg.releases || [];
+      if (releases.length) {
+        const official = releases.find((r) => r.status === 'Official');
+        return (official || releases[0]).id;
+      }
+    } catch (err) {
+      // A 404 means the id is not a release-group — treat it as a release id.
+      if (err.status && err.status !== 404) throw err;
+    }
+    return albumId;
+  }
+
+  /**
+   * @param {string} albumId - canonical album id (a MusicBrainz UUID)
+   * @returns {Promise<{seedUrl: string|null, links: Array<{service:string, url:string}>}>}
+   */
+  async function getDirectLinks(albumId) {
+    if (!mbFetch || !isMusicbrainzId(albumId)) {
+      return { seedUrl: null, links: [] };
+    }
+
+    const releaseId = await resolveReleaseId(albumId);
+    const release = await mbJson(
+      `${MB_BASE}/release/${releaseId}?inc=url-rels&fmt=json`
+    );
+    const relations = release.relations || [];
+
+    const links = [];
+    const seen = new Set();
+    for (const rel of relations) {
+      const url = rel.url && rel.url.resource;
+      if (!url) continue;
+      const service = normalizeMusicbrainzUrl(url);
+      if (!service || seen.has(service)) continue;
+      seen.add(service);
+      links.push({ service, url });
+    }
+
+    const streaming = relations.find(
+      (r) => /stream/i.test(r.type || '') && r.url && r.url.resource
+    );
+    const seedUrl = (streaming && streaming.url.resource) || null;
+
+    logger.debug?.('MusicBrainz url-rels resolved', {
+      albumId,
+      links: links.length,
+    });
+    return { seedUrl, links };
+  }
+
+  return { getDirectLinks };
+}
+
+module.exports = { createMbUrlRelsSource };

--- a/services/availability/odesli-client.js
+++ b/services/availability/odesli-client.js
@@ -1,0 +1,52 @@
+/**
+ * Odesli (song.link) client — expands one seed link/id into deep links across
+ * many platforms. Pure adapter: returns normalized links on success, throws on
+ * a transient transport problem (network / 429 / 5xx) so the orchestrator can
+ * decide whether to retry. No persistence, no rate-limiting (the queue paces it).
+ */
+
+const defaultLogger = require('../../utils/logger');
+const { ODESLI_BASE_URL, ODESLI_USER_COUNTRY } = require('./platforms');
+
+function createOdesliClient(deps = {}) {
+  const fetchFn = deps.fetch || fetch;
+  const logger = deps.logger || defaultLogger;
+  const baseUrl = deps.baseUrl || ODESLI_BASE_URL;
+
+  /**
+   * @param {{url?:string, platform?:string, type?:string, id?:string}} seed
+   * @returns {Promise<Array<{platform:string, url:string}>>} Odesli platform links
+   */
+  async function fetchLinksBySeed(seed) {
+    const params = new URLSearchParams({ userCountry: ODESLI_USER_COUNTRY });
+    if (seed?.url) {
+      params.set('url', seed.url);
+    } else if (seed?.platform && seed?.id) {
+      params.set('platform', seed.platform);
+      params.set('type', seed.type || 'album');
+      params.set('id', String(seed.id));
+    } else {
+      return []; // nothing to expand — not an error
+    }
+
+    const resp = await fetchFn(`${baseUrl}?${params.toString()}`);
+    if (!resp.ok) {
+      const err = new Error(`Odesli responded ${resp.status}`);
+      err.status = resp.status;
+      throw err;
+    }
+
+    const data = await resp.json();
+    const byPlatform = (data && data.linksByPlatform) || {};
+    const links = [];
+    for (const [platform, info] of Object.entries(byPlatform)) {
+      if (info && info.url) links.push({ platform, url: info.url });
+    }
+    logger.debug?.('Odesli expanded seed', { count: links.length });
+    return links;
+  }
+
+  return { fetchLinksBySeed };
+}
+
+module.exports = { createOdesliClient };

--- a/services/availability/platforms.js
+++ b/services/availability/platforms.js
@@ -1,0 +1,130 @@
+/**
+ * Music platform allowlist + name normalization (single source of truth).
+ *
+ * "Which services exist" is application policy, not a storage invariant, so the
+ * DB no longer constrains it (migration 063). Add a platform by editing the
+ * maps here only — the repository, resolution service and queue all read from
+ * this module.
+ */
+
+// Services that prior code already used for cross-platform identity resolution.
+const IDENTITY_SERVICES = ['spotify', 'tidal', 'lastfm'];
+
+// Canonical (snake_case) names for the streaming/store platforms whose
+// availability we resolve and store.
+const AVAILABILITY_SERVICES = [
+  'spotify',
+  'apple_music',
+  'itunes',
+  'tidal',
+  'deezer',
+  'amazon_music',
+  'amazon_store',
+  'youtube',
+  'youtube_music',
+  'soundcloud',
+  'bandcamp',
+  'pandora',
+  'napster',
+  'anghami',
+  'boomplay',
+  'yandex',
+  'audiomack',
+  'audius',
+];
+
+// Full set the repository accepts on read/write (replaces the dropped DB CHECK).
+const SUPPORTED_SERVICES = new Set([
+  ...IDENTITY_SERVICES,
+  ...AVAILABILITY_SERVICES,
+]);
+
+// Odesli (song.link) platform keys -> canonical service name.
+const ODESLI_PLATFORM_TO_SERVICE = {
+  spotify: 'spotify',
+  appleMusic: 'apple_music',
+  itunes: 'itunes',
+  tidal: 'tidal',
+  deezer: 'deezer',
+  amazonMusic: 'amazon_music',
+  amazonStore: 'amazon_store',
+  youtube: 'youtube',
+  youtubeMusic: 'youtube_music',
+  soundcloud: 'soundcloud',
+  bandcamp: 'bandcamp',
+  pandora: 'pandora',
+  napster: 'napster',
+  anghami: 'anghami',
+  boomplay: 'boomplay',
+  yandex: 'yandex',
+  audiomack: 'audiomack',
+  audius: 'audius',
+};
+
+// MusicBrainz url-rels hostnames -> canonical service. Ordered most-specific
+// first; first substring hit wins (so music.apple.com beats itunes.apple.com,
+// music.youtube.com beats youtube.com).
+const MB_HOST_MATCHERS = [
+  ['music.apple.com', 'apple_music'],
+  ['itunes.apple.com', 'itunes'],
+  ['music.youtube.com', 'youtube_music'],
+  ['youtube.com', 'youtube'],
+  ['youtu.be', 'youtube'],
+  ['music.amazon', 'amazon_music'],
+  ['open.spotify.com', 'spotify'],
+  ['spotify.com', 'spotify'],
+  ['tidal.com', 'tidal'],
+  ['deezer.com', 'deezer'],
+  ['bandcamp.com', 'bandcamp'],
+  ['soundcloud.com', 'soundcloud'],
+  ['anghami.com', 'anghami'],
+  ['boomplay.com', 'boomplay'],
+  ['audiomack.com', 'audiomack'],
+];
+
+// Odesli request configuration. Rate is held under the free tier's ~10 req/min.
+const ODESLI_BASE_URL = 'https://api.song.link/v1-alpha.1/links';
+const ODESLI_USER_COUNTRY = 'US';
+const ODESLI_RATE_LIMIT_MS = 6500;
+
+// Drop any resolved service whose seed confidence is below this floor.
+const AVAILABILITY_CONFIDENCE_FLOOR = 0.5;
+
+/**
+ * @param {string} platformKey - Odesli platform key (e.g. 'appleMusic')
+ * @returns {string|null} canonical service name, or null if unknown
+ */
+function normalizeOdesliPlatform(platformKey) {
+  return ODESLI_PLATFORM_TO_SERVICE[platformKey] || null;
+}
+
+/**
+ * @param {string} url - A url-rels resource url from MusicBrainz
+ * @returns {string|null} canonical service name, or null if unrecognised
+ */
+function normalizeMusicbrainzUrl(url) {
+  let host;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  for (const [needle, service] of MB_HOST_MATCHERS) {
+    if (host.includes(needle)) return service;
+  }
+  return null;
+}
+
+module.exports = {
+  IDENTITY_SERVICES,
+  AVAILABILITY_SERVICES,
+  SUPPORTED_SERVICES,
+  ODESLI_PLATFORM_TO_SERVICE,
+  MB_HOST_MATCHERS,
+  ODESLI_BASE_URL,
+  ODESLI_USER_COUNTRY,
+  ODESLI_RATE_LIMIT_MS,
+  AVAILABILITY_CONFIDENCE_FLOOR,
+  normalizeOdesliPlatform,
+  normalizeMusicbrainzUrl,
+};

--- a/services/availability/seed-providers.js
+++ b/services/availability/seed-providers.js
@@ -1,0 +1,146 @@
+/**
+ * Seed acquisition for Odesli expansion.
+ *
+ * Returns the highest-confidence seed available, tried cheapest-first:
+ *   (a) an existing Spotify/Tidal mapping (zero extra network calls),
+ *   (b) a MusicBrainz streaming url passed in by the orchestrator,
+ *   (c) a public iTunes/Deezer search, each gated by the shared entity-matching
+ *       confidence check so a loose text match never seeds a wrong release.
+ * This module only *acquires* a seed; it does not call Odesli or persist.
+ */
+
+const defaultLogger = require('../../utils/logger');
+const { normalizeForExternalApi } = require('../../utils/normalization');
+const { selectBestCandidate } = require('../../utils/entity-matching');
+
+const SEED_CONFIDENCE = { existing: 0.95, musicbrainz: 0.9 };
+const EXISTING_SEED_SERVICES = ['spotify', 'tidal'];
+
+function clean(value) {
+  return normalizeForExternalApi(value || '')
+    .replace(/[()[\]{}]/g, '')
+    .replace(/[.,!?]/g, '')
+    .trim();
+}
+
+function createSeedProviders(deps = {}) {
+  const fetchFn = deps.fetch || fetch;
+  const logger = deps.logger || defaultLogger;
+  const externalIdentityService = deps.externalIdentityService;
+
+  async function existingMappingSeed(albumId) {
+    if (!externalIdentityService || !albumId) return null;
+    for (const service of EXISTING_SEED_SERVICES) {
+      try {
+        const mapping = await externalIdentityService.getAlbumServiceMapping(
+          service,
+          albumId
+        );
+        if (mapping && mapping.external_album_id) {
+          return {
+            kind: 'existing',
+            confidence: SEED_CONFIDENCE.existing,
+            seed: {
+              platform: service,
+              type: 'album',
+              id: mapping.external_album_id,
+            },
+          };
+        }
+      } catch (err) {
+        logger.debug?.('existing-mapping seed lookup failed', {
+          service,
+          error: err.message,
+        });
+      }
+    }
+    return null;
+  }
+
+  async function itunesSeed(artist, album) {
+    const term = `${clean(artist)} ${clean(album)}`.trim();
+    const url = `https://itunes.apple.com/search?term=${encodeURIComponent(term)}&entity=album&limit=5`;
+    const resp = await fetchFn(url);
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const candidates = data.results || [];
+    const { best, isConfident } = selectBestCandidate({
+      target: { artist, album },
+      candidates,
+      getArtist: (r) => r.artistName,
+      getAlbum: (r) => r.collectionName,
+    });
+    if (!isConfident || !best.candidate.collectionId) return null;
+    return {
+      kind: 'itunes',
+      confidence: best.combined,
+      seed: {
+        platform: 'itunes',
+        type: 'album',
+        id: best.candidate.collectionId,
+      },
+    };
+  }
+
+  async function deezerSeed(artist, album) {
+    const q = `${clean(artist)} ${clean(album)}`.trim();
+    const url = `https://api.deezer.com/search/album?q=${encodeURIComponent(q)}&limit=5`;
+    const resp = await fetchFn(url);
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const candidates = data.data || [];
+    const { best, isConfident } = selectBestCandidate({
+      target: { artist, album },
+      candidates,
+      getArtist: (r) => r.artist && r.artist.name,
+      getAlbum: (r) => r.title,
+    });
+    if (!isConfident || !best.candidate.id) return null;
+    return {
+      kind: 'deezer',
+      confidence: best.combined,
+      seed: {
+        url:
+          best.candidate.link ||
+          `https://www.deezer.com/album/${best.candidate.id}`,
+      },
+    };
+  }
+
+  async function searchSeed(artist, album) {
+    if (!artist || !album) return null;
+    for (const provider of [itunesSeed, deezerSeed]) {
+      try {
+        const result = await provider(artist, album);
+        if (result) return result;
+      } catch (err) {
+        logger.debug?.('search seed provider failed', { error: err.message });
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param {{albumId:string, artist:string, album:string}} album
+   * @param {string|null} mbSeedUrl - streaming url from MusicBrainz, if any
+   * @returns {Promise<{kind:string, confidence:number, seed:Object}|null>}
+   */
+  async function acquireSeed(album, mbSeedUrl) {
+    const existing = await existingMappingSeed(album.albumId);
+    if (existing) return existing;
+
+    if (mbSeedUrl) {
+      return {
+        kind: 'musicbrainz',
+        confidence: SEED_CONFIDENCE.musicbrainz,
+        seed: { url: mbSeedUrl },
+      };
+    }
+
+    return searchSeed(album.artist, album.album);
+  }
+
+  return { acquireSeed };
+}
+
+module.exports = { createSeedProviders };

--- a/services/external-identity-service.js
+++ b/services/external-identity-service.js
@@ -4,8 +4,7 @@ const {
   normalizeArtistName,
   sanitizeForStorage,
 } = require('../utils/normalization');
-
-const SUPPORTED_SERVICES = new Set(['spotify', 'tidal', 'lastfm']);
+const { SUPPORTED_SERVICES } = require('./availability/platforms');
 const LAST_USED_TOUCH_INTERVAL_SQL = "INTERVAL '1 hour'";
 
 function normalizeService(service) {
@@ -20,6 +19,49 @@ function normalizeArtistKey(name) {
 
 function isSupportedService(service) {
   return SUPPORTED_SERVICES.has(normalizeService(service));
+}
+
+/**
+ * All stored platform availability rows for one album.
+ * @param {import('../db/types').DbFacade} db
+ * @param {string} albumId
+ * @returns {Promise<Array<{service:string, external_album_id:string|null,
+ *   external_url:string|null, confidence:number|null, strategy:string|null}>>}
+ */
+async function fetchAlbumAvailability(db, albumId) {
+  if (!albumId) return [];
+
+  const result = await db.raw(
+    `SELECT service, external_album_id, external_url, confidence, strategy
+       FROM album_service_mappings
+      WHERE album_id = $1
+      ORDER BY service`,
+    [albumId],
+    { name: 'external-identity-get-album-availability', retryable: true }
+  );
+
+  return result.rows;
+}
+
+/**
+ * Availability rows for many albums at once (caller groups by album_id).
+ * @param {import('../db/types').DbFacade} db
+ * @param {string[]} albumIds
+ * @returns {Promise<Array<Object>>}
+ */
+async function fetchAlbumAvailabilityBulk(db, albumIds) {
+  if (!Array.isArray(albumIds) || albumIds.length === 0) return [];
+
+  const result = await db.raw(
+    `SELECT album_id, service, external_album_id, external_url, confidence, strategy
+       FROM album_service_mappings
+      WHERE album_id = ANY($1)
+      ORDER BY album_id, service`,
+    [albumIds],
+    { name: 'external-identity-get-album-availability-bulk', retryable: true }
+  );
+
+  return result.rows;
 }
 
 function createExternalIdentityService(deps = {}) {
@@ -66,13 +108,14 @@ function createExternalIdentityService(deps = {}) {
     await db.raw(
       `INSERT INTO album_service_mappings (
          album_id, service, external_album_id, external_artist, external_album,
-         confidence, strategy, created_at, updated_at, last_used_at
-       ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), NOW())
+         external_url, confidence, strategy, created_at, updated_at, last_used_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW(), NOW())
        ON CONFLICT (album_id, service)
        DO UPDATE SET
          external_album_id = COALESCE(EXCLUDED.external_album_id, album_service_mappings.external_album_id),
          external_artist = COALESCE(EXCLUDED.external_artist, album_service_mappings.external_artist),
          external_album = COALESCE(EXCLUDED.external_album, album_service_mappings.external_album),
+         external_url = COALESCE(EXCLUDED.external_url, album_service_mappings.external_url),
          confidence = COALESCE(EXCLUDED.confidence, album_service_mappings.confidence),
          strategy = COALESCE(EXCLUDED.strategy, album_service_mappings.strategy),
          updated_at = NOW(),
@@ -87,11 +130,17 @@ function createExternalIdentityService(deps = {}) {
         mapping.externalAlbum
           ? sanitizeForStorage(mapping.externalAlbum)
           : null,
+        mapping.externalUrl || null,
         mapping.confidence || null,
         mapping.strategy || null,
       ]
     );
   }
+
+  // Availability reads delegate to module-scope helpers to keep the factory lean.
+  const getAlbumAvailability = (albumId) => fetchAlbumAvailability(db, albumId);
+  const getAlbumAvailabilityBulk = (albumIds) =>
+    fetchAlbumAvailabilityBulk(db, albumIds);
 
   async function getArtistAlias(service, canonicalArtist) {
     const normalizedService = normalizeService(service);
@@ -233,6 +282,8 @@ function createExternalIdentityService(deps = {}) {
   return {
     getAlbumServiceMapping,
     upsertAlbumServiceMapping,
+    getAlbumAvailability,
+    getAlbumAvailabilityBulk,
     getArtistAlias,
     getArtistAliasCandidates,
     upsertArtistAlias,

--- a/test/availability-fetch-queue.test.js
+++ b/test/availability-fetch-queue.test.js
@@ -1,0 +1,96 @@
+const { describe, it, mock, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const {
+  createAvailabilityFetchQueue,
+  initializeAvailabilityFetchQueue,
+  getAvailabilityFetchQueue,
+} = require('../services/availability-fetch-queue');
+const { createMockLogger } = require('./helpers');
+
+function build({ existing = [], resolve } = {}) {
+  const getAlbumAvailability = mock.fn(async () => existing);
+  const resolveAvailability = mock.fn(
+    resolve || (async () => ({ action: 'resolved', services: ['spotify'] }))
+  );
+  const queue = createAvailabilityFetchQueue({
+    logger: createMockLogger(),
+    rateLimitMs: 0,
+    externalIdentityService: { getAlbumAvailability },
+    resolutionService: { resolveAvailability },
+    // a db value so ensureDb is bypassed via injected services (db unused here)
+  });
+  return { queue, getAlbumAvailability, resolveAvailability };
+}
+
+describe('availability-fetch-queue', () => {
+  it('ignores incomplete input', async () => {
+    const { queue, resolveAvailability } = build();
+    queue.add('', 'a', 'b');
+    queue.add('id', '', 'b');
+    queue.add('id', 'a', '');
+    assert.strictEqual(resolveAvailability.mock.calls.length, 0);
+  });
+
+  it('resolves availability for a new album', async () => {
+    const { queue, resolveAvailability } = build({ existing: [] });
+    await queue.add('alb-1', 'Metallica', '72 Seasons');
+    assert.strictEqual(resolveAvailability.mock.calls.length, 1);
+    assert.deepStrictEqual(resolveAvailability.mock.calls[0].arguments[0], {
+      albumId: 'alb-1',
+      artist: 'Metallica',
+      album: '72 Seasons',
+    });
+  });
+
+  it('short-circuits when availability was already resolved', async () => {
+    const { queue, resolveAvailability } = build({
+      existing: [{ service: 'spotify', strategy: 'availability:existing' }],
+    });
+    await queue.add('alb-1', 'Metallica', '72 Seasons');
+    assert.strictEqual(resolveAvailability.mock.calls.length, 0);
+  });
+
+  it('still resolves when only a prior identity mapping exists', async () => {
+    const { queue, resolveAvailability } = build({
+      existing: [{ service: 'spotify', strategy: 'scored_search' }],
+    });
+    await queue.add('alb-1', 'Metallica', '72 Seasons');
+    assert.strictEqual(resolveAvailability.mock.calls.length, 1);
+  });
+
+  it('swallows resolution errors without throwing', async () => {
+    const { queue } = build({
+      resolve: async () => {
+        throw new Error('boom');
+      },
+    });
+    await assert.doesNotReject(() => queue.add('alb-1', 'A', 'B'));
+  });
+
+  describe('singleton', () => {
+    beforeEach(() => {
+      // reset module singleton between assertions via fresh require cache
+    });
+
+    it('getAvailabilityFetchQueue throws before init', () => {
+      // Note: initialize may have run in another test file; guard both shapes.
+      try {
+        const q = getAvailabilityFetchQueue();
+        assert.ok(q && typeof q.add === 'function');
+      } catch (err) {
+        assert.match(err.message, /not initialized/);
+      }
+    });
+
+    it('initialize is idempotent', () => {
+      const a = initializeAvailabilityFetchQueue({
+        raw: async () => ({ rows: [] }),
+      });
+      const b = initializeAvailabilityFetchQueue({
+        raw: async () => ({ rows: [] }),
+      });
+      assert.strictEqual(a, b);
+      assert.ok(typeof getAvailabilityFetchQueue().add === 'function');
+    });
+  });
+});

--- a/test/availability-platforms.test.js
+++ b/test/availability-platforms.test.js
@@ -1,0 +1,51 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  SUPPORTED_SERVICES,
+  normalizeOdesliPlatform,
+  normalizeMusicbrainzUrl,
+} = require('../services/availability/platforms');
+
+describe('availability/platforms', () => {
+  it('allows identity + availability services', () => {
+    for (const s of ['spotify', 'tidal', 'lastfm', 'deezer', 'apple_music']) {
+      assert.ok(SUPPORTED_SERVICES.has(s), `${s} should be supported`);
+    }
+  });
+
+  it('maps Odesli platform keys to canonical services', () => {
+    assert.strictEqual(normalizeOdesliPlatform('appleMusic'), 'apple_music');
+    assert.strictEqual(normalizeOdesliPlatform('amazonMusic'), 'amazon_music');
+    assert.strictEqual(
+      normalizeOdesliPlatform('youtubeMusic'),
+      'youtube_music'
+    );
+    assert.strictEqual(normalizeOdesliPlatform('tidal'), 'tidal');
+    assert.strictEqual(normalizeOdesliPlatform('unknownThing'), null);
+  });
+
+  it('maps MusicBrainz hosts to canonical services (most-specific first)', () => {
+    assert.strictEqual(
+      normalizeMusicbrainzUrl('https://music.apple.com/us/album/1655432387'),
+      'apple_music'
+    );
+    assert.strictEqual(
+      normalizeMusicbrainzUrl('https://itunes.apple.com/fr/album/id1679530462'),
+      'itunes'
+    );
+    assert.strictEqual(
+      normalizeMusicbrainzUrl('https://listen.tidal.com/album/288984589'),
+      'tidal'
+    );
+    assert.strictEqual(
+      normalizeMusicbrainzUrl('https://artist.bandcamp.com/album/x'),
+      'bandcamp'
+    );
+    assert.strictEqual(
+      normalizeMusicbrainzUrl('https://music.youtube.com/playlist?list=x'),
+      'youtube_music'
+    );
+    assert.strictEqual(normalizeMusicbrainzUrl('not a url'), null);
+    assert.strictEqual(normalizeMusicbrainzUrl('https://example.com/x'), null);
+  });
+});

--- a/test/availability-resolution-service.test.js
+++ b/test/availability-resolution-service.test.js
@@ -1,0 +1,127 @@
+const { describe, it, mock } = require('node:test');
+const assert = require('node:assert');
+const {
+  createAvailabilityResolutionService,
+  mergeLinks,
+} = require('../services/availability-resolution-service');
+const { createMockLogger } = require('./helpers');
+
+const album = { albumId: 'alb-1', artist: 'Metallica', album: '72 Seasons' };
+
+function build({ seed, odesli, mb }) {
+  const upsert = mock.fn(async () => {});
+  const service = createAvailabilityResolutionService({
+    logger: createMockLogger(),
+    externalIdentityService: { upsertAlbumServiceMapping: upsert },
+    seedProviders: { acquireSeed: async () => seed },
+    odesliClient: {
+      fetchLinksBySeed: async () => {
+        if (odesli instanceof Error) throw odesli;
+        return odesli || [];
+      },
+    },
+    mbUrlRelsSource: {
+      getDirectLinks: async () => mb || { seedUrl: null, links: [] },
+    },
+  });
+  return { service, upsert };
+}
+
+describe('availability-resolution-service', () => {
+  it('mergeLinks unions sources and keeps higher confidence; applies floor', () => {
+    const rows = mergeLinks(
+      [
+        { platform: 'appleMusic', url: 'https://am/1' },
+        { platform: 'spotify', url: 'https://sp/1' },
+      ],
+      [{ service: 'apple_music', url: 'https://mb-am/1' }],
+      'existing',
+      0.95
+    );
+    const apple = rows.find((r) => r.service === 'apple_music');
+    assert.strictEqual(apple.url, 'https://am/1'); // 0.95 odesli beats 0.9 mb
+    assert.ok(rows.find((r) => r.service === 'spotify'));
+
+    const floored = mergeLinks(
+      [{ platform: 'spotify', url: 'https://sp/1' }],
+      [],
+      'itunes',
+      0.3 // below floor
+    );
+    assert.strictEqual(floored.length, 0);
+  });
+
+  it('skips when there is no seed and no MusicBrainz links', async () => {
+    const { service, upsert } = build({ seed: null, odesli: [], mb: null });
+    const result = await service.resolveAvailability(album);
+    assert.deepStrictEqual(result, {
+      action: 'skip',
+      reason: 'no-seed',
+      transient: false,
+    });
+    assert.strictEqual(upsert.mock.calls.length, 0);
+  });
+
+  it('resolves and persists one row per platform', async () => {
+    const { service, upsert } = build({
+      seed: { kind: 'existing', confidence: 0.95, seed: { url: 'x' } },
+      odesli: [
+        { platform: 'spotify', url: 'https://sp/1' },
+        { platform: 'tidal', url: 'https://td/1' },
+        { platform: 'unknownThing', url: 'https://x/1' }, // dropped (unmapped)
+      ],
+      mb: { seedUrl: null, links: [] },
+    });
+
+    const result = await service.resolveAvailability(album);
+    assert.strictEqual(result.action, 'resolved');
+    assert.deepStrictEqual(result.services.sort(), ['spotify', 'tidal']);
+    assert.strictEqual(upsert.mock.calls.length, 2);
+    const first = upsert.mock.calls[0].arguments[0];
+    assert.strictEqual(first.albumId, 'alb-1');
+    assert.ok(first.strategy.startsWith('availability:existing'));
+    assert.ok(first.externalUrl);
+  });
+
+  it('falls through to MusicBrainz links when Odesli errors', async () => {
+    const odesliErr = Object.assign(new Error('boom'), { status: 500 });
+    const { service, upsert } = build({
+      seed: { kind: 'musicbrainz', confidence: 0.9, seed: { url: 'x' } },
+      odesli: odesliErr,
+      mb: {
+        seedUrl: 'x',
+        links: [{ service: 'apple_music', url: 'https://am/1' }],
+      },
+    });
+    const result = await service.resolveAvailability(album);
+    assert.strictEqual(result.action, 'resolved');
+    assert.deepStrictEqual(result.services, ['apple_music']);
+    assert.strictEqual(upsert.mock.calls.length, 1);
+  });
+
+  it('returns a transient skip when Odesli errors and no MB links', async () => {
+    const { service } = build({
+      seed: { kind: 'itunes', confidence: 0.8, seed: { url: 'x' } },
+      odesli: Object.assign(new Error('rate'), { status: 429 }),
+      mb: null,
+    });
+    const result = await service.resolveAvailability(album);
+    assert.deepStrictEqual(result, {
+      action: 'skip',
+      reason: 'odesli-error',
+      transient: true,
+    });
+  });
+
+  it('does not persist in dry-run mode', async () => {
+    const { service, upsert } = build({
+      seed: { kind: 'existing', confidence: 0.95, seed: { url: 'x' } },
+      odesli: [{ platform: 'deezer', url: 'https://dz/1' }],
+      mb: null,
+    });
+    const result = await service.resolveAvailability(album, { persist: false });
+    assert.strictEqual(result.action, 'resolved');
+    assert.deepStrictEqual(result.services, ['deezer']);
+    assert.strictEqual(upsert.mock.calls.length, 0);
+  });
+});

--- a/test/availability-seed-providers.test.js
+++ b/test/availability-seed-providers.test.js
@@ -1,0 +1,102 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  createSeedProviders,
+} = require('../services/availability/seed-providers');
+const { createMockLogger } = require('./helpers');
+
+const album = { albumId: 'alb-1', artist: 'Metallica', album: '72 Seasons' };
+
+function eis(mapping) {
+  return {
+    getAlbumServiceMapping: async (service) =>
+      service === 'spotify' ? mapping : null,
+  };
+}
+
+describe('availability/seed-providers', () => {
+  it('prefers an existing Spotify mapping (no network)', async () => {
+    const providers = createSeedProviders({
+      logger: createMockLogger(),
+      externalIdentityService: eis({ external_album_id: 'sp123' }),
+      fetch: async () => {
+        throw new Error('should not search');
+      },
+    });
+
+    const result = await providers.acquireSeed(album, 'https://mb-seed');
+    assert.strictEqual(result.kind, 'existing');
+    assert.deepStrictEqual(result.seed, {
+      platform: 'spotify',
+      type: 'album',
+      id: 'sp123',
+    });
+  });
+
+  it('uses the MusicBrainz seed url when no mapping exists', async () => {
+    const providers = createSeedProviders({
+      logger: createMockLogger(),
+      externalIdentityService: eis(null),
+      fetch: async () => {
+        throw new Error('should not search');
+      },
+    });
+
+    const result = await providers.acquireSeed(
+      album,
+      'https://music.apple.com/x'
+    );
+    assert.strictEqual(result.kind, 'musicbrainz');
+    assert.deepStrictEqual(result.seed, { url: 'https://music.apple.com/x' });
+  });
+
+  it('falls through to a confident iTunes search seed', async () => {
+    const providers = createSeedProviders({
+      logger: createMockLogger(),
+      externalIdentityService: eis(null),
+      fetch: async (url) => {
+        assert.ok(url.includes('itunes.apple.com/search'));
+        return {
+          ok: true,
+          json: async () => ({
+            results: [
+              {
+                artistName: 'Metallica',
+                collectionName: '72 Seasons',
+                collectionId: 1655432387,
+              },
+            ],
+          }),
+        };
+      },
+    });
+
+    const result = await providers.acquireSeed(album, null);
+    assert.strictEqual(result.kind, 'itunes');
+    assert.strictEqual(result.seed.id, 1655432387);
+  });
+
+  it('rejects a low-confidence search match and yields no seed', async () => {
+    const providers = createSeedProviders({
+      logger: createMockLogger(),
+      externalIdentityService: eis(null),
+      fetch: async (url) => {
+        const body = url.includes('itunes')
+          ? {
+              results: [
+                {
+                  artistName: 'Nope',
+                  collectionName: 'Different',
+                  collectionId: 1,
+                },
+              ],
+            }
+          : { data: [{ artist: { name: 'Nope' }, title: 'Different', id: 2 }] };
+        return { ok: true, json: async () => body };
+      },
+    });
+
+    const result = await providers.acquireSeed(album, null);
+    assert.strictEqual(result, null);
+  });
+});

--- a/test/external-identity-service.test.js
+++ b/test/external-identity-service.test.js
@@ -148,6 +148,80 @@ describe('external-identity-service', () => {
     assert.strictEqual(pool.query.mock.calls.length, 0);
   });
 
+  it('persists external_url and allows a newly-supported service', async () => {
+    const pool = createMockPoolWithQuery(async () => ({ rows: [] }));
+    const service = createExternalIdentityService({
+      db: pool,
+      logger: createMockLogger(),
+    });
+
+    await service.upsertAlbumServiceMapping({
+      albumId: 'album-9',
+      service: 'deezer', // previously rejected by the DB CHECK
+      externalAlbumId: 'dz9',
+      externalUrl: 'https://www.deezer.com/album/9',
+      confidence: 0.95,
+      strategy: 'availability:itunes',
+    });
+
+    assert.strictEqual(pool.query.mock.calls.length, 1);
+    const args = pool.query.mock.calls[0].arguments[1];
+    assert.ok(
+      pool.query.mock.calls[0].arguments[0].includes('external_url'),
+      'INSERT should include external_url column'
+    );
+    assert.strictEqual(args[5], 'https://www.deezer.com/album/9');
+  });
+
+  it('reads all availability rows for an album', async () => {
+    const pool = createMockPoolWithQuery(async () => ({
+      rows: [
+        { service: 'deezer', external_url: 'https://d/1' },
+        { service: 'tidal', external_url: 'https://t/1' },
+      ],
+    }));
+    const service = createExternalIdentityService({
+      db: pool,
+      logger: createMockLogger(),
+    });
+
+    const rows = await service.getAlbumAvailability('album-9');
+
+    assert.strictEqual(rows.length, 2);
+    assert.ok(
+      pool.query.mock.calls[0].arguments[0].includes('ORDER BY service')
+    );
+    assert.strictEqual(pool.query.mock.calls[0].arguments[1][0], 'album-9');
+  });
+
+  it('bulk-reads availability with ANY($1)', async () => {
+    const pool = createMockPoolWithQuery(async () => ({ rows: [] }));
+    const service = createExternalIdentityService({
+      db: pool,
+      logger: createMockLogger(),
+    });
+
+    await service.getAlbumAvailabilityBulk(['a', 'b']);
+
+    assert.ok(pool.query.mock.calls[0].arguments[0].includes('ANY($1)'));
+    assert.deepStrictEqual(pool.query.mock.calls[0].arguments[1][0], [
+      'a',
+      'b',
+    ]);
+  });
+
+  it('returns empty without a network/db call for empty availability input', async () => {
+    const pool = createMockPoolWithQuery(async () => ({ rows: [] }));
+    const service = createExternalIdentityService({
+      db: pool,
+      logger: createMockLogger(),
+    });
+
+    assert.deepStrictEqual(await service.getAlbumAvailability(''), []);
+    assert.deepStrictEqual(await service.getAlbumAvailabilityBulk([]), []);
+    assert.strictEqual(pool.query.mock.calls.length, 0);
+  });
+
   it('normalizes canonical/service keys when upserting artist aliases', async () => {
     const pool = createMockPoolWithQuery(async () => ({ rows: [] }));
     const service = createExternalIdentityService({

--- a/test/mb-url-rels-source.test.js
+++ b/test/mb-url-rels-source.test.js
@@ -1,0 +1,88 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  createMbUrlRelsSource,
+} = require('../services/availability/mb-url-rels-source');
+const { createMockLogger } = require('./helpers');
+
+const MB_ID = 'e9b61dee-4172-4173-9bf6-6f80d2fb3f13';
+
+function jsonResponse(body) {
+  return { ok: true, json: async () => body };
+}
+
+describe('availability/mb-url-rels-source', () => {
+  it('resolves release-group -> release -> url-rels links and a seed', async () => {
+    const mbFetch = async (url) => {
+      if (url.includes('/release-group/')) {
+        return jsonResponse({
+          releases: [
+            { id: 'rel-promo', status: 'Promotion' },
+            { id: 'rel-official', status: 'Official' },
+          ],
+        });
+      }
+      if (url.includes('/release/rel-official')) {
+        return jsonResponse({
+          relations: [
+            {
+              type: 'streaming',
+              url: { resource: 'https://music.apple.com/us/album/1' },
+            },
+            {
+              type: 'purchase for download',
+              url: { resource: 'https://www.deezer.com/album/2' },
+            },
+            { type: 'discogs', url: { resource: 'https://discogs.com/x' } },
+          ],
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    };
+
+    const source = createMbUrlRelsSource({
+      mbFetch,
+      logger: createMockLogger(),
+    });
+    const { seedUrl, links } = await source.getDirectLinks(MB_ID);
+
+    assert.strictEqual(seedUrl, 'https://music.apple.com/us/album/1');
+    assert.deepStrictEqual(links, [
+      { service: 'apple_music', url: 'https://music.apple.com/us/album/1' },
+      { service: 'deezer', url: 'https://www.deezer.com/album/2' },
+    ]);
+  });
+
+  it('returns empty for a non-MusicBrainz id', async () => {
+    const source = createMbUrlRelsSource({
+      mbFetch: async () => {
+        throw new Error('should not be called');
+      },
+      logger: createMockLogger(),
+    });
+    assert.deepStrictEqual(await source.getDirectLinks('spotify:album:x'), {
+      seedUrl: null,
+      links: [],
+    });
+  });
+
+  it('treats a release-group 404 as a direct release id', async () => {
+    const seen = [];
+    const mbFetch = async (url) => {
+      seen.push(url);
+      if (url.includes('/release-group/')) {
+        const err = new Error('not found');
+        err.status = 404;
+        throw err;
+      }
+      return jsonResponse({ relations: [] });
+    };
+    const source = createMbUrlRelsSource({
+      mbFetch,
+      logger: createMockLogger(),
+    });
+    const result = await source.getDirectLinks(MB_ID);
+    assert.deepStrictEqual(result, { seedUrl: null, links: [] });
+    assert.ok(seen.some((u) => u.includes(`/release/${MB_ID}`)));
+  });
+});

--- a/test/odesli-client.test.js
+++ b/test/odesli-client.test.js
@@ -1,0 +1,85 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  createOdesliClient,
+} = require('../services/availability/odesli-client');
+const { createMockLogger } = require('./helpers');
+
+function mockFetch(handler) {
+  return async (url) => handler(url);
+}
+
+describe('availability/odesli-client', () => {
+  it('expands a url seed into normalized platform links', async () => {
+    let calledUrl = null;
+    const client = createOdesliClient({
+      logger: createMockLogger(),
+      fetch: mockFetch(async (url) => {
+        calledUrl = url;
+        return {
+          ok: true,
+          json: async () => ({
+            linksByPlatform: {
+              appleMusic: { url: 'https://music.apple.com/a' },
+              tidal: { url: 'https://tidal.com/a' },
+              broken: {},
+            },
+          }),
+        };
+      }),
+    });
+
+    const links = await client.fetchLinksBySeed({
+      url: 'https://deezer.com/album/1',
+    });
+
+    assert.ok(calledUrl.includes('url=https%3A%2F%2Fdeezer.com%2Falbum%2F1'));
+    assert.ok(calledUrl.includes('userCountry=US'));
+    assert.deepStrictEqual(links, [
+      { platform: 'appleMusic', url: 'https://music.apple.com/a' },
+      { platform: 'tidal', url: 'https://tidal.com/a' },
+    ]);
+  });
+
+  it('builds a platform/type/id query', async () => {
+    let calledUrl = null;
+    const client = createOdesliClient({
+      logger: createMockLogger(),
+      fetch: mockFetch(async (url) => {
+        calledUrl = url;
+        return { ok: true, json: async () => ({ linksByPlatform: {} }) };
+      }),
+    });
+
+    await client.fetchLinksBySeed({
+      platform: 'itunes',
+      type: 'album',
+      id: 99,
+    });
+
+    assert.ok(calledUrl.includes('platform=itunes'));
+    assert.ok(calledUrl.includes('type=album'));
+    assert.ok(calledUrl.includes('id=99'));
+  });
+
+  it('returns [] for an empty seed', async () => {
+    const client = createOdesliClient({
+      logger: createMockLogger(),
+      fetch: mockFetch(async () => {
+        throw new Error('should not be called');
+      }),
+    });
+    assert.deepStrictEqual(await client.fetchLinksBySeed({}), []);
+  });
+
+  it('throws with status on a transient non-200', async () => {
+    const client = createOdesliClient({
+      logger: createMockLogger(),
+      fetch: mockFetch(async () => ({ ok: false, status: 429 })),
+    });
+    await assert.rejects(
+      () => client.fetchLinksBySeed({ url: 'https://x/y' }),
+      (err) => err.status === 429
+    );
+  });
+});


### PR DESCRIPTION
Backend feature: for each canonical album, resolve **which platforms provide it** and cache it as metadata. No frontend changes.

Availability needs **no per-service integration** — resolved from two free, key-less sources, combined for speed + coverage:
- **Odesli/song.link** expands one seed into deep links across ~12 platforms.
- **MusicBrainz url-rels** supply identity-confirmed links + a high-quality seed.

### Design (SOLID / DRY / SoC)
- Strategy modules in `services/availability/` (odesli-client, mb-url-rels-source, seed-providers, platforms allowlist/normalizer) — small, SRP, DI-testable.
- `availability-resolution-service` orchestrates seed → Odesli expand → union with MB → confidence gate → persist (no SQL/HTTP itself).
- Seeds tiered cheapest-first: existing Spotify/Tidal mapping → MB streaming url → public iTunes/Deezer search gated by the shared entity-matching check.
- Storage reuses `album_service_mappings`; migration 063 adds `external_url` and drops the 3-service CHECK (platform set becomes an app-layer allowlist — add a platform without a migration). Repository gains `external_url` + `getAlbumAvailability`/`*Bulk`.
- `availability-fetch-queue` mirrors the cover/track/native-name queues; triggered from `triggerAlbumBackgroundFetches`/`upsertAlbumRecord` so new albums resolve off the request path; already-resolved albums short-circuit.
- `scripts/backfill-availability.js` resolves existing albums (dry-run default, `--apply`, `--limit`), sharing the same resolution service, with transient retry.

### Validation (local Docker)
- Migration 063 applied; `external_url` present, service CHECK removed.
- Backfill dry-run + `--apply` resolve **real** platform sets and write `external_url` rows; re-runs idempotent.
- Clean app boot (availability queue initialized).
- `eslint . --max-warnings 0`, `format:check:source`, `lint:structure:baseline` all green; **2629 unit + 49 integration + 64 e2e** tests pass.

### Notes
- Pre-prod gate: confirm Odesli ToS/rate limits before enabling backfill in prod (code defaults conservative, treats 429/5xx as transient).
- Frontend badges + a thin read endpoint are deliberately out of scope (the bulk read is already shaped for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)