### PR TITLE
Fix album rendering change detection

### DIFF
--- a/src/js/modules/album-display-shared.js
+++ b/src/js/modules/album-display-shared.js
@@ -12,6 +12,10 @@ const MAX_COVER_RETRIES = 2;
 // cover settles (load or error).
 const MAX_CONCURRENT_COVER_LOADS = 12;
 
+function availabilityFingerprint(availability) {
+  return Array.isArray(availability) ? [...availability].sort().join(',') : '';
+}
+
 function addRetryParam(url) {
   try {
     const origin = globalThis.location?.origin || 'http://localhost';
@@ -32,7 +36,7 @@ function addRetryParam(url) {
  * @returns {string} Pipe-separated fingerprint string
  */
 export function albumMutableFingerprint(album) {
-  return `${album._id || ''}|${album.artist || ''}|${album.album || ''}|${album.release_date || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}|${album.primary_track || ''}|${album.secondary_track || ''}`;
+  return `${album._id || ''}|${album.artist || ''}|${album.album || ''}|${album.release_date || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}|${album.primary_track || ''}|${album.secondary_track || ''}|${availabilityFingerprint(album.availability)}`;
 }
 
 function renderCoverPlaceholder(parent) {
@@ -62,7 +66,6 @@ export function createAlbumDisplayShared(deps = {}) {
     isColumnVisible,
   } = deps;
 
-  let fingerprintCache = new WeakMap();
   let rowElementsCache = new WeakMap();
 
   function handleCoverError(image) {
@@ -215,6 +218,7 @@ export function createAlbumDisplayShared(deps = {}) {
         row.querySelector('.position-display'),
       albumName: row.querySelector('.album-name'),
       releaseDate: row.querySelector('.release-date-display'),
+      availabilityBadges: row.querySelector('.album-availability'),
       artist: row.querySelector('.artist-cell span'),
       countryCell: row.querySelector('.country-cell'),
       genre1Cell: row.querySelector('.genre-1-cell'),
@@ -250,7 +254,9 @@ export function createAlbumDisplayShared(deps = {}) {
   function cacheMobileCardElements(card) {
     const cache = {
       position: card.querySelector('[data-position-element="true"]'),
+      albumTitle: card.querySelector('[data-field="album-mobile-title"]'),
       releaseDate: card.querySelector('.release-date-display'),
+      availabilityBadges: card.querySelector('.album-availability'),
       artistText: card.querySelector('[data-field="artist-mobile-text"]'),
       countryText: card.querySelector('[data-field="country-mobile-text"]'),
       genreText: card.querySelector('[data-field="genre-mobile-text"]'),
@@ -281,27 +287,13 @@ export function createAlbumDisplayShared(deps = {}) {
   function generateAlbumFingerprint(albums) {
     if (!albums || albums.length === 0) return '';
 
-    const cached = fingerprintCache.get(albums);
-    if (cached !== undefined) {
-      return cached;
-    }
-
     const fingerprint = albums
-      .map(
-        (album) =>
-          `${album._id || ''}|${album.primary_track || ''}|${album.secondary_track || ''}|${album.country || ''}|${album.genre_1 || ''}|${album.genre_2 || ''}|${album.comments || ''}|${album.comments_2 || ''}`
-      )
+      .map((album) => albumMutableFingerprint(album))
       .join('::');
-
-    fingerprintCache.set(albums, fingerprint);
     return fingerprint;
   }
 
-  function invalidateFingerprint(albums) {
-    if (albums) {
-      fingerprintCache.delete(albums);
-    }
-  }
+  function invalidateFingerprint() {}
 
   function extractMutableFingerprints(albums) {
     if (!albums || albums.length === 0) return null;
@@ -309,9 +301,7 @@ export function createAlbumDisplayShared(deps = {}) {
     return albums.map((album) => albumMutableFingerprint(album));
   }
 
-  function resetFingerprintCache() {
-    fingerprintCache = new WeakMap();
-  }
+  function resetFingerprintCache() {}
 
   return {
     applyVisibilityInPlace,

--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -230,6 +230,9 @@ export function createAlbumDisplay(deps = {}) {
     if (comment === 'Comment') comment = '';
     let comment2 = album.comments_2 || '';
     if (comment2 === 'Comment 2') comment2 = '';
+    const availability = Array.isArray(album.availability)
+      ? album.availability
+      : [];
 
     const primaryTrack = album.primary_track || '';
 
@@ -316,7 +319,54 @@ export function createAlbumDisplay(deps = {}) {
       primaryTrackDuration,
       secondaryTrack,
       secondaryTrackDisplay,
+      availability,
     };
+  }
+
+  function updateAvailabilityBadges(
+    row,
+    cache,
+    releaseDate,
+    availability,
+    isMobile
+  ) {
+    const html = renderAvailabilityBadges(
+      availability,
+      isMobile ? { variant: 'mobile' } : {}
+    );
+    const existing =
+      cache.availabilityBadges || row.querySelector('.album-availability');
+
+    if (existing) {
+      if (html) {
+        existing.outerHTML = html;
+        cache.availabilityBadges = row.querySelector('.album-availability');
+      } else {
+        existing.remove();
+        cache.availabilityBadges = null;
+      }
+      return;
+    }
+
+    if (html && releaseDate) {
+      releaseDate.insertAdjacentHTML('afterend', html);
+      cache.availabilityBadges = row.querySelector('.album-availability');
+    }
+  }
+
+  function playTrackButton(index, trackIdentifier) {
+    if (trackIdentifier && typeof playSpecificTrack === 'function') {
+      playSpecificTrack(index, trackIdentifier);
+      return;
+    }
+
+    const albumsForTrackPlay = getListData(getCurrentList());
+    const albumForTrackPlay = albumsForTrackPlay && albumsForTrackPlay[index];
+    if (albumForTrackPlay) {
+      const albumId =
+        `${albumForTrackPlay.artist}::${albumForTrackPlay.album}::${albumForTrackPlay.release_date || ''}`.toLowerCase();
+      playTrackSafe(albumId);
+    }
   }
 
   /**
@@ -886,7 +936,7 @@ export function createAlbumDisplay(deps = {}) {
                absolutely centered on the title line. -->
           <div class="flex items-center relative" style="padding-right: 55px">
             <h3 class="text-gray-100 leading-tight truncate min-w-0" style="font-size: 13px; font-weight: 700">
-              <i class="fas fa-compact-disc fa-xs inline-block w-4 text-center align-middle mr-1"></i>${escapeHtml(data.albumName)}
+              <i class="fas fa-compact-disc fa-xs inline-block w-4 text-center align-middle mr-1"></i><span data-field="album-mobile-title">${escapeHtml(data.albumName)}</span>
             </h3>
             <!-- Recommendation first (left), summary last so the summary badge
                  is always the rightmost, fixed regardless of the recommendation. -->
@@ -1121,21 +1171,7 @@ export function createAlbumDisplay(deps = {}) {
       trackPlayBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
-        const trackIdentifier = trackPlayBtn.dataset.trackIdentifier;
-        if (trackIdentifier && typeof playSpecificTrack === 'function') {
-          // Play the specific track using its identifier
-          playSpecificTrack(index, trackIdentifier);
-        } else {
-          // Fallback to album's default track
-          const albumsForTrackPlay = getListData(getCurrentList());
-          const albumForTrackPlay =
-            albumsForTrackPlay && albumsForTrackPlay[index];
-          if (albumForTrackPlay) {
-            const albumId =
-              `${albumForTrackPlay.artist}::${albumForTrackPlay.album}::${albumForTrackPlay.release_date || ''}`.toLowerCase();
-            playTrackSafe(albumId);
-          }
-        }
+        playTrackButton(index, trackPlayBtn.dataset.trackIdentifier);
       });
     });
   }
@@ -1320,6 +1356,10 @@ export function createAlbumDisplay(deps = {}) {
             }
           }
         } else {
+          if (cache.albumTitle) {
+            cache.albumTitle.textContent = data.albumName;
+          }
+
           if (cache.releaseDate) {
             cache.releaseDate.textContent = data.releaseDate;
             cache.releaseDate.className = `release-date-display text-xs leading-none whitespace-nowrap ${data.yearMismatch ? 'text-red-500' : 'text-gray-500'}`;
@@ -1330,6 +1370,14 @@ export function createAlbumDisplay(deps = {}) {
             }
           }
         }
+
+        updateAvailabilityBadges(
+          row,
+          cache,
+          cache.releaseDate,
+          data.availability,
+          isMobile
+        );
 
         if (!isMobile) {
           // Update country using cached span
@@ -1430,6 +1478,11 @@ export function createAlbumDisplay(deps = {}) {
                 'data-track-play-btn',
                 hasTrack ? 'true' : ''
               );
+              if (hasTrack) {
+                trackPlayBtn.dataset.trackIdentifier = data.primaryTrack;
+              } else {
+                delete trackPlayBtn.dataset.trackIdentifier;
+              }
 
               if (hasTrack) {
                 trackPlayBtn.classList.add(
@@ -1438,6 +1491,9 @@ export function createAlbumDisplay(deps = {}) {
                 );
                 const newBtn = trackPlayBtn.cloneNode(true);
                 trackPlayBtn.parentNode.replaceChild(newBtn, trackPlayBtn);
+                cache.trackText = newBtn.querySelector(
+                  '[data-field="track-mobile-text"]'
+                );
 
                 newBtn.addEventListener(
                   'touchstart',
@@ -1454,13 +1510,7 @@ export function createAlbumDisplay(deps = {}) {
                 newBtn.addEventListener('click', (e) => {
                   e.stopPropagation();
                   e.preventDefault();
-                  const albumsForPlay = getListData(getCurrentList());
-                  const albumForPlay = albumsForPlay && albumsForPlay[index];
-                  if (albumForPlay) {
-                    const albumId =
-                      `${albumForPlay.artist}::${albumForPlay.album}::${albumForPlay.release_date || ''}`.toLowerCase();
-                    playTrackSafe(albumId);
-                  }
+                  playTrackButton(index, newBtn.dataset.trackIdentifier);
                 });
               } else {
                 trackPlayBtn.classList.remove(
@@ -1484,6 +1534,11 @@ export function createAlbumDisplay(deps = {}) {
                 'data-track-play-btn',
                 hasSecondary ? 'true' : ''
               );
+              if (hasSecondary) {
+                secondaryPlayBtn.dataset.trackIdentifier = data.secondaryTrack;
+              } else {
+                delete secondaryPlayBtn.dataset.trackIdentifier;
+              }
 
               if (hasSecondary) {
                 secondaryPlayBtn.classList.add(
@@ -1512,13 +1567,10 @@ export function createAlbumDisplay(deps = {}) {
                 newSecondaryBtn.addEventListener('click', (e) => {
                   e.stopPropagation();
                   e.preventDefault();
-                  const albumsForPlay = getListData(getCurrentList());
-                  const albumForPlay = albumsForPlay && albumsForPlay[index];
-                  if (albumForPlay) {
-                    const albumId =
-                      `${albumForPlay.artist}::${albumForPlay.album}::${albumForPlay.release_date || ''}`.toLowerCase();
-                    playTrackSafe(albumId);
-                  }
+                  playTrackButton(
+                    index,
+                    newSecondaryBtn.dataset.trackIdentifier
+                  );
                 });
               } else {
                 secondaryPlayBtn.classList.remove(

--- a/src/js/modules/album-display/playcount-view.js
+++ b/src/js/modules/album-display/playcount-view.js
@@ -108,7 +108,11 @@ export function applyMobilePlaycount(el, status, display) {
   const { className, html, title } = mobileAtoms(status, display);
   el.className = className;
   el.innerHTML = html;
-  if (title) el.title = title;
+  if (title) {
+    el.title = title;
+  } else {
+    el.removeAttribute('title');
+  }
   el.dataset.status = status;
   el.classList.remove('hidden');
 }

--- a/test/album-display-shared.test.js
+++ b/test/album-display-shared.test.js
@@ -343,7 +343,7 @@ describe('album-display-shared module', () => {
     assert.ok(queries > queryCountAfterCache);
   });
 
-  it('creates and invalidates album fingerprints and mutable fingerprints', () => {
+  it('creates fingerprints from visible mutable album fields', () => {
     const utils = createAlbumDisplayShared({
       doc: { getElementById: () => null },
       computeGridTemplate: () => '',
@@ -359,6 +359,7 @@ describe('album-display-shared module', () => {
         album: 'B',
         release_date: '2024-01-01',
         primary_track: 'Song',
+        availability: ['qobuz', 'spotify'],
       },
     ];
 
@@ -366,11 +367,16 @@ describe('album-display-shared module', () => {
     const second = utils.generateAlbumFingerprint(albums);
     assert.strictEqual(first, second);
 
-    albums[0].primary_track = 'New';
-    const stale = utils.generateAlbumFingerprint(albums);
-    assert.strictEqual(stale, first);
+    albums[0].album = 'New title';
+    const titleUpdated = utils.generateAlbumFingerprint(albums);
+    assert.notStrictEqual(titleUpdated, first);
 
-    utils.invalidateFingerprint(albums);
+    albums[0].album = 'B';
+    albums[0].availability = ['spotify', 'qobuz'];
+    const reorderedAvailability = utils.generateAlbumFingerprint(albums);
+    assert.strictEqual(reorderedAvailability, first);
+
+    albums[0].availability = ['spotify'];
     const updated = utils.generateAlbumFingerprint(albums);
     assert.notStrictEqual(updated, first);
 

--- a/test/album-display.test.js
+++ b/test/album-display.test.js
@@ -276,6 +276,53 @@ describe('album-display module', () => {
       }
     });
 
+    it('renders mobile hooks for mutable title and availability fields', () => {
+      const previousCreateElement = globalThis.document.createElement;
+      globalThis.document.createElement = () => ({
+        className: '',
+        dataset: {},
+        style: {},
+        children: [],
+        innerHTML: '',
+        appendChild(child) {
+          this.children.push(child);
+        },
+        querySelector: () => null,
+        querySelectorAll: () => [],
+        addEventListener: () => {},
+      });
+
+      try {
+        const module = createAlbumDisplay({
+          getCurrentList: () => 'list-1',
+          getListMetadata: () => ({ isMain: false }),
+          getListData: () => [],
+          getTrackName: (track) => track?.name || track || '',
+          getTrackLength: () => null,
+          formatTrackTime: () => '',
+        });
+
+        const wrapper = module.createAlbumItem(
+          {
+            album: 'Mutable Album',
+            artist: 'Artist',
+            album_id: 'album-1',
+            availability: ['spotify'],
+          },
+          0,
+          true
+        );
+        const card = wrapper.children[0];
+
+        assert.match(card.innerHTML, /data-field="album-mobile-title"/);
+        assert.match(card.innerHTML, /Mutable Album/);
+        assert.match(card.innerHTML, /album-availability--mobile/);
+        assert.match(card.innerHTML, /fa-spotify/);
+      } finally {
+        globalThis.document.createElement = previousCreateElement;
+      }
+    });
+
     it('should handle empty dependencies gracefully', () => {
       // Should not throw when called with empty deps
       const module = createAlbumDisplay({});
@@ -551,9 +598,12 @@ describe('album-display module', () => {
 
     // Helper: build a fingerprint string from an album object, matching the
     // format used by extractMutableFingerprints in album-display-shared.js.
-    // Format: "_id|artist|album|release_date|country|genre_1|genre_2|comments|comments_2|primary_track|secondary_track"
+    // Format: "_id|artist|album|release_date|country|genre_1|genre_2|comments|comments_2|primary_track|secondary_track|availability"
     function fp(a) {
-      return `${a._id || ''}|${a.artist || ''}|${a.album || ''}|${a.release_date || ''}|${a.country || ''}|${a.genre_1 || ''}|${a.genre_2 || ''}|${a.comments || ''}|${a.comments_2 || ''}|${a.primary_track || ''}|${a.secondary_track || ''}`;
+      const availability = Array.isArray(a.availability)
+        ? [...a.availability].sort().join(',')
+        : '';
+      return `${a._id || ''}|${a.artist || ''}|${a.album || ''}|${a.release_date || ''}|${a.country || ''}|${a.genre_1 || ''}|${a.genre_2 || ''}|${a.comments || ''}|${a.comments_2 || ''}|${a.primary_track || ''}|${a.secondary_track || ''}|${availability}`;
     }
 
     it('should return SINGLE_ADD when one album is added', () => {
@@ -592,6 +642,28 @@ describe('album-display module', () => {
       ];
       const newAlbums = [
         { artist: 'A', album: '1', release_date: '', country: 'UK' },
+      ];
+      const result = module.detectUpdateType(oldAlbums.map(fp), newAlbums);
+      assert.strictEqual(result, 'FIELD_UPDATE');
+    });
+
+    it('should return FIELD_UPDATE for availability changes', () => {
+      const module = createAlbumDisplay({});
+      const oldAlbums = [
+        {
+          artist: 'A',
+          album: '1',
+          release_date: '',
+          availability: ['spotify'],
+        },
+      ];
+      const newAlbums = [
+        {
+          artist: 'A',
+          album: '1',
+          release_date: '',
+          availability: ['spotify', 'qobuz'],
+        },
       ];
       const result = module.detectUpdateType(oldAlbums.map(fp), newAlbums);
       assert.strictEqual(result, 'FIELD_UPDATE');

--- a/test/playcount-view.test.js
+++ b/test/playcount-view.test.js
@@ -1,0 +1,41 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+function createPlaycountElement() {
+  return {
+    className: '',
+    innerHTML: '',
+    title: '',
+    dataset: {},
+    removedAttributes: [],
+    classList: {
+      removed: [],
+      remove(name) {
+        this.removed.push(name);
+      },
+    },
+    removeAttribute(name) {
+      this.removedAttributes.push(name);
+      if (name === 'title') this.title = '';
+    },
+  };
+}
+
+describe('playcount-view', async () => {
+  const { applyMobilePlaycount } =
+    await import('../src/js/modules/album-display/playcount-view.js');
+
+  it('clears stale mobile not-found title when a playcount succeeds', () => {
+    const el = createPlaycountElement();
+
+    applyMobilePlaycount(el, 'not_found');
+    assert.strictEqual(el.title, 'Album not found on Last.fm');
+
+    applyMobilePlaycount(el, 'success', '42');
+
+    assert.strictEqual(el.title, '');
+    assert.deepStrictEqual(el.removedAttributes, ['title']);
+    assert.strictEqual(el.dataset.status, 'success');
+    assert.match(el.innerHTML, /42/);
+  });
+});


### PR DESCRIPTION
## Summary
- make album render fingerprints track all visible mutable fields and availability
- remove stale array-identity fingerprint caching so in-place list mutations are detected
- update mobile album titles, availability badges, and track play metadata during incremental field updates
- clear stale mobile playcount titles when a not-found badge becomes a successful playcount
- add focused regression coverage for fingerprints, mobile render hooks, availability changes, and playcount title cleanup

## Tests
- docker compose -f docker-compose.local.yml exec app node --test test/album-display-shared.test.js test/album-display.test.js test/album-display-incremental-update-detector.test.js test/availability-badges.test.js test/playcount-view.test.js
- npm run lint:strict