### PR TITLE
Show platform-availability badges in the album column

### DIFF
--- a/services/list/fetchers.js
+++ b/services/list/fetchers.js
@@ -44,7 +44,13 @@ function createListFetchers(deps = {}) {
           a.cover_image_format,
           a.cover_image_updated_at,
           a.summary,
-         a.summary_source
+         a.summary_source,
+         COALESCE((
+           SELECT json_agg(m.service)
+           FROM album_service_mappings m
+           WHERE m.album_id = li.album_id
+             AND m.strategy LIKE 'availability:%'
+         ), '[]'::json) AS availability
        FROM lists l
        LEFT JOIN list_items li ON li.list_id = l._id
        LEFT JOIN albums a ON li.album_id = a.album_id
@@ -189,7 +195,13 @@ function createListFetchers(deps = {}) {
               a.cover_image_format,
               a.cover_image_updated_at,
               a.summary,
-              a.summary_source
+              a.summary_source,
+              COALESCE((
+                SELECT json_agg(m.service)
+                FROM album_service_mappings m
+                WHERE m.album_id = li.album_id
+                  AND m.strategy LIKE 'availability:%'
+              ), '[]'::json) AS availability
        FROM list_items li
        LEFT JOIN albums a ON li.album_id = a.album_id
        WHERE li.list_id = $1
@@ -218,6 +230,7 @@ function createListFetchers(deps = {}) {
       coverImageUpdatedAt: row.cover_image_updated_at || null,
       summary: row.summary || '',
       summarySource: row.summary_source || '',
+      availability: row.availability || [],
     }));
     const recMaps = await fetchRecommendationMaps(
       list.year ? [list.year] : [],

--- a/services/list/item-mapper.js
+++ b/services/list/item-mapper.js
@@ -5,6 +5,10 @@
  * can focus on orchestration and validation.
  */
 
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
 function mapListRowToItem(row, recommendationMap = null) {
   const recommendation = recommendationMap?.get(row.album_id) || null;
 
@@ -28,6 +32,7 @@ function mapListRowToItem(row, recommendationMap = null) {
     cover_image_updated_at: row.cover_image_updated_at,
     summary: row.summary || '',
     summary_source: row.summary_source || '',
+    availability: asArray(row.availability),
     recommended_by: recommendation?.recommendedBy || null,
     recommended_at: recommendation?.recommendedAt || null,
   };
@@ -62,6 +67,7 @@ function mapAlbumDataItemToResponse(item, options = {}) {
     cover_image_updated_at: item.coverImageUpdatedAt || null,
     summary: item.summary || '',
     summary_source: item.summarySource || '',
+    availability: asArray(item.availability),
     recommended_by: recommendation?.recommendedBy || null,
     recommended_at: recommendation?.recommendedAt || null,
   };

--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -37,6 +37,7 @@ import {
   formatPlaycount,
 } from './album-display/album-data.js';
 import { createPlaycountSync } from './album-display/playcount-sync.js';
+import { renderAvailabilityBadges } from './album-display/availability-badges.js';
 
 // Feature flag for incremental updates (can be disabled if issues arise)
 const ENABLE_INCREMENTAL_UPDATES = true;
@@ -354,6 +355,7 @@ export function createAlbumDisplay(deps = {}) {
           }
         </div>
         <div class="text-xs mt-0.5 release-date-display ${data.yearMismatch ? 'text-red-500 cursor-help' : 'text-gray-400'}" ${data.yearMismatch ? `title="${data.yearMismatchTooltip}"` : ''}>${data.releaseDate}</div>
+        ${renderAvailabilityBadges(data.availability)}
       </div>`,
       artist: `<div class="artist-cell flex items-center">
         <span class="album-cell-text ${data.artist ? 'text-gray-200' : 'text-gray-800 italic'} truncate cursor-pointer hover:text-gray-100">${data.artist}</span>

--- a/src/js/modules/album-display/album-data.js
+++ b/src/js/modules/album-display/album-data.js
@@ -150,6 +150,10 @@ export function createAlbumDataProcessor(deps = {}) {
     const recommendedBy = album.recommended_by || null;
     const recommendedAt = album.recommended_at || null;
 
+    const availability = Array.isArray(album.availability)
+      ? album.availability
+      : [];
+
     const itemId = album._id || '';
     const cachedData = getPlaycountCacheEntry(itemId);
     const playcount = cachedData?.playcount ?? null;
@@ -197,6 +201,7 @@ export function createAlbumDataProcessor(deps = {}) {
       playcountDisplay,
       summary,
       summarySource,
+      availability,
       recommendedBy,
       recommendedAt,
     };

--- a/src/js/modules/album-display/availability-badges.js
+++ b/src/js/modules/album-display/availability-badges.js
@@ -1,0 +1,71 @@
+/**
+ * Platform availability badges for the album column.
+ *
+ * Renders small, icon-only, brand-coloured squares for the platforms that
+ * provide an album. Visual only (no links). A fixed priority order is applied
+ * and the count is capped so they fit on one line below the release date.
+ */
+
+// service -> { label, icon (Font Awesome brand class | null), color }.
+// Platforms without a brand icon render their initial letter instead.
+const PLATFORM_BADGES = {
+  spotify: { label: 'Spotify', icon: 'fa-spotify', color: '#1db954' },
+  apple_music: { label: 'Apple Music', icon: 'fa-apple', color: '#fa243c' },
+  tidal: { label: 'Tidal', icon: null, color: '#33b6c9' },
+  deezer: { label: 'Deezer', icon: 'fa-deezer', color: '#a238ff' },
+  youtube_music: {
+    label: 'YouTube Music',
+    icon: 'fa-youtube',
+    color: '#ff0000',
+  },
+  bandcamp: { label: 'Bandcamp', icon: 'fa-bandcamp', color: '#629aa9' },
+  soundcloud: { label: 'SoundCloud', icon: 'fa-soundcloud', color: '#ff5500' },
+  amazon_music: { label: 'Amazon Music', icon: 'fa-amazon', color: '#25d1da' },
+};
+
+// Order badges are shown in; only the first MAX_BADGES present are rendered.
+const PLATFORM_PRIORITY = [
+  'spotify',
+  'apple_music',
+  'tidal',
+  'deezer',
+  'youtube_music',
+  'bandcamp',
+  'soundcloud',
+  'amazon_music',
+];
+
+const MAX_BADGES = 6;
+
+function badgeInner(meta) {
+  return meta.icon
+    ? `<i class="fab ${meta.icon}"></i>`
+    : `<span class="availability-badge-letter">${meta.label.charAt(0)}</span>`;
+}
+
+/**
+ * Build the availability badge row HTML for an album. Returns '' when there is
+ * nothing to show (so the album cell keeps its original layout).
+ *
+ * @param {string[]} availability - canonical service names available for the album
+ * @returns {string} HTML for the badge row, or ''
+ */
+export function renderAvailabilityBadges(availability) {
+  if (!Array.isArray(availability) || availability.length === 0) return '';
+
+  const have = new Set(availability);
+  const chosen = PLATFORM_PRIORITY.filter((service) => have.has(service)).slice(
+    0,
+    MAX_BADGES
+  );
+  if (chosen.length === 0) return '';
+
+  const squares = chosen
+    .map((service) => {
+      const meta = PLATFORM_BADGES[service];
+      return `<span class="availability-badge" style="background-color:${meta.color}" title="${meta.label}" aria-label="${meta.label}">${badgeInner(meta)}</span>`;
+    })
+    .join('');
+
+  return `<div class="album-availability">${squares}</div>`;
+}

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -2732,6 +2732,36 @@ body.now-playing-bar-visible #addAlbumFAB {
   color: #d97706; /* Orange/amber color for Claude */
 }
 
+/* Platform availability badges (album column, below the release date).
+   Small, icon-only, brand-coloured squares. Visual only. */
+.album-availability {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 3px;
+}
+
+.availability-badge {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.availability-badge i,
+.availability-badge-letter {
+  font-size: 9px;
+}
+
+.availability-badge-letter {
+  font-weight: 700;
+}
+
 /* Mobile-specific summary badge styles */
 .summary-badge-mobile {
   width: 24px;

--- a/test/availability-badges.test.js
+++ b/test/availability-badges.test.js
@@ -1,0 +1,53 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('availability-badges', () => {
+  let renderAvailabilityBadges;
+
+  beforeEach(async () => {
+    ({ renderAvailabilityBadges } =
+      await import('../src/js/modules/album-display/availability-badges.js'));
+  });
+
+  it('returns empty when there is nothing to show', () => {
+    assert.strictEqual(renderAvailabilityBadges([]), '');
+    assert.strictEqual(renderAvailabilityBadges(null), '');
+    assert.strictEqual(renderAvailabilityBadges(undefined), '');
+  });
+
+  it('renders known platforms in priority order (spotify before deezer)', () => {
+    const html = renderAvailabilityBadges(['deezer', 'spotify']);
+    assert.ok(html.includes('album-availability'));
+    assert.ok(html.includes('fa-spotify'));
+    assert.ok(html.indexOf('Spotify') < html.indexOf('Deezer'));
+  });
+
+  it('caps at 6 badges by priority', () => {
+    const all = [
+      'spotify',
+      'apple_music',
+      'tidal',
+      'deezer',
+      'youtube_music',
+      'bandcamp',
+      'soundcloud',
+      'amazon_music',
+    ];
+    const html = renderAvailabilityBadges(all);
+    const count = (html.match(/availability-badge"/g) || []).length;
+    assert.strictEqual(count, 6);
+    // 7th/8th priority are dropped
+    assert.ok(!html.includes('SoundCloud'));
+    assert.ok(!html.includes('Amazon Music'));
+  });
+
+  it('ignores unmapped services', () => {
+    assert.strictEqual(renderAvailabilityBadges(['pandora', 'napster']), '');
+  });
+
+  it('renders an initial letter for platforms without a brand icon', () => {
+    const html = renderAvailabilityBadges(['tidal']);
+    assert.ok(html.includes('availability-badge-letter'));
+    assert.ok(html.includes('>T<'));
+  });
+});

--- a/test/list-item-mapper.test.js
+++ b/test/list-item-mapper.test.js
@@ -31,6 +31,7 @@ test('mapListRowToItem maps row fields and recommendation metadata', () => {
       cover_image_updated_at: '2026-05-11T10:20:34.794Z',
       summary: 'Summary',
       summary_source: 'claude',
+      availability: ['spotify', 'deezer'],
     },
     recommendationMap
   );
@@ -55,6 +56,7 @@ test('mapListRowToItem maps row fields and recommendation metadata', () => {
     cover_image_updated_at: '2026-05-11T10:20:34.794Z',
     summary: 'Summary',
     summary_source: 'claude',
+    availability: ['spotify', 'deezer'],
     recommended_by: 'alice',
     recommended_at: '2025-01-01',
   });
@@ -85,6 +87,7 @@ test('mapAlbumDataItemToResponse maps non-export response with cover image URL',
       coverImageUpdatedAt: coverDate,
       summary: null,
       summarySource: null,
+      availability: ['spotify', 'apple_music'],
     },
     {
       recommendationMap,
@@ -98,6 +101,7 @@ test('mapAlbumDataItemToResponse maps non-export response with cover image URL',
     result.cover_image_url,
     `/api/albums/album-2/cover?v=${coverDate.getTime()}`
   );
+  assert.deepStrictEqual(result.availability, ['spotify', 'apple_music']);
   assert.strictEqual(result.track_pick, 'Song 1');
   assert.strictEqual(result.comments_2, '');
   assert.strictEqual(result.recommended_by, 'bob');


### PR DESCRIPTION
Renders small, icon-only, brand-coloured squares for the platforms that provide each album, along the bottom edge of the album cell (below the release date). **Visual only**, ordered by a fixed priority and **capped at 6**.

Builds on the availability backend (#368).

### Read path
Per-album availability (services with an `availability:%` mapping) is aggregated into the list payload via a correlated subquery in **both** list fetchers, threaded through the item mappers, exposed as `availability` on each item. No extra per-album requests.

### Frontend
- New render module `src/js/modules/album-display/availability-badges.js` (platform icon/color map, priority order, cap 6, initial-letter for platforms without a Font Awesome brand icon — e.g. Tidal).
- `processAlbumData` carries `availability`; the desktop album cell renders the badge row **after** the release date — the third row shifts the title/date up within the centered cell (no row-height change).
- Badge styling in `input.css`.

### Verified
- Live end-to-end: add album → background availability resolves → reload → badges render in the DOM with correct platforms + styling (screenshot confirmed).
- `eslint . --max-warnings 0`, structural baseline, build, **2634 unit + 64 e2e** tests green.

### Notes
- The 5-min list response cache means a **just-added** album's badges appear after the cache expires or the next list write; **backfilled/existing albums show immediately** on load.
- **Existing albums need the prod backfill** (`scripts/backfill-availability.js --apply`) to have data — see follow-up.
- Mobile card badges are a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)