### PR TITLE
Fix overlay lifecycle cleanup leaks

### DIFF
--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -40,7 +40,7 @@ import {
 import { createPlaycountSync } from './album-display/playcount-sync.js';
 import { renderAvailabilityBadges } from './album-display/availability-badges.js';
 import { getPositionBadgeColor } from './album-display/position-badge.js';
-import { createModal } from './modal-factory.js';
+import { createModal, destroyModalForElement } from './modal-factory.js';
 import {
   mobilePlaycountSpan,
   desktopPlaycountSpan,
@@ -1865,7 +1865,7 @@ export function createAlbumDisplay(deps = {}) {
 
     // Remove any existing recommendation modals
     const existing = document.querySelectorAll('[data-recommendation-modal]');
-    existing.forEach((m) => m.remove());
+    existing.forEach((modal) => destroyModalForElement(modal));
 
     // Hide FAB when modal is shown
     const fab = document.getElementById('addAlbumFAB');

--- a/src/js/modules/discovery.js
+++ b/src/js/modules/discovery.js
@@ -9,7 +9,7 @@
 
 import { escapeHtml } from './html-utils.js';
 import { apiCall } from './utils.js';
-import { createModal } from './modal-factory.js';
+import { createModal, destroyModalForElement } from './modal-factory.js';
 
 // Lazy-loaded to avoid pulling in the 508KB musicbrainz chunk at startup.
 // searchArtistImageRacing is only needed when viewing similar artists.
@@ -41,7 +41,11 @@ export function initDiscovery() {
 function createModalElement() {
   // Remove existing modal if any
   const existing = document.getElementById('discoveryModal');
-  if (existing) existing.remove();
+  if (existing) {
+    destroyModalForElement(existing);
+    discoveryModal = null;
+    discoveryController = null;
+  }
 
   const modal = document.createElement('div');
   modal.id = 'discoveryModal';

--- a/src/js/modules/duplicate-review-modal.js
+++ b/src/js/modules/duplicate-review-modal.js
@@ -8,7 +8,7 @@
 
 import { escapeHtml, getPlaceholderSvg } from './html-utils.js';
 import { showToast, apiCall } from './utils.js';
-import { createModal } from './modal-factory.js';
+import { createModal, destroyModalForElement } from './modal-factory.js';
 import { markAlbumsDistinct } from '../utils/album-api.js';
 
 let modalElement = null;
@@ -115,7 +115,13 @@ export function openDuplicateReviewModal(scanData, onCompleteCallback = null) {
 
 function createModalDOM() {
   if (modalElement) {
-    modalElement.remove();
+    // Replacing stale DOM should clean listeners without completing the active
+    // review promise; completion is reserved for explicit close/finish paths.
+    const activeOnComplete = onComplete;
+    onComplete = null;
+    destroyModalForElement(modalElement);
+    onComplete = activeOnComplete;
+    modalController = null;
   }
 
   modalElement = document.createElement('div');

--- a/src/js/modules/mobile-ui.js
+++ b/src/js/modules/mobile-ui.js
@@ -10,7 +10,7 @@
 import { normalizeDateForInput, formatDateForStorage } from './date-utils.js';
 import { escapeHtmlAttr as escapeHtml } from './html-utils.js';
 import { createActionSheet } from './ui-factories.js';
-import { createModal } from './modal-factory.js';
+import { createModal, destroyModalForElement } from './modal-factory.js';
 import { createTransferHelpers } from './album-transfer.js';
 import { fetchSpotifyDevices } from '../utils/playback-service.js';
 import { createMobileAlbumActions } from './mobile-ui/album-actions.js';
@@ -450,7 +450,7 @@ export function createMobileUI(deps = {}) {
 
     // Remove any existing edit modals first
     const existingModals = document.querySelectorAll('.mobile-edit-modal');
-    existingModals.forEach((modal) => modal.remove());
+    existingModals.forEach((modal) => destroyModalForElement(modal));
 
     const availableCountries = getAvailableCountries();
     const availableGenres = getAvailableGenres();
@@ -1081,7 +1081,7 @@ export function createMobileUI(deps = {}) {
 
     // Remove any existing modals first
     const existingModals = document.querySelectorAll('.mobile-edit-modal');
-    existingModals.forEach((modal) => modal.remove());
+    existingModals.forEach((modal) => destroyModalForElement(modal));
 
     // Hide FAB when modal is shown
     const fab = document.getElementById('addAlbumFAB');

--- a/src/js/modules/modal-factory.js
+++ b/src/js/modules/modal-factory.js
@@ -15,6 +15,28 @@
 
 import { createFocusManager, applyInert, releaseInert } from './modal-a11y.js';
 
+const modalControllers = new WeakMap();
+
+/**
+ * Destroy a managed modal by element, falling back to raw DOM removal for
+ * legacy overlays that were not created through createModal.
+ *
+ * @param {HTMLElement} element - Modal element to destroy
+ * @returns {boolean} True when a managed controller handled the destroy
+ */
+export function destroyModalForElement(element) {
+  if (!element) return false;
+
+  const controller = modalControllers.get(element);
+  if (!controller) {
+    element.remove();
+    return false;
+  }
+
+  controller.destroy();
+  return true;
+}
+
 /**
  * @typedef {Object} ModalOptions
  * @property {HTMLElement} element - Modal element
@@ -213,6 +235,7 @@ export function createModal(options) {
    * Destroy the modal and remove from DOM
    */
   function destroy() {
+    modalControllers.delete(element);
     close();
     element.remove();
   }
@@ -236,7 +259,7 @@ export function createModal(options) {
     }
   }
 
-  return {
+  const controller = {
     open,
     close,
     destroy,
@@ -244,4 +267,7 @@ export function createModal(options) {
     isOpen: getIsOpen,
     addListener,
   };
+
+  modalControllers.set(element, controller);
+  return controller;
 }

--- a/src/js/modules/settings-drawer/handlers/account-actions.js
+++ b/src/js/modules/settings-drawer/handlers/account-actions.js
@@ -250,17 +250,17 @@ export function createSettingsAccountActions(deps = {}) {
 
     form?.addEventListener('submit', async (e) => {
       e.preventDefault();
-      await handleSavePassword(modal);
+      await handleSavePassword(modal, close);
     });
 
     saveBtn?.addEventListener('click', async () => {
-      await handleSavePassword(modal);
+      await handleSavePassword(modal, close);
     });
 
     return modal;
   }
 
-  async function handleSavePassword(modal) {
+  async function handleSavePassword(modal, close) {
     const currentPassword = modal.querySelector('#currentPasswordInput').value;
     const newPassword = modal.querySelector('#newPasswordInput').value;
     const confirmPassword = modal.querySelector('#confirmPasswordInput').value;
@@ -303,10 +303,7 @@ export function createSettingsAccountActions(deps = {}) {
 
       if (response.success) {
         showToast('Password updated successfully', 'success');
-        modal.classList.add('hidden');
-        setTimeoutFn(() => {
-          doc.body.removeChild(modal);
-        }, 300);
+        close();
       }
     } catch (error) {
       console.error('Error changing password:', error);

--- a/src/js/modules/settings-drawer/handlers/telegram-actions.js
+++ b/src/js/modules/settings-drawer/handlers/telegram-actions.js
@@ -160,7 +160,9 @@ export function createSettingsTelegramActions(deps = {}) {
       handleSelectTelegramTopic(modal, e.target.value)
     );
     testBtn?.addEventListener('click', () => handleSendTelegramTest(modal));
-    saveBtn?.addEventListener('click', () => handleSaveTelegramConfig(modal));
+    saveBtn?.addEventListener('click', () =>
+      handleSaveTelegramConfig(modal, close)
+    );
 
     const tokenInput = modal.querySelector('#telegramBotToken');
     tokenInput?.addEventListener('keypress', (e) => {
@@ -491,7 +493,7 @@ export function createSettingsTelegramActions(deps = {}) {
     }
   }
 
-  async function handleSaveTelegramConfig(modal) {
+  async function handleSaveTelegramConfig(modal, close) {
     if (
       !telegramModalState ||
       !telegramModalState.botToken ||
@@ -536,16 +538,9 @@ export function createSettingsTelegramActions(deps = {}) {
         showToast('Telegram notifications enabled!', 'success');
 
         setTimeoutFn(() => {
-          modal.classList.add('hidden');
-          setTimeoutFn(() => {
-            if (doc.body.contains(modal)) {
-              doc.body.removeChild(modal);
-            }
-            telegramModalState = null;
-
-            categoryData.admin = null;
-            loadCategoryData('admin');
-          }, 300);
+          close();
+          categoryData.admin = null;
+          loadCategoryData('admin');
         }, 1000);
       } else {
         throw new Error(response.error || 'Failed to save configuration');

--- a/src/js/modules/ui-factories.js
+++ b/src/js/modules/ui-factories.js
@@ -5,7 +5,7 @@
  * Eliminates boilerplate DOM creation, event wiring, and cleanup logic.
  */
 
-import { createModal } from './modal-factory.js';
+import { createModal, destroyModalForElement } from './modal-factory.js';
 
 /**
  * Create a settings modal with standard structure and close behavior.
@@ -138,7 +138,7 @@ export function createActionSheet({
       : `.fixed.inset-0.z-\\[${zIndex}\\]`;
   const existingSheet = document.querySelector(escapedSelector);
   if (existingSheet) {
-    existingSheet.remove();
+    destroyModalForElement(existingSheet);
   }
 
   // Hide FAB if requested
@@ -170,9 +170,8 @@ export function createActionSheet({
   document.body.appendChild(sheet);
 
   // Backdrop, cancel button, Escape and tracked cleanup via the shared
-  // controller. Scroll lock is OFF: sheets use a replace-at-z-level pattern
-  // (an existing sheet is removed directly, bypassing close), so a locked
-  // scroll state could otherwise leak.
+  // controller. Scroll lock is OFF so replacing sheets at the same z-level does
+  // not unexpectedly affect page scroll.
   const controller = createModal({
     element: sheet,
     dialog:

--- a/test/modal-factory.test.js
+++ b/test/modal-factory.test.js
@@ -56,10 +56,12 @@ function setupMockDocument() {
 }
 
 let createModal;
+let destroyModalForElement;
 
 describe('modal-factory', async () => {
   const mod = await import('../src/js/modules/modal-factory.js');
   createModal = mod.createModal;
+  destroyModalForElement = mod.destroyModalForElement;
 
   describe('createModal - basic API', () => {
     it('should throw if element is not provided', () => {
@@ -488,6 +490,36 @@ describe('modal-factory', async () => {
 
       controller.destroy();
 
+      assert.strictEqual(element.remove.mock.calls.length, 1);
+      restore();
+    });
+
+    it('should destroy a managed modal by element and clean up listeners', () => {
+      const { restore } = setupMockDocument();
+      const element = createMockElement();
+      const controller = createModal({ element, closeOnEscape: true });
+
+      controller.open();
+      const handled = destroyModalForElement(element);
+
+      assert.strictEqual(handled, true);
+      assert.strictEqual(controller.isOpen(), false);
+      assert.strictEqual(element.remove.mock.calls.length, 1);
+
+      const keydownRemove = document.removeEventListener.mock.calls.find(
+        (c) => c.arguments[0] === 'keydown'
+      );
+      assert.ok(keydownRemove, 'Should remove keydown listener from document');
+      restore();
+    });
+
+    it('should remove unmanaged modal elements as a fallback', () => {
+      const { restore } = setupMockDocument();
+      const element = createMockElement();
+
+      const handled = destroyModalForElement(element);
+
+      assert.strictEqual(handled, false);
       assert.strictEqual(element.remove.mock.calls.length, 1);
       restore();
     });

--- a/test/ui-factories.test.js
+++ b/test/ui-factories.test.js
@@ -1,0 +1,133 @@
+const { describe, it, mock } = require('node:test');
+const assert = require('node:assert');
+
+function createClassList(initial = []) {
+  const classes = new Set(initial);
+  return {
+    add: (...items) => items.forEach((item) => classes.add(item)),
+    remove: (...items) => items.forEach((item) => classes.delete(item)),
+    contains: (item) => classes.has(item),
+  };
+}
+
+function createElement(tagName = 'div') {
+  const element = {
+    tagName,
+    className: '',
+    style: {},
+    parentNode: null,
+    _removed: false,
+    _innerHTML: '',
+    classList: createClassList(),
+    addEventListener: mock.fn(),
+    removeEventListener: mock.fn(),
+    querySelector(selector) {
+      if (selector === '[data-backdrop]') return this._backdrop || null;
+      if (selector === '[data-action="cancel"]') return this._cancel || null;
+      if (selector === '[data-sheet-panel]') return this._panel || null;
+      return null;
+    },
+    remove: mock.fn(function remove() {
+      this._removed = true;
+      if (this.parentNode?.children) {
+        this.parentNode.children = this.parentNode.children.filter(
+          (child) => child !== this
+        );
+      }
+      this.parentNode = null;
+    }),
+  };
+
+  Object.defineProperty(element, 'innerHTML', {
+    get() {
+      return this._innerHTML;
+    },
+    set(value) {
+      this._innerHTML = value;
+      this._backdrop = createElement('div');
+      this._panel = createElement('div');
+      this._cancel = value.includes('data-action="cancel"')
+        ? createElement('button')
+        : null;
+    },
+  });
+
+  return element;
+}
+
+function createDocument() {
+  const fab = createElement('button');
+  return {
+    addEventListener: mock.fn(),
+    removeEventListener: mock.fn(),
+    body: {
+      style: {},
+      children: [],
+      appendChild(node) {
+        node.parentNode = this;
+        this.children.push(node);
+      },
+      contains(node) {
+        return this.children.includes(node);
+      },
+    },
+    createElement,
+    getElementById(id) {
+      return id === 'addAlbumFAB' ? fab : null;
+    },
+    querySelector(selector) {
+      if (!selector.includes('z-50')) return null;
+      return this.body.children.find((node) => {
+        return (
+          node.className.includes('fixed') &&
+          node.className.includes('inset-0') &&
+          node.className.includes('z-50') &&
+          node.className.includes('lg:hidden')
+        );
+      });
+    },
+    _fab: fab,
+  };
+}
+
+describe('ui-factories', async () => {
+  const { createActionSheet } =
+    await import('../src/js/modules/ui-factories.js');
+
+  it('destroys an existing action sheet through its controller when replacing it', () => {
+    const originalDocument = globalThis.document;
+    const doc = createDocument();
+    globalThis.document = doc;
+
+    try {
+      createActionSheet({
+        contentHtml: '<button data-action="cancel">Cancel</button>',
+        checkCurrentList: false,
+      });
+      const firstSheet = doc.body.children[0];
+
+      createActionSheet({
+        contentHtml: '<button data-action="cancel">Cancel</button>',
+        checkCurrentList: false,
+      });
+
+      assert.strictEqual(firstSheet._removed, true);
+      assert.strictEqual(doc.body.contains(firstSheet), false);
+      assert.strictEqual(doc.body.children.length, 1);
+      assert.strictEqual(doc._fab.style.display, 'none');
+
+      const keydownRemove = doc.removeEventListener.mock.calls.find(
+        (call) => call.arguments[0] === 'keydown'
+      );
+      assert.ok(keydownRemove, 'replacing sheet removes document key listener');
+
+      const backdropRemove =
+        firstSheet._backdrop.removeEventListener.mock.calls.find(
+          (call) => call.arguments[0] === 'click'
+        );
+      assert.ok(backdropRemove, 'replacing sheet removes backdrop listener');
+    } finally {
+      globalThis.document = originalDocument;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a modal registry helper for lifecycle-aware destroy-by-element
- route action-sheet/replacement overlays through managed destroy instead of raw remove
- close password and Telegram settings modals via controller close paths
- add regression tests for managed destroy and action-sheet replacement cleanup

## Tests
- docker compose -f docker-compose.local.yml exec app node --test test/modal-factory.test.js test/ui-factories.test.js test/settings-account-actions.test.js test/settings-telegram-actions.test.js
- npm run lint:strict