### PR TITLE
Add local CI parity command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:security": "npm audit --audit-level=moderate",
     "test:security:full": "npm audit && npm outdated",
     "test:all": "npm run lint && npm test && npm run test:security",
+    "ci:local": "bash scripts/local-ci.sh",
+    "ci:local:e2e": "RUN_E2E=1 bash scripts/local-ci.sh",
     "lint": "eslint .",
     "lint:strict": "npm run format:check:source && eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.local.yml}"
+APP_SERVICE="${APP_SERVICE:-app}"
+
+run_in_app_container() {
+  docker compose -f "$COMPOSE_FILE" exec -e CI=true "$APP_SERVICE" "$@"
+}
+
+echo "=== Local CI: build ==="
+npm run build
+
+echo "=== Local CI: lint ==="
+npm run lint
+
+echo "=== Local CI: structure baseline ==="
+npm run lint:structure:baseline
+
+echo "=== Local CI: strict lint ==="
+npm run lint:strict
+
+echo "=== Local CI: unit + integration tests (Docker, CI=true) ==="
+run_in_app_container bash scripts/run-tests.sh
+
+if [ "${RUN_E2E:-0}" = "1" ]; then
+  echo "=== Local CI: Playwright e2e tests ==="
+  PLAYWRIGHT_SKIP_SERVER=1 npx playwright test
+else
+  echo "Skipping Playwright e2e tests (set RUN_E2E=1 to run them)."
+fi


### PR DESCRIPTION
## Summary
- add npm scripts for local CI parity with optional e2e
- add a script that runs build/lint checks locally and unit/integration tests in Docker with CI=true

## Verification
- npm run ci:local