### PR TITLE
Skip active recommendations sidebar reload

### DIFF
--- a/src/js/modules/album-display.js
+++ b/src/js/modules/album-display.js
@@ -42,16 +42,24 @@ import { renderAvailabilityBadges } from './album-display/availability-badges.js
 import { getPositionBadgeColor } from './album-display/position-badge.js';
 import { createModal, destroyModalForElement } from './modal-factory.js';
 import {
-  mobilePlaycountSpan,
-  desktopPlaycountSpan,
-} from './album-display/playcount-view.js';
+  renderDesktopAlbumCell,
+  renderDesktopArtistCell,
+  renderDesktopCoverCell,
+  renderDesktopGenreCell,
+  renderMobileArtistRow,
+  renderMobileCoverSection,
+  renderMobileGenreRow,
+  renderMobilePlaycountRow,
+  renderMobilePositionBadge,
+  renderMobileTitleRow,
+  renderRecommendationBadge,
+  renderSummaryBadge,
+} from './album-display/render-parts.js';
 
 // Feature flag for incremental updates (can be disabled if issues arise)
 const ENABLE_INCREMENTAL_UPDATES = true;
 const PROGRESSIVE_RENDER_THRESHOLD = 120;
 const PROGRESSIVE_RENDER_BATCH_SIZE = 60;
-const INITIAL_DESKTOP_COVER_COUNT = 16;
-const INITIAL_MOBILE_COVER_COUNT = 8;
 const INITIAL_COVER_REVEAL_TIMEOUT_MS = 800;
 
 // Module-level state
@@ -82,45 +90,6 @@ const {
   invalidateFingerprint,
   extractMutableFingerprints,
 } = albumDisplayShared;
-
-function getCoverLoadMode(index, isMobile) {
-  const initialCount = isMobile
-    ? INITIAL_MOBILE_COVER_COUNT
-    : INITIAL_DESKTOP_COVER_COUNT;
-  return index < initialCount ? 'initial' : 'eager';
-}
-
-function renderCoverImage({ src, fullSrc, alt, className, loadMode }) {
-  const escapedSrc = escapeHtml(src);
-  const escapedFullSrc = escapeHtml(fullSrc || src);
-  const escapedAlt = escapeHtml(alt || '');
-
-  if (loadMode === 'initial') {
-    return `<img src="${escapedSrc}"
-      data-full-src="${escapedFullSrc}"
-      data-cover-reveal-group="initial"
-      alt="${escapedAlt}"
-      class="${className} cover-reveal-pending"
-      loading="eager"
-      decoding="async"
-      fetchpriority="high"
-    >`;
-  }
-
-  // Off-screen covers still render a placeholder + data-lazy-src so the error
-  // handler can attach before the real src is swapped in (loadCoverImages does
-  // the swap right after render). loading="eager" means they are not deferred by
-  // the browser; fetchpriority="low" keeps them behind the visible covers.
-  return `<img src="${PLACEHOLDER_GIF}"
-    data-lazy-src="${escapedSrc}"
-    data-full-src="${escapedFullSrc}"
-    alt="${escapedAlt}"
-    class="${className}"
-    loading="eager"
-    decoding="async"
-    fetchpriority="low"
-  >`;
-}
 
 /**
  * Factory function to create the album display module with injected dependencies
@@ -403,50 +372,7 @@ export function createAlbumDisplay(deps = {}) {
     const row = document.createElement('div');
     row.className = 'album-row album-grid gap-4 py-2';
     row.dataset.index = index;
-
-    // Determine cover image source:
-    // 1. Base64 cover (takes priority - may be locally edited or custom cover)
-    // 2. URL-based loading - uses coverImageUrl from API (efficient for unmodified covers)
-    // 3. Placeholder if no cover available
-    const coverImageSrc = data.coverImage
-      ? `data:image/${data.imageFormat};base64,${data.coverImage}`
-      : data.coverThumbUrl
-        ? data.coverThumbUrl
-        : null;
-    const coverLoadMode = getCoverLoadMode(index, false);
-
-    // Summary badge HTML (shown if album has a summary from any source)
-    // All summaries now use Claude badge (even if originally from Last.fm/Wikipedia)
-    let summaryBadgeHtml = '';
-    if (data.summary) {
-      const source = data.summarySource || '';
-      // Always show Claude badge for all summaries
-      const badgeClass = 'claude-badge';
-      const iconClass = 'fas fa-robot';
-      // No source URL for Claude summaries
-      const sourceUrl = null;
-
-      summaryBadgeHtml = `<div class="summary-badge ${badgeClass}" 
-        data-summary="${escapeHtml(data.summary)}" 
-        data-source-url="${escapeHtml(sourceUrl || '')}" 
-        data-source="${escapeHtml(source)}"
-        data-album-name="${escapeHtml(data.albumName)}" 
-        data-artist="${escapeHtml(data.artist)}">
-        <i class="${iconClass}"></i>
-      </div>`;
-    }
-
-    // Recommendation badge HTML (shown if album is on the year's recommendations list)
-    let recommendationBadgeHtml = '';
-    if (data.recommendedBy) {
-      recommendationBadgeHtml = `<div class="recommendation-badge"
-        data-recommended-by="${escapeHtml(data.recommendedBy)}"
-        data-recommended-at="${escapeHtml(data.recommendedAt || '')}"
-        data-album-name="${escapeHtml(data.albumName)}"
-        data-artist="${escapeHtml(data.artist)}">
-        <i class="fas fa-thumbs-up"></i>
-      </div>`;
-    }
+    const badgeHtml = `${renderSummaryBadge(data)}${renderRecommendationBadge(data)}`;
 
     // Build cell HTML map — each column produces its own cell
     const cellMap = {
@@ -454,49 +380,14 @@ export function createAlbumDisplay(deps = {}) {
         data.position !== null
           ? `<div class="position-cell flex items-center justify-center text-gray-400 font-medium text-sm position-display" data-position-element="true">${data.position}</div>`
           : '<div class="position-cell"></div>',
-      cover: `<div class="cover-cell flex items-center">
-        <div class="album-cover-container${coverImageSrc && coverLoadMode === 'initial' ? ' cover-reveal-shell' : ''}">
-          ${
-            coverImageSrc
-              ? renderCoverImage({
-                  src: coverImageSrc,
-                  fullSrc: data.coverImageUrl || coverImageSrc,
-                  alt: data.albumName,
-                  className: 'album-cover rounded-sm shadow-lg',
-                  loadMode: coverLoadMode,
-                })
-              : `<div class="album-cover-placeholder rounded-sm bg-gray-800 shadow-lg">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-gray-600">
-                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-                <circle cx="8.5" cy="8.5" r="1.5"></circle>
-                <polyline points="21 15 16 10 5 21"></polyline>
-              </svg>
-            </div>`
-          }
-          ${summaryBadgeHtml}
-          ${recommendationBadgeHtml}
-        </div>
-      </div>`,
-      album: `<div class="album-cell flex flex-col justify-start">
-        <div class="flex items-center gap-2">
-          <span class="album-name font-semibold text-gray-200 truncate">${escapeHtml(data.albumName)}</span>
-          ${desktopPlaycountSpan(data.itemId, data.playcountDisplay, data.playcount)}
-        </div>
-        <div class="text-xs mt-0.5 release-date-display ${data.yearMismatch ? 'text-red-500 cursor-help' : 'text-gray-400'}" ${data.yearMismatch ? `title="${data.yearMismatchTooltip}"` : ''}>${data.releaseDate}</div>
-        ${renderAvailabilityBadges(data.availability)}
-      </div>`,
-      artist: `<div class="artist-cell flex items-center">
-        <span class="album-cell-text ${data.artist ? 'text-gray-200' : 'text-gray-800 italic'} truncate cursor-pointer hover:text-gray-100">${escapeHtml(data.artist)}</span>
-      </div>`,
+      cover: renderDesktopCoverCell(data, index, { badgesHtml: badgeHtml }),
+      album: renderDesktopAlbumCell(data, { alwaysShowReleaseDate: true }),
+      artist: renderDesktopArtistCell(data),
       country: `<div class="flex items-center country-cell">
         <span class="album-cell-text ${data.countryClass} truncate cursor-pointer hover:text-gray-100">${data.countryDisplay}</span>
       </div>`,
-      genre_1: `<div class="flex items-center genre-1-cell">
-        <span class="album-cell-text ${data.genre1Class} truncate cursor-pointer hover:text-gray-100">${data.genre1Display}</span>
-      </div>`,
-      genre_2: `<div class="flex items-center genre-2-cell">
-        <span class="album-cell-text ${data.genre2Class} truncate cursor-pointer hover:text-gray-100">${data.genre2Display}</span>
-      </div>`,
+      genre_1: renderDesktopGenreCell(data, 1),
+      genre_2: renderDesktopGenreCell(data, 2),
       track: `<div class="flex flex-col justify-start track-cell min-w-0 cursor-pointer overflow-hidden">
         ${
           data.primaryTrackDisplay
@@ -813,72 +704,11 @@ export function createAlbumDisplay(deps = {}) {
     const card = document.createElement('div');
     card.className = 'album-card album-row relative h-[145px] bg-gray-900';
     card.dataset.index = index;
-
-    // === COVER IMAGE SOURCE ===
-    const mobileCoverSrc = data.coverImage
-      ? `data:image/${data.imageFormat};base64,${data.coverImage}`
-      : data.coverThumbUrl || null;
-    const coverLoadMode = getCoverLoadMode(index, true);
-
-    // === SUMMARY BADGE (AI indicator, shown at the right of the title row) ===
-    // Styling (bare icon, no disc) lives in .summary-badge-mobile in input.css.
-    let summaryBadgeHtml = '';
-    if (data.summary) {
-      summaryBadgeHtml = `
-        <div class="summary-badge summary-badge-mobile claude-badge"
-             data-summary="${escapeHtml(data.summary)}"
-             data-source-url="${escapeHtml('')}"
-             data-source="${escapeHtml(data.summarySource || '')}"
-             data-album-name="${escapeHtml(data.albumName)}"
-             data-artist="${escapeHtml(data.artist)}">
-          <i class="fas fa-robot"></i>
-        </div>`;
-    }
-
-    // === RECOMMENDATION BADGE (shown if album is on the year's recommendations) ===
-    let mobileRecommendationBadgeHtml = '';
-    if (data.recommendedBy) {
-      mobileRecommendationBadgeHtml = `
-        <div class="recommendation-badge recommendation-badge-mobile"
-             data-recommended-by="${escapeHtml(data.recommendedBy)}"
-             data-recommended-at="${escapeHtml(data.recommendedAt || '')}"
-             data-album-name="${escapeHtml(data.albumName)}"
-             data-artist="${escapeHtml(data.artist)}">
-          <i class="fas fa-thumbs-up"></i>
-        </div>`;
-    }
-
-    // === POSITION BADGE ===
-    // Circular badge showing album rank, positioned in top-right of menu section
-    const getPositionBadgeHtml = (position) => {
-      if (position === null) return '';
-
-      // Color coding: gold (1st), silver (2nd), bronze (3rd), gray (rest).
-      // Shared with the drag-reorder recolor so the two never diverge.
-      const c = getPositionBadgeColor(position);
-
-      // Positioned in the card's top-right with equal top/right insets (6.5px)
-      // so the badge is centered over the menu column width (matching the
-      // three-dot button): right = (30px column - 19px badge) / 2 = 5.5px, and
-      // top mirrors that for symmetric corner spacing.
-      return `
-        <div class="mobile-position-badge"
-             style="position: absolute; top: 5.5px; right: 5.5px; z-index: 10;
-                    width: 19px; height: 19px;
-                    display: flex; align-items: center; justify-content: center;
-                    border: 1px solid ${c.border}; border-radius: 50%;
-                    background: rgba(17, 24, 39, 0.7);
-                    box-shadow: 0 0 ${c.size} ${c.shadow};
-                    color: white; font-size: 10px; font-weight: 500; line-height: 1;
-                    font-variant-numeric: tabular-nums; pointer-events: none;"
-             data-position-element="true">
-          <span style="display: block; line-height: 1">${position}</span>
-        </div>`;
-    };
+    const mobileBadgeHtml = `${renderRecommendationBadge(data, { mobile: true })}${renderSummaryBadge(data, { mobile: true })}`;
 
     // === BUILD CARD HTML ===
     card.innerHTML = `
-      ${getPositionBadgeHtml(data.position)}
+      ${renderMobilePositionBadge(data.position)}
 
       <div class="flex items-stretch h-full">
         
@@ -903,29 +733,7 @@ export function createAlbumDisplay(deps = {}) {
              four gaps visually equal. The live-update twin (mobile branch of the
              release-date className reset, ~line 1310) MUST keep these same
              classes or the asymmetry returns on the next in-place update. -->
-        <div class="h-full shrink-0 w-[88px] flex flex-col items-center justify-evenly pl-0.5">
-          <!-- Album cover with optional summary badge -->
-          <div class="mobile-album-cover relative w-20 h-20 flex items-center justify-center ${!mobileCoverSrc ? 'bg-gray-800 rounded-lg' : ''} ${mobileCoverSrc && coverLoadMode === 'initial' ? 'cover-reveal-shell' : ''}">
-            ${
-              mobileCoverSrc
-                ? renderCoverImage({
-                    src: mobileCoverSrc,
-                    fullSrc: data.coverImageUrl || mobileCoverSrc,
-                    alt: data.albumName,
-                    className: 'w-full h-full rounded-lg object-cover',
-                    loadMode: coverLoadMode,
-                  })
-                : `<i class="fas fa-compact-disc text-xl text-gray-600"></i>`
-            }
-          </div>
-          <!-- Release date -->
-          <span class="release-date-display text-xs leading-none whitespace-nowrap ${data.yearMismatch ? 'text-red-500' : 'text-gray-500'}"
-                ${data.yearMismatch ? `title="${escapeHtml(data.yearMismatchTooltip || '')}"` : ''}>
-            ${data.releaseDate}
-          </span>
-          <!-- Platform availability badges -->
-          ${renderAvailabilityBadges(data.availability, { variant: 'mobile' })}
-        </div>
+        ${renderMobileCoverSection(data, index)}
         
         <!-- INFO SECTION -->
         <div class="flex-1 min-w-0 pl-0.5 pr-1 flex flex-col justify-evenly h-[130px] leading-[18px]">
@@ -934,26 +742,11 @@ export function createAlbumDisplay(deps = {}) {
                truncated title cuts off at (info-section width - this padding).
                The summary/recommendation badges overlay that reserved zone,
                absolutely centered on the title line. -->
-          <div class="flex items-center relative" style="padding-right: 55px">
-            <h3 class="text-gray-100 leading-tight truncate min-w-0" style="font-size: 13px; font-weight: 700">
-              <i class="fas fa-compact-disc fa-xs inline-block w-4 text-center align-middle mr-1"></i><span data-field="album-mobile-title">${escapeHtml(data.albumName)}</span>
-            </h3>
-            <!-- Recommendation first (left), summary last so the summary badge
-                 is always the rightmost, fixed regardless of the recommendation. -->
-            <div class="absolute flex items-center" style="top: 50%; right: 4px; transform: translateY(-50%); gap: 4px">
-              ${mobileRecommendationBadgeHtml}${summaryBadgeHtml}
-            </div>
-          </div>
+          ${renderMobileTitleRow(data, { paddingRight: '55px', badgesHtml: mobileBadgeHtml })}
           <!-- Artist -->
-          <div class="flex items-center" style="padding-right: 55px">
-            <p class="text-[12px] text-gray-400 truncate min-w-0">
-              <i class="fas fa-user fa-xs inline-block w-4 text-center mr-1"></i><span data-field="artist-mobile-text">${escapeHtml(data.artist)}</span>
-            </p>
-          </div>
+          ${renderMobileArtistRow(data, { paddingRight: '55px' })}
           <!-- Last.fm playcount -->
-          <div class="flex items-center">
-            ${mobilePlaycountSpan(data.itemId, data.playcountDisplay)}
-          </div>
+          ${renderMobilePlaycountRow(data)}
           <!-- Country -->
           <div class="flex items-center">
             <span class="text-[12px] text-gray-400">
@@ -961,11 +754,7 @@ export function createAlbumDisplay(deps = {}) {
             </span>
           </div>
           <!-- Genres -->
-          <div class="flex items-center">
-            <span class="text-[12px] text-gray-400 truncate">
-              <i class="fas fa-music fa-xs inline-block w-4 text-center mr-1"></i><span data-field="genre-mobile-text">${escapeHtml(data.genre1 && data.genre2 ? `${data.genre1} / ${data.genre2}` : data.genre1 || data.genre2 || '')}</span>
-            </span>
-          </div>
+          ${renderMobileGenreRow(data)}
           <!-- Primary track (marker: 1) -->
           <div class="flex items-center ${data.primaryTrackDisplay ? 'cursor-pointer active:opacity-70' : ''}"
                data-track-play-btn="${data.primaryTrackDisplay ? 'true' : ''}"

--- a/src/js/modules/album-display/render-parts.js
+++ b/src/js/modules/album-display/render-parts.js
@@ -1,0 +1,325 @@
+import { escapeHtmlAttr as escapeHtml } from '../html-utils.js';
+import { PLACEHOLDER_GIF } from '../album-display-shared.js';
+import { renderAvailabilityBadges } from './availability-badges.js';
+import { getPositionBadgeColor } from './position-badge.js';
+import { desktopPlaycountSpan, mobilePlaycountSpan } from './playcount-view.js';
+
+const INITIAL_DESKTOP_COVER_COUNT = 16;
+const INITIAL_MOBILE_COVER_COUNT = 8;
+
+const COVER_PLACEHOLDER_SVG = `<div class="album-cover-placeholder rounded-sm bg-gray-800 shadow-lg">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-gray-600">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+    <circle cx="8.5" cy="8.5" r="1.5"></circle>
+    <polyline points="21 15 16 10 5 21"></polyline>
+  </svg>
+</div>`;
+
+export function getCoverLoadMode(index, isMobile) {
+  const initialCount = isMobile
+    ? INITIAL_MOBILE_COVER_COUNT
+    : INITIAL_DESKTOP_COVER_COUNT;
+  return index < initialCount ? 'initial' : 'eager';
+}
+
+function getCoverSrc(data) {
+  if (data.coverImage) {
+    return `data:image/${data.imageFormat};base64,${data.coverImage}`;
+  }
+
+  return data.coverThumbUrl || null;
+}
+
+function compactFallbackHtml(html) {
+  return html.replace(/\n\s*/g, '');
+}
+
+function renderFallbackAttr(fallbackHtml) {
+  if (!fallbackHtml) return '';
+
+  const handler = `this.onerror=null; this.parentElement.innerHTML=${JSON.stringify(compactFallbackHtml(fallbackHtml))}`;
+  return ` onerror="${escapeHtml(handler)}"`;
+}
+
+export function renderCoverImage({
+  src,
+  fullSrc,
+  alt,
+  className,
+  loadMode,
+  fallbackHtml = '',
+}) {
+  const escapedSrc = escapeHtml(src);
+  const escapedFullSrc = escapeHtml(fullSrc || src);
+  const escapedAlt = escapeHtml(alt || '');
+  const fallbackAttr = renderFallbackAttr(fallbackHtml);
+
+  if (loadMode === 'lazy') {
+    return `<img src="${escapedSrc}"
+      data-full-src="${escapedFullSrc}"
+      alt="${escapedAlt}"
+      class="${className}"
+      loading="lazy"
+      decoding="async"${fallbackAttr}
+    >`;
+  }
+
+  if (loadMode === 'initial') {
+    return `<img src="${escapedSrc}"
+      data-full-src="${escapedFullSrc}"
+      data-cover-reveal-group="initial"
+      alt="${escapedAlt}"
+      class="${className} cover-reveal-pending"
+      loading="eager"
+      decoding="async"
+      fetchpriority="high"${fallbackAttr}
+    >`;
+  }
+
+  return `<img src="${PLACEHOLDER_GIF}"
+    data-lazy-src="${escapedSrc}"
+    data-full-src="${escapedFullSrc}"
+    alt="${escapedAlt}"
+    class="${className}"
+    loading="eager"
+    decoding="async"
+    fetchpriority="low"${fallbackAttr}
+  >`;
+}
+
+export function renderSummaryBadge(data, { mobile = false } = {}) {
+  if (!data.summary) return '';
+
+  const mobileClass = mobile ? ' summary-badge-mobile' : '';
+  return `<div class="summary-badge${mobileClass} claude-badge"
+    data-summary="${escapeHtml(data.summary)}"
+    data-source-url="${escapeHtml('')}"
+    data-source="${escapeHtml(data.summarySource || '')}"
+    data-album-name="${escapeHtml(data.albumName)}"
+    data-artist="${escapeHtml(data.artist)}">
+    <i class="fas fa-robot"></i>
+  </div>`;
+}
+
+export function renderRecommendationBadge(data, { mobile = false } = {}) {
+  if (!data.recommendedBy) return '';
+
+  const mobileClass = mobile ? ' recommendation-badge-mobile' : '';
+  return `<div class="recommendation-badge${mobileClass}"
+    data-recommended-by="${escapeHtml(data.recommendedBy)}"
+    data-recommended-at="${escapeHtml(data.recommendedAt || '')}"
+    data-album-name="${escapeHtml(data.albumName)}"
+    data-artist="${escapeHtml(data.artist)}">
+    <i class="fas fa-thumbs-up"></i>
+  </div>`;
+}
+
+export function renderDesktopCoverCell(data, index, options = {}) {
+  const coverImageSrc = getCoverSrc(data);
+  const loadMode = options.loadMode || getCoverLoadMode(index, false);
+  const revealClass =
+    coverImageSrc && loadMode === 'initial' ? ' cover-reveal-shell' : '';
+  const placeholderHtml = options.placeholderHtml || COVER_PLACEHOLDER_SVG;
+  const badgesHtml = options.badgesHtml || '';
+
+  return `<div class="${options.cellClass || 'cover-cell flex items-center'}">
+    <div class="album-cover-container${revealClass}">
+      ${
+        coverImageSrc
+          ? renderCoverImage({
+              src: coverImageSrc,
+              fullSrc: data.coverImageUrl || coverImageSrc,
+              alt: data.albumName,
+              className:
+                options.imageClassName || 'album-cover rounded-sm shadow-lg',
+              loadMode,
+              fallbackHtml: placeholderHtml,
+            })
+          : placeholderHtml
+      }
+      ${badgesHtml}
+    </div>
+  </div>`;
+}
+
+export function renderDesktopAlbumCell(data, options = {}) {
+  const playcountHtml =
+    options.includePlaycount === false
+      ? ''
+      : desktopPlaycountSpan(
+          data.itemId,
+          data.playcountDisplay,
+          data.playcount
+        );
+  const availabilityHtml =
+    options.includeAvailability === false
+      ? ''
+      : renderAvailabilityBadges(data.availability);
+  const titleAttr = options.includeTitle
+    ? ` title="${escapeHtml(data.albumName)}"`
+    : '';
+  const releaseDateHtml =
+    data.releaseDate || options.alwaysShowReleaseDate
+      ? `<div class="text-xs mt-0.5 release-date-display ${data.yearMismatch ? 'text-red-500 cursor-help' : 'text-gray-400'}" ${data.yearMismatch ? `title="${escapeHtml(data.yearMismatchTooltip || '')}"` : ''}>${escapeHtml(data.releaseDate || '')}</div>`
+      : '';
+
+  return `<div class="${options.cellClass || 'album-cell flex flex-col justify-start'}">
+    <div class="flex items-center gap-2">
+      <span class="album-name font-semibold text-gray-200 truncate"${titleAttr}>${escapeHtml(data.albumName)}</span>
+      ${playcountHtml}
+    </div>
+    ${releaseDateHtml}
+    ${availabilityHtml}
+  </div>`;
+}
+
+export function renderDesktopArtistCell(data, options = {}) {
+  const hasArtist = Boolean(data.artist);
+  const textClass = hasArtist
+    ? options.textClass || 'text-gray-200'
+    : options.emptyTextClass || 'text-gray-800 italic';
+  const interactiveClass =
+    options.interactive === false ? '' : ' cursor-pointer hover:text-gray-100';
+  const titleAttr = options.includeTitle
+    ? ` title="${escapeHtml(data.artist)}"`
+    : '';
+
+  return `<div class="${options.cellClass || 'artist-cell flex items-center'}">
+    <span class="album-cell-text ${textClass} truncate${interactiveClass}"${titleAttr}>${escapeHtml(data.artist)}</span>
+  </div>`;
+}
+
+export function renderDesktopGenreCell(data, slot, options = {}) {
+  const value = slot === 2 ? data.genre2 : data.genre1;
+  const display = slot === 2 ? data.genre2Display : data.genre1Display;
+  const defaultClass = slot === 2 ? data.genre2Class : data.genre1Class;
+  const fallback = options.fallback || (slot === 2 ? 'Genre 2' : 'Genre 1');
+  const text = value ? display : fallback;
+  const textClass = value
+    ? options.textClass || defaultClass || 'text-gray-300'
+    : options.emptyTextClass || defaultClass || 'text-gray-800 italic';
+  const interactiveClass =
+    options.interactive === false ? '' : ' cursor-pointer hover:text-gray-100';
+  const titleAttr = options.includeTitle
+    ? ` title="${escapeHtml(value || fallback)}"`
+    : '';
+
+  return `<div class="${options.cellClass || `flex items-center genre-${slot}-cell`}">
+    <span class="album-cell-text ${textClass} truncate${interactiveClass}"${titleAttr}>${escapeHtml(text)}</span>
+  </div>`;
+}
+
+export function renderMobilePositionBadge(position) {
+  if (position === null) return '';
+
+  const color = getPositionBadgeColor(position);
+  return `<div class="mobile-position-badge"
+    style="position: absolute; top: 5.5px; right: 5.5px; z-index: 10;
+      width: 19px; height: 19px;
+      display: flex; align-items: center; justify-content: center;
+      border: 1px solid ${color.border}; border-radius: 50%;
+      background: rgba(17, 24, 39, 0.7);
+      box-shadow: 0 0 ${color.size} ${color.shadow};
+      color: white; font-size: 10px; font-weight: 500; line-height: 1;
+      font-variant-numeric: tabular-nums; pointer-events: none;"
+    data-position-element="true">
+    <span style="display: block; line-height: 1">${position}</span>
+  </div>`;
+}
+
+export function renderMobileCoverSection(data, index, options = {}) {
+  const coverSrc = getCoverSrc(data);
+  const loadMode = options.loadMode || getCoverLoadMode(index, true);
+  const coverExtraHtml = options.coverExtraHtml || '';
+  const placeholderHtml =
+    options.placeholderHtml ||
+    '<i class="fas fa-compact-disc text-xl text-gray-600"></i>';
+  const dateText = options.dateText ?? data.releaseDate;
+  const availabilityHtml =
+    options.includeAvailability === false
+      ? ''
+      : renderAvailabilityBadges(data.availability, { variant: 'mobile' });
+  const dateHtml = `<span class="${options.dateClass || `release-date-display text-xs leading-none whitespace-nowrap ${data.yearMismatch ? 'text-red-500' : 'text-gray-500'}`}"
+    ${data.yearMismatch ? `title="${escapeHtml(data.yearMismatchTooltip || '')}"` : ''}>${escapeHtml(dateText || '')}</span>`;
+  const wrappedDateHtml = options.dateWrapperClass
+    ? `<div class="${options.dateWrapperClass}">${dateHtml}</div>`
+    : dateHtml;
+
+  return `<div class="${options.wrapperClass || 'h-full shrink-0 w-[88px] flex flex-col items-center justify-evenly pl-0.5'}">
+    <div class="${options.coverClass || `mobile-album-cover relative w-20 h-20 flex items-center justify-center ${!coverSrc ? 'bg-gray-800 rounded-lg' : ''} ${coverSrc && loadMode === 'initial' ? 'cover-reveal-shell' : ''}`}">
+      ${coverExtraHtml}
+      ${
+        coverSrc
+          ? renderCoverImage({
+              src: coverSrc,
+              fullSrc: data.coverImageUrl || coverSrc,
+              alt: data.albumName,
+              className:
+                options.imageClassName ||
+                'w-full h-full rounded-lg object-cover',
+              loadMode,
+              fallbackHtml: placeholderHtml,
+            })
+          : placeholderHtml
+      }
+    </div>
+    ${wrappedDateHtml}
+    ${availabilityHtml}
+  </div>`;
+}
+
+export function renderMobileTitleRow(data, options = {}) {
+  const badgesHtml = options.badgesHtml || '';
+  const paddingStyle = options.paddingRight
+    ? ` style="padding-right: ${options.paddingRight}"`
+    : '';
+  const titleClass =
+    options.titleClass || 'text-gray-100 leading-tight truncate min-w-0';
+  const titleStyle = options.titleStyle ?? 'font-size: 13px; font-weight: 700';
+  const iconClass =
+    options.iconClass ||
+    'fas fa-compact-disc fa-xs inline-block w-4 text-center align-middle mr-1';
+  const titleStyleAttr = titleStyle ? ` style="${titleStyle}"` : '';
+  const titleSpanClass = options.titleSpanClass
+    ? ` class="${options.titleSpanClass}"`
+    : '';
+
+  return `<div class="${options.wrapperClass || 'flex items-center relative'}"${paddingStyle}>
+    <h3 class="${titleClass}"${titleStyleAttr}>
+      <i class="${iconClass}"></i><span data-field="album-mobile-title"${titleSpanClass} title="${escapeHtml(data.albumName)}">${escapeHtml(data.albumName)}</span>
+    </h3>
+    ${badgesHtml ? `<div class="absolute flex items-center" style="top: 50%; right: 4px; transform: translateY(-50%); gap: 4px">${badgesHtml}</div>` : ''}
+  </div>`;
+}
+
+export function renderMobileArtistRow(data, options = {}) {
+  const spanClass = options.spanClass ? ` class="${options.spanClass}"` : '';
+
+  return `<div class="${options.wrapperClass || 'flex items-center'}"${options.paddingRight ? ` style="padding-right: ${options.paddingRight}"` : ''}>
+    <p class="${options.textClass || 'text-[12px] text-gray-400 truncate min-w-0'}">
+      <i class="${options.iconClass || 'fas fa-user fa-xs inline-block w-4 text-center mr-1'}"></i><span data-field="artist-mobile-text"${spanClass} title="${escapeHtml(data.artist)}">${escapeHtml(data.artist)}</span>
+    </p>
+  </div>`;
+}
+
+export function renderMobileGenreRow(data, options = {}) {
+  const value =
+    data.genre1 && data.genre2
+      ? `${data.genre1}${options.separator || ' / '}${data.genre2}`
+      : data.genre1 || data.genre2 || options.fallback || '';
+  const valueSpanClass = options.valueSpanClass
+    ? ` class="${options.valueSpanClass}"`
+    : '';
+
+  return `<div class="${options.wrapperClass || 'flex items-center'}">
+    <span class="${options.textClass || 'text-[12px] text-gray-400 truncate'}" title="${escapeHtml(value || options.fallback || '')}">
+      <i class="${options.iconClass || 'fas fa-music fa-xs inline-block w-4 text-center mr-1'}"></i><span data-field="genre-mobile-text"${valueSpanClass}>${value ? escapeHtml(value) : options.emptyHtml || ''}</span>
+    </span>
+  </div>`;
+}
+
+export function renderMobilePlaycountRow(data) {
+  return `<div class="flex items-center">
+    ${mobilePlaycountSpan(data.itemId, data.playcountDisplay)}
+  </div>`;
+}

--- a/src/js/modules/list-nav.js
+++ b/src/js/modules/list-nav.js
@@ -64,13 +64,20 @@ export function createListNav(deps = {}) {
   let groupsSortable = null;
   const listSortables = new Map();
 
+  function getActiveRecommendationsYear() {
+    return typeof getCurrentRecommendationsYear === 'function'
+      ? getCurrentRecommendationsYear()
+      : null;
+  }
+
   function isListActive(listId) {
-    const activeRecommendationsYear =
-      typeof getCurrentRecommendationsYear === 'function'
-        ? getCurrentRecommendationsYear()
-        : null;
+    const activeRecommendationsYear = getActiveRecommendationsYear();
 
     return getCurrentList() === listId && !activeRecommendationsYear;
+  }
+
+  function isRecommendationsActive(year) {
+    return getActiveRecommendationsYear() === year;
   }
 
   // ============ EXPAND STATE MANAGEMENT ============
@@ -614,12 +621,7 @@ export function createListNav(deps = {}) {
    * @returns {HTMLElement} List item element
    */
   function createRecommendationsButton(year, isMobile) {
-    // Check if recommendations is currently active for this year
-    const currentRecommendationsYear =
-      typeof getCurrentRecommendationsYear === 'function'
-        ? getCurrentRecommendationsYear()
-        : null;
-    const isActive = currentRecommendationsYear === year;
+    const isActive = isRecommendationsActive(year);
 
     const li = document.createElement('li');
     if (isMobile) {
@@ -631,6 +633,8 @@ export function createListNav(deps = {}) {
 
     // Click handler for selecting recommendations
     button.onclick = () => {
+      if (isRecommendationsActive(year)) return;
+
       if (typeof selectRecommendations === 'function') {
         selectRecommendations(year);
       }

--- a/src/js/modules/recommendations.js
+++ b/src/js/modules/recommendations.js
@@ -4,6 +4,16 @@ import {
   formatInUserListsTooltip as formatInUserListsTooltipBase,
   formatInUserListsAriaLabel,
 } from './recommendations-list-tooltips.js';
+import {
+  renderDesktopAlbumCell,
+  renderDesktopArtistCell,
+  renderDesktopCoverCell,
+  renderDesktopGenreCell,
+  renderMobileArtistRow,
+  renderMobileCoverSection,
+  renderMobileGenreRow,
+  renderMobileTitleRow,
+} from './album-display/render-parts.js';
 
 /**
  * Recommendations Module
@@ -101,6 +111,61 @@ export function createRecommendations(deps = {}) {
     const escapedName = escapeHtml(safeName);
 
     return `<span class="font-semibold text-gray-200">${escapedName}:</span><br>${escapedReasoning}`;
+  }
+
+  function formatRecommendationDate(value, options) {
+    if (!value) return '';
+    return new Date(value).toLocaleDateString('en-US', options);
+  }
+
+  function getRecommendationAlbumData(rec) {
+    const coverUrl = rec.album_id
+      ? `/api/albums/${encodeURIComponent(rec.album_id)}/cover`
+      : '';
+
+    return {
+      albumId: rec.album_id || '',
+      albumName: rec.album || 'Unknown Album',
+      artist: rec.artist || 'Unknown Artist',
+      releaseDate: formatRecommendationDate(rec.release_date, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }),
+      genre1: rec.genre_1 || '',
+      genre1Display: rec.genre_1 || 'No genre',
+      genre1Class: rec.genre_1 ? 'text-gray-400' : 'text-gray-600 italic',
+      genre2: rec.genre_2 || '',
+      genre2Display: rec.genre_2 || 'No genre',
+      genre2Class: rec.genre_2 ? 'text-gray-400' : 'text-gray-600 italic',
+      coverThumbUrl: coverUrl,
+      coverImageUrl: coverUrl,
+      availability: [],
+    };
+  }
+
+  function getInUserListNames(rec) {
+    return Array.isArray(rec.in_user_list_names)
+      ? rec.in_user_list_names.filter(
+          (name) => typeof name === 'string' && name.trim().length > 0
+        )
+      : [];
+  }
+
+  function renderInUserListsBadge(inUserListNames, { mobile = false } = {}) {
+    if (inUserListNames.length === 0) return '';
+
+    const className = mobile
+      ? 'in-user-lists-badge-mobile'
+      : 'in-user-lists-badge';
+    const ariaLabel = formatInUserListsAriaLabel(inUserListNames);
+
+    return `<div class="${className}"
+      aria-label="${escapeHtmlAttr(ariaLabel)}"
+      role="button"
+      tabindex="0">
+      <i class="fas fa-list"></i>
+    </div>`;
   }
 
   function clearReasoningTooltipTimeouts() {
@@ -547,72 +612,67 @@ export function createRecommendations(deps = {}) {
     card.dataset.albumId = rec.album_id;
     card.dataset.recIndex = index;
 
-    const date = new Date(rec.created_at);
-    const formattedDate = date.toLocaleDateString('en-US', {
+    const albumData = getRecommendationAlbumData(rec);
+    const formattedDate = formatRecommendationDate(rec.created_at, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
     });
 
     const hasReasoning = rec.reasoning && rec.reasoning.trim().length > 0;
-    const inUserListNames = Array.isArray(rec.in_user_list_names)
-      ? rec.in_user_list_names.filter(
-          (name) => typeof name === 'string' && name.trim().length > 0
-        )
-      : [];
-    const inUserListsAriaLabel = formatInUserListsAriaLabel(inUserListNames);
-    const inUserListsBadgeHtml =
-      inUserListNames.length > 0
-        ? `<div class="in-user-lists-badge-mobile"
-                 aria-label="${escapeHtmlAttr(inUserListsAriaLabel)}"
-                 role="button"
-                 tabindex="0">
-             <i class="fas fa-list"></i>
-           </div>`
-        : '';
+    const inUserListsBadgeHtml = renderInUserListsBadge(
+      getInUserListNames(rec),
+      { mobile: true }
+    );
 
     card.innerHTML = `
       <div class="flex items-stretch h-full">
         
         <!-- COVER SECTION -->
-        <div class="shrink-0 w-[88px] flex flex-col items-center pt-2 pl-1">
-          <div class="mobile-album-cover relative w-20 h-20 flex items-center justify-center bg-gray-800 rounded-lg">
-            ${inUserListsBadgeHtml}
-            <img src="/api/albums/${encodeURIComponent(rec.album_id)}/cover" 
-                 alt="${escapeHtml(rec.album)}"
-                 class="album-cover-blur w-[75px] h-[75px] rounded-lg object-cover"
-                 loading="lazy" decoding="async"
-                 onerror="this.parentElement.innerHTML='<div class=\\'w-[75px] h-[75px] rounded-lg bg-gray-800 flex items-center justify-center\\'><i class=\\'fas fa-compact-disc text-xl text-gray-600\\'></i></div>'">
-          </div>
-          <div class="flex-1 flex items-center mt-1">
-            <span class="text-xs whitespace-nowrap text-gray-500">
-              ${formattedDate}
-            </span>
-          </div>
-        </div>
+        ${renderMobileCoverSection(albumData, index, {
+          coverClass:
+            'mobile-album-cover relative w-20 h-20 flex items-center justify-center bg-gray-800 rounded-lg',
+          coverExtraHtml: inUserListsBadgeHtml,
+          dateClass: 'text-xs whitespace-nowrap text-gray-500',
+          dateText: formattedDate,
+          dateWrapperClass: 'flex-1 flex items-center mt-1',
+          imageClassName:
+            'album-cover-blur w-[75px] h-[75px] rounded-lg object-cover',
+          includeAvailability: false,
+          loadMode: 'lazy',
+          placeholderHtml:
+            '<div class="w-[75px] h-[75px] rounded-lg bg-gray-800 flex items-center justify-center"><i class="fas fa-compact-disc text-xl text-gray-600"></i></div>',
+          wrapperClass:
+            'shrink-0 w-[88px] flex flex-col items-center pt-2 pl-1',
+        })}
         
         <!-- INFO SECTION -->
         <div class="flex-1 min-w-0 py-1 pl-2 pr-1 flex flex-col justify-between h-[122px]">
-          <div class="flex items-center min-w-0">
-            <h3 class="font-semibold text-gray-200 text-sm leading-tight flex items-center min-w-0 w-full">
-              <i class="fas fa-compact-disc fa-xs mr-2 shrink-0"></i>
-              <span class="truncate flex-1 min-w-0" title="${escapeHtml(rec.album)}">${escapeHtml(rec.album)}</span>
-            </h3>
-          </div>
-          <div class="flex items-center min-w-0">
-            <p class="text-[13px] text-gray-500 flex items-center min-w-0 w-full">
-              <i class="fas fa-user fa-xs mr-2 shrink-0"></i>
-              <span data-field="artist-mobile-text" class="truncate flex-1 min-w-0" title="${escapeHtml(rec.artist)}">${escapeHtml(rec.artist)}</span>
-            </p>
-          </div>
-          <div class="flex items-center min-w-0">
-            <p class="text-[13px] text-gray-400 flex items-center min-w-0 w-full">
-              <i class="fas fa-tag fa-xs mr-2 shrink-0"></i>
-              <span class="truncate flex-1 min-w-0" title="${escapeHtml(rec.genre_1 && rec.genre_2 ? `${rec.genre_1}, ${rec.genre_2}` : rec.genre_1 || rec.genre_2 || 'No genre')}">
-                ${rec.genre_1 ? escapeHtml(rec.genre_1) : ''}${rec.genre_1 && rec.genre_2 ? ', ' : ''}${rec.genre_2 ? escapeHtml(rec.genre_2) : ''}${!rec.genre_1 && !rec.genre_2 ? '<span class="text-gray-600 italic">No genre</span>' : ''}
-              </span>
-            </p>
-          </div>
+          ${renderMobileTitleRow(albumData, {
+            iconClass: 'fas fa-compact-disc fa-xs mr-2 shrink-0',
+            titleClass:
+              'font-semibold text-gray-200 text-sm leading-tight flex items-center min-w-0 w-full',
+            titleSpanClass: 'truncate flex-1 min-w-0',
+            titleStyle: '',
+            wrapperClass: 'flex items-center min-w-0',
+          })}
+          ${renderMobileArtistRow(albumData, {
+            iconClass: 'fas fa-user fa-xs mr-2 shrink-0',
+            spanClass: 'truncate flex-1 min-w-0',
+            textClass:
+              'text-[13px] text-gray-500 flex items-center min-w-0 w-full',
+            wrapperClass: 'flex items-center min-w-0',
+          })}
+          ${renderMobileGenreRow(albumData, {
+            emptyHtml: '<span class="text-gray-600 italic">No genre</span>',
+            fallback: 'No genre',
+            iconClass: 'fas fa-tag fa-xs mr-2 shrink-0',
+            separator: ', ',
+            textClass:
+              'text-[13px] text-gray-400 flex items-center min-w-0 w-full',
+            valueSpanClass: 'truncate flex-1 min-w-0',
+            wrapperClass: 'flex items-center min-w-0',
+          })}
           <div class="flex items-center min-w-0">
             <span class="text-[13px] text-blue-400 flex items-center min-w-0 w-full">
               <i class="fas fa-thumbs-up fa-xs mr-2 shrink-0"></i>
@@ -1122,87 +1182,62 @@ export function createRecommendations(deps = {}) {
         `;
         rowsContainer.appendChild(emptyDiv);
       } else {
-        recommendations.forEach((rec) => {
+        recommendations.forEach((rec, index) => {
           const row = document.createElement('div');
           row.className =
             'album-row recommendations-grid gap-4 py-2 cursor-pointer';
           row.dataset.albumId = rec.album_id;
 
-          const date = new Date(rec.created_at);
-          const formattedDate = date.toLocaleDateString('en-US', {
+          const albumData = getRecommendationAlbumData(rec);
+          const formattedDate = formatRecommendationDate(rec.created_at, {
             year: 'numeric',
             month: 'short',
             day: 'numeric',
           });
 
-          // Split genres into separate display values
-          const genre1Display = rec.genre_1
-            ? escapeHtml(rec.genre_1)
-            : '<span class="text-gray-600 italic">No genre</span>';
-          const genre2Display = rec.genre_2
-            ? escapeHtml(rec.genre_2)
-            : '<span class="text-gray-600 italic">No genre</span>';
-          const genre1Title = rec.genre_1 || 'No genre';
-          const genre2Title = rec.genre_2 || 'No genre';
-
-          // Format release date (matches regular list formatting)
-          const releaseDate = rec.release_date
-            ? new Date(rec.release_date).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-              })
-            : '';
-          const inUserListNames = Array.isArray(rec.in_user_list_names)
-            ? rec.in_user_list_names.filter(
-                (name) => typeof name === 'string' && name.trim().length > 0
-              )
-            : [];
-          const inUserListsAriaLabel =
-            formatInUserListsAriaLabel(inUserListNames);
-          const inUserListsBadgeHtml =
-            inUserListNames.length > 0
-              ? `<div class="in-user-lists-badge"
-                   aria-label="${escapeHtmlAttr(inUserListsAriaLabel)}"
-                   role="button"
-                   tabindex="0">
-                 <i class="fas fa-list"></i>
-               </div>`
-              : '';
+          const inUserListNames = getInUserListNames(rec);
+          const inUserListsBadgeHtml = renderInUserListsBadge(inUserListNames);
 
           row.innerHTML = `
-            <div class="cover-cell flex items-center justify-center">
-              <div class="album-cover-container">
-                <img src="/api/albums/${encodeURIComponent(rec.album_id)}/cover" 
-                     alt="${escapeHtml(rec.album)}" 
-                     class="album-cover rounded-sm shadow-lg"
-                     loading="lazy"
-                     decoding="async"
-                     onerror="this.onerror=null; this.parentElement.innerHTML='<div class=\\'album-cover-placeholder rounded-sm bg-gray-800 shadow-lg\\'><svg width=\\'24\\' height=\\'24\\' viewBox=\\'0 0 24 24\\' fill=\\'none\\' stroke=\\'currentColor\\' stroke-width=\\'2\\' class=\\'text-gray-600\\'><rect x=\\'3\\' y=\\'3\\' width=\\'18\\' height=\\'18\\' rx=\\'2\\' ry=\\'2\\'></rect><circle cx=\\'8.5\\' cy=\\'8.5\\' r=\\'1.5\\'></circle><polyline points=\\'21 15 16 10 5 21\\'></polyline></svg></div>'">
-                ${inUserListsBadgeHtml}
-              </div>
-            </div>
-            <div class="album-cell flex flex-col justify-center min-w-0">
-              <div class="flex items-center gap-2">
-                <span class="album-name font-semibold text-gray-200 truncate" title="${escapeHtml(rec.album)}">${escapeHtml(rec.album)}</span>
-              </div>
-              ${releaseDate ? `<div class="text-xs mt-0.5 release-date-display text-gray-400">${releaseDate}</div>` : ''}
-            </div>
-            <div class="artist-cell flex items-center min-w-0">
-              <span class="album-cell-text text-gray-300 truncate" title="${escapeHtml(rec.artist)}">${escapeHtml(rec.artist)}</span>
-            </div>
-            <div class="genre-1-cell flex items-center min-w-0">
-              <span class="album-cell-text text-gray-400 truncate" title="${escapeHtml(genre1Title)}">${genre1Display}</span>
-            </div>
-            <div class="genre-2-cell flex items-center min-w-0">
-              <span class="album-cell-text text-gray-400 truncate" title="${escapeHtml(genre2Title)}">${genre2Display}</span>
-            </div>
+            ${renderDesktopCoverCell(albumData, index, {
+              badgesHtml: inUserListsBadgeHtml,
+              cellClass: 'cover-cell flex items-center justify-center',
+              loadMode: 'lazy',
+            })}
+            ${renderDesktopAlbumCell(albumData, {
+              cellClass: 'album-cell flex flex-col justify-center min-w-0',
+              includeAvailability: false,
+              includePlaycount: false,
+              includeTitle: true,
+            })}
+            ${renderDesktopArtistCell(albumData, {
+              cellClass: 'artist-cell flex items-center min-w-0',
+              includeTitle: true,
+              interactive: false,
+              textClass: 'text-gray-300',
+            })}
+            ${renderDesktopGenreCell(albumData, 1, {
+              cellClass: 'genre-1-cell flex items-center min-w-0',
+              emptyTextClass: 'text-gray-600 italic',
+              fallback: 'No genre',
+              includeTitle: true,
+              interactive: false,
+              textClass: 'text-gray-400',
+            })}
+            ${renderDesktopGenreCell(albumData, 2, {
+              cellClass: 'genre-2-cell flex items-center min-w-0',
+              emptyTextClass: 'text-gray-600 italic',
+              fallback: 'No genre',
+              includeTitle: true,
+              interactive: false,
+              textClass: 'text-gray-400',
+            })}
             <div class="recommended-by-cell flex items-center min-w-0">
               <span class="album-cell-text text-blue-400 truncate flex-1 min-w-0" title="${escapeHtml(rec.recommended_by)}">${escapeHtml(rec.recommended_by)}</span>
               <span class="ml-1 shrink-0">
                 <button class="view-reasoning-btn text-gray-500 hover:text-blue-400 p-1 transition-colors shrink-0" 
                         aria-label="View reasoning"
-                        data-rec-index="${recommendations.indexOf(rec)}">
+                        data-rec-index="${index}">
                   <i class="fas fa-comment-alt text-xs"></i>
                 </button>
               </span>

--- a/test/album-render-parts.test.js
+++ b/test/album-render-parts.test.js
@@ -1,0 +1,110 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+describe('album render parts', () => {
+  it('renders shared desktop album cells for recommendation data', async () => {
+    const {
+      renderDesktopAlbumCell,
+      renderDesktopArtistCell,
+      renderDesktopCoverCell,
+      renderDesktopGenreCell,
+    } = await import('../src/js/modules/album-display/render-parts.js');
+
+    const album = {
+      albumName: 'Shared Album',
+      artist: 'Shared Artist',
+      releaseDate: '07/05/2026',
+      genre1: 'Jazz',
+      genre1Display: 'Jazz',
+      genre1Class: 'text-gray-400',
+      genre2: '',
+      genre2Display: 'No genre',
+      genre2Class: 'text-gray-600 italic',
+      coverThumbUrl: '/api/albums/abc/cover',
+      coverImageUrl: '/api/albums/abc/cover',
+      availability: [],
+    };
+
+    const html = [
+      renderDesktopCoverCell(album, 0, {
+        badgesHtml: '<div class="in-user-lists-badge"></div>',
+        loadMode: 'lazy',
+      }),
+      renderDesktopAlbumCell(album, {
+        includeAvailability: false,
+        includePlaycount: false,
+        includeTitle: true,
+      }),
+      renderDesktopArtistCell(album, {
+        includeTitle: true,
+        interactive: false,
+      }),
+      renderDesktopGenreCell(album, 1, { includeTitle: true }),
+      renderDesktopGenreCell(album, 2, {
+        emptyTextClass: 'text-gray-600 italic',
+        fallback: 'No genre',
+        includeTitle: true,
+      }),
+    ].join('');
+
+    assert.match(html, /loading="lazy"/);
+    assert.match(
+      html,
+      /onerror="this.onerror=null; this.parentElement.innerHTML=&quot;/
+    );
+    assert.match(html, /in-user-lists-badge/);
+    assert.match(html, /Shared Album/);
+    assert.match(html, /title="Shared Artist"/);
+    assert.match(html, /Jazz/);
+    assert.match(html, /No genre/);
+  });
+
+  it('renders shared mobile card sections with optional recommendation wrappers', async () => {
+    const {
+      renderMobileArtistRow,
+      renderMobileCoverSection,
+      renderMobileGenreRow,
+      renderMobileTitleRow,
+    } = await import('../src/js/modules/album-display/render-parts.js');
+
+    const album = {
+      albumName: 'Mobile Album',
+      artist: 'Mobile Artist',
+      releaseDate: 'Jul 5, 2026',
+      genre1: '',
+      genre2: '',
+      coverThumbUrl: '/api/albums/mobile/cover',
+      coverImageUrl: '/api/albums/mobile/cover',
+      availability: [],
+    };
+
+    const html = [
+      renderMobileCoverSection(album, 0, {
+        coverExtraHtml: '<div class="in-user-lists-badge-mobile"></div>',
+        dateText: 'Jul 5, 2026',
+        dateWrapperClass: 'flex-1 flex items-center mt-1',
+        includeAvailability: false,
+        loadMode: 'lazy',
+      }),
+      renderMobileTitleRow(album, {
+        titleSpanClass: 'truncate flex-1 min-w-0',
+        titleStyle: '',
+      }),
+      renderMobileArtistRow(album, {
+        spanClass: 'truncate flex-1 min-w-0',
+      }),
+      renderMobileGenreRow(album, {
+        emptyHtml: '<span class="text-gray-600 italic">No genre</span>',
+        fallback: 'No genre',
+      }),
+    ].join('');
+
+    assert.match(html, /in-user-lists-badge-mobile/);
+    assert.match(html, /loading="lazy"/);
+    assert.match(html, /Jul 5, 2026/);
+    assert.match(html, /data-field="album-mobile-title"/);
+    assert.doesNotMatch(html, /font-size: 13px; font-weight: 700/);
+    assert.match(html, /Mobile Artist/);
+    assert.match(html, /No genre/);
+  });
+});

--- a/test/list-nav.test.js
+++ b/test/list-nav.test.js
@@ -43,12 +43,21 @@ function createFakeListItem() {
       this._innerHTML = value;
       const listId = value.match(/data-list-id="([^"]+)"/)?.[1];
       const menuListId = value.match(/data-list-menu-btn="([^"]+)"/)?.[1];
+      const recommendationsYear = value.match(
+        /data-recommendations-year="([^"]+)"/
+      )?.[1];
 
       if (listId) {
         children.set('[data-list-id]', createFakeButton({ listId }));
       }
       if (menuListId) {
         children.set('[data-list-menu-btn]', createFakeButton({ menuListId }));
+      }
+      if (recommendationsYear) {
+        children.set(
+          '[data-recommendations-year]',
+          createFakeButton({ recommendationsYear })
+        );
       }
     },
     get innerHTML() {
@@ -82,6 +91,7 @@ async function withFakeDocument(callback) {
 function createSidebarSelectionDeps(overrides = {}) {
   const calls = {
     selectedLists: [],
+    selectedRecommendations: [],
     mobileToggles: 0,
   };
 
@@ -92,6 +102,7 @@ function createSidebarSelectionDeps(overrides = {}) {
       getCurrentList: () => 'list-1',
       getCurrentRecommendationsYear: () => null,
       selectList: (listId) => calls.selectedLists.push(listId),
+      selectRecommendations: (year) => calls.selectedRecommendations.push(year),
       toggleMobileLists: () => {
         calls.mobileToggles += 1;
       },
@@ -406,6 +417,55 @@ describe('List Navigation Module - Unit Tests', () => {
       });
 
       assert.deepStrictEqual(calls.selectedLists, ['list-1']);
+      assert.strictEqual(calls.mobileToggles, 1);
+    });
+  });
+
+  describe('Sidebar recommendations selection behavior', () => {
+    it('ignores desktop clicks on the active recommendations year', async () => {
+      const { createListNav } = await import('../src/js/modules/list-nav.js');
+      const { deps, calls } = createSidebarSelectionDeps({
+        getCurrentRecommendationsYear: () => 2024,
+      });
+      const listNav = createListNav(deps);
+
+      await withFakeDocument(() => {
+        const item = listNav.createRecommendationsButton(2024, false);
+        item.querySelector('[data-recommendations-year]').onclick();
+      });
+
+      assert.deepStrictEqual(calls.selectedRecommendations, []);
+    });
+
+    it('keeps the mobile drawer open when tapping the active recommendations year', async () => {
+      const { createListNav } = await import('../src/js/modules/list-nav.js');
+      const { deps, calls } = createSidebarSelectionDeps({
+        getCurrentRecommendationsYear: () => 2024,
+      });
+      const listNav = createListNav(deps);
+
+      await withFakeDocument(() => {
+        const item = listNav.createRecommendationsButton(2024, true);
+        item.querySelector('[data-recommendations-year]').onclick();
+      });
+
+      assert.deepStrictEqual(calls.selectedRecommendations, []);
+      assert.strictEqual(calls.mobileToggles, 0);
+    });
+
+    it('still selects and closes mobile drawer for inactive recommendations years', async () => {
+      const { createListNav } = await import('../src/js/modules/list-nav.js');
+      const { deps, calls } = createSidebarSelectionDeps({
+        getCurrentRecommendationsYear: () => 2023,
+      });
+      const listNav = createListNav(deps);
+
+      await withFakeDocument(() => {
+        const item = listNav.createRecommendationsButton(2024, true);
+        item.querySelector('[data-recommendations-year]').onclick();
+      });
+
+      assert.deepStrictEqual(calls.selectedRecommendations, [2024]);
       assert.strictEqual(calls.mobileToggles, 1);
     });
   });


### PR DESCRIPTION
## Summary
- reuse the sidebar active-selection helper for recommendation year buttons
- skip recommendation reloads when the clicked recommendation year is already active
- keep the mobile drawer open for active recommendation taps
- add focused regression coverage for recommendation sidebar selection

## Verification
- node --test test/list-nav.test.js
- npm run ci:local