### PR TITLE
Fix playcount view CI test failure

### DIFF
--- a/src/js/modules/album-display/playcount-view.js
+++ b/src/js/modules/album-display/playcount-view.js
@@ -110,8 +110,10 @@ export function applyMobilePlaycount(el, status, display) {
   el.innerHTML = html;
   if (title) {
     el.title = title;
-  } else {
+  } else if (typeof el.removeAttribute === 'function') {
     el.removeAttribute('title');
+  } else {
+    el.title = '';
   }
   el.dataset.status = status;
   el.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- keep clearing stale mobile playcount titles with removeAttribute when available
- fall back to clearing the title property for lightweight test doubles
- fixes the latest main CI failure in album-playcount-sync tests

## Tests
- docker compose -f docker-compose.local.yml exec app node --test test/album-playcount-sync.test.js test/playcount-view.test.js
- npm run lint:strict
- docker compose -f docker-compose.local.yml exec -e CI=true app npm test

Note: docker compose npm test without CI=true still fails locally because the container lacks Playwright Chromium; the GitHub workflow runs Playwright in a separate e2e job after installing browsers.