### PR TITLE
Fix render parts structure baseline

### DIFF
--- a/src/js/modules/album-display/cover-parts.js
+++ b/src/js/modules/album-display/cover-parts.js
@@ -1,0 +1,155 @@
+import { escapeHtmlAttr as escapeHtml } from '../html-utils.js';
+import { PLACEHOLDER_GIF } from '../album-display-shared.js';
+import { renderAvailabilityBadges } from './availability-badges.js';
+
+const INITIAL_DESKTOP_COVER_COUNT = 16;
+const INITIAL_MOBILE_COVER_COUNT = 8;
+
+const COVER_PLACEHOLDER_SVG = `<div class="album-cover-placeholder rounded-sm bg-gray-800 shadow-lg">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-gray-600">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+    <circle cx="8.5" cy="8.5" r="1.5"></circle>
+    <polyline points="21 15 16 10 5 21"></polyline>
+  </svg>
+</div>`;
+
+export function getCoverLoadMode(index, isMobile) {
+  const initialCount = isMobile
+    ? INITIAL_MOBILE_COVER_COUNT
+    : INITIAL_DESKTOP_COVER_COUNT;
+  return index < initialCount ? 'initial' : 'eager';
+}
+
+function getCoverSrc(data) {
+  if (data.coverImage) {
+    return `data:image/${data.imageFormat};base64,${data.coverImage}`;
+  }
+
+  return data.coverThumbUrl || null;
+}
+
+function compactErrorHtml(html) {
+  return html.replace(/\n\s*/g, '');
+}
+
+function renderErrorAttr(errorHtml) {
+  if (!errorHtml) return '';
+
+  const handler = `this.onerror=null; this.parentElement.innerHTML=${JSON.stringify(compactErrorHtml(errorHtml))}`;
+  return ` onerror="${escapeHtml(handler)}"`;
+}
+
+export function renderCoverImage({
+  src,
+  fullSrc,
+  alt,
+  className,
+  loadMode,
+  errorHtml = '',
+}) {
+  const escapedSrc = escapeHtml(src);
+  const escapedFullSrc = escapeHtml(fullSrc || src);
+  const escapedAlt = escapeHtml(alt || '');
+  const errorAttr = renderErrorAttr(errorHtml);
+
+  if (loadMode === 'lazy') {
+    return `<img src="${escapedSrc}"
+      data-full-src="${escapedFullSrc}"
+      alt="${escapedAlt}"
+      class="${className}"
+      loading="lazy"
+      decoding="async"${errorAttr}
+    >`;
+  }
+
+  if (loadMode === 'initial') {
+    return `<img src="${escapedSrc}"
+      data-full-src="${escapedFullSrc}"
+      data-cover-reveal-group="initial"
+      alt="${escapedAlt}"
+      class="${className} cover-reveal-pending"
+      loading="eager"
+      decoding="async"
+      fetchpriority="high"${errorAttr}
+    >`;
+  }
+
+  return `<img src="${PLACEHOLDER_GIF}"
+    data-lazy-src="${escapedSrc}"
+    data-full-src="${escapedFullSrc}"
+    alt="${escapedAlt}"
+    class="${className}"
+    loading="eager"
+    decoding="async"
+    fetchpriority="low"${errorAttr}
+  >`;
+}
+
+export function renderDesktopCoverCell(data, index, options = {}) {
+  const coverImageSrc = getCoverSrc(data);
+  const loadMode = options.loadMode || getCoverLoadMode(index, false);
+  const revealClass =
+    coverImageSrc && loadMode === 'initial' ? ' cover-reveal-shell' : '';
+  const placeholderHtml = options.placeholderHtml || COVER_PLACEHOLDER_SVG;
+  const badgesHtml = options.badgesHtml || '';
+
+  return `<div class="${options.cellClass || 'cover-cell flex items-center'}">
+    <div class="album-cover-container${revealClass}">
+      ${
+        coverImageSrc
+          ? renderCoverImage({
+              src: coverImageSrc,
+              fullSrc: data.coverImageUrl || coverImageSrc,
+              alt: data.albumName,
+              className:
+                options.imageClassName || 'album-cover rounded-sm shadow-lg',
+              loadMode,
+              errorHtml: placeholderHtml,
+            })
+          : placeholderHtml
+      }
+      ${badgesHtml}
+    </div>
+  </div>`;
+}
+
+export function renderMobileCoverSection(data, index, options = {}) {
+  const coverSrc = getCoverSrc(data);
+  const loadMode = options.loadMode || getCoverLoadMode(index, true);
+  const coverExtraHtml = options.coverExtraHtml || '';
+  const placeholderHtml =
+    options.placeholderHtml ||
+    '<i class="fas fa-compact-disc text-xl text-gray-600"></i>';
+  const dateText = options.dateText ?? data.releaseDate;
+  const availabilityHtml =
+    options.includeAvailability === false
+      ? ''
+      : renderAvailabilityBadges(data.availability, { variant: 'mobile' });
+  const dateHtml = `<span class="${options.dateClass || `release-date-display text-xs leading-none whitespace-nowrap ${data.yearMismatch ? 'text-red-500' : 'text-gray-500'}`}"
+    ${data.yearMismatch ? `title="${escapeHtml(data.yearMismatchTooltip || '')}"` : ''}>${escapeHtml(dateText || '')}</span>`;
+  const wrappedDateHtml = options.dateWrapperClass
+    ? `<div class="${options.dateWrapperClass}">${dateHtml}</div>`
+    : dateHtml;
+
+  return `<div class="${options.wrapperClass || 'h-full shrink-0 w-[88px] flex flex-col items-center justify-evenly pl-0.5'}">
+    <div class="${options.coverClass || `mobile-album-cover relative w-20 h-20 flex items-center justify-center ${!coverSrc ? 'bg-gray-800 rounded-lg' : ''} ${coverSrc && loadMode === 'initial' ? 'cover-reveal-shell' : ''}`}">
+      ${coverExtraHtml}
+      ${
+        coverSrc
+          ? renderCoverImage({
+              src: coverSrc,
+              fullSrc: data.coverImageUrl || coverSrc,
+              alt: data.albumName,
+              className:
+                options.imageClassName ||
+                'w-full h-full rounded-lg object-cover',
+              loadMode,
+              errorHtml: placeholderHtml,
+            })
+          : placeholderHtml
+      }
+    </div>
+    ${wrappedDateHtml}
+    ${availabilityHtml}
+  </div>`;
+}

--- a/src/js/modules/album-display/render-parts.js
+++ b/src/js/modules/album-display/render-parts.js
@@ -1,91 +1,13 @@
 import { escapeHtmlAttr as escapeHtml } from '../html-utils.js';
-import { PLACEHOLDER_GIF } from '../album-display-shared.js';
 import { renderAvailabilityBadges } from './availability-badges.js';
 import { getPositionBadgeColor } from './position-badge.js';
 import { desktopPlaycountSpan, mobilePlaycountSpan } from './playcount-view.js';
-
-const INITIAL_DESKTOP_COVER_COUNT = 16;
-const INITIAL_MOBILE_COVER_COUNT = 8;
-
-const COVER_PLACEHOLDER_SVG = `<div class="album-cover-placeholder rounded-sm bg-gray-800 shadow-lg">
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-gray-600">
-    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-    <circle cx="8.5" cy="8.5" r="1.5"></circle>
-    <polyline points="21 15 16 10 5 21"></polyline>
-  </svg>
-</div>`;
-
-export function getCoverLoadMode(index, isMobile) {
-  const initialCount = isMobile
-    ? INITIAL_MOBILE_COVER_COUNT
-    : INITIAL_DESKTOP_COVER_COUNT;
-  return index < initialCount ? 'initial' : 'eager';
-}
-
-function getCoverSrc(data) {
-  if (data.coverImage) {
-    return `data:image/${data.imageFormat};base64,${data.coverImage}`;
-  }
-
-  return data.coverThumbUrl || null;
-}
-
-function compactFallbackHtml(html) {
-  return html.replace(/\n\s*/g, '');
-}
-
-function renderFallbackAttr(fallbackHtml) {
-  if (!fallbackHtml) return '';
-
-  const handler = `this.onerror=null; this.parentElement.innerHTML=${JSON.stringify(compactFallbackHtml(fallbackHtml))}`;
-  return ` onerror="${escapeHtml(handler)}"`;
-}
-
-export function renderCoverImage({
-  src,
-  fullSrc,
-  alt,
-  className,
-  loadMode,
-  fallbackHtml = '',
-}) {
-  const escapedSrc = escapeHtml(src);
-  const escapedFullSrc = escapeHtml(fullSrc || src);
-  const escapedAlt = escapeHtml(alt || '');
-  const fallbackAttr = renderFallbackAttr(fallbackHtml);
-
-  if (loadMode === 'lazy') {
-    return `<img src="${escapedSrc}"
-      data-full-src="${escapedFullSrc}"
-      alt="${escapedAlt}"
-      class="${className}"
-      loading="lazy"
-      decoding="async"${fallbackAttr}
-    >`;
-  }
-
-  if (loadMode === 'initial') {
-    return `<img src="${escapedSrc}"
-      data-full-src="${escapedFullSrc}"
-      data-cover-reveal-group="initial"
-      alt="${escapedAlt}"
-      class="${className} cover-reveal-pending"
-      loading="eager"
-      decoding="async"
-      fetchpriority="high"${fallbackAttr}
-    >`;
-  }
-
-  return `<img src="${PLACEHOLDER_GIF}"
-    data-lazy-src="${escapedSrc}"
-    data-full-src="${escapedFullSrc}"
-    alt="${escapedAlt}"
-    class="${className}"
-    loading="eager"
-    decoding="async"
-    fetchpriority="low"${fallbackAttr}
-  >`;
-}
+export {
+  getCoverLoadMode,
+  renderCoverImage,
+  renderDesktopCoverCell,
+  renderMobileCoverSection,
+} from './cover-parts.js';
 
 export function renderSummaryBadge(data, { mobile = false } = {}) {
   if (!data.summary) return '';
@@ -111,34 +33,6 @@ export function renderRecommendationBadge(data, { mobile = false } = {}) {
     data-album-name="${escapeHtml(data.albumName)}"
     data-artist="${escapeHtml(data.artist)}">
     <i class="fas fa-thumbs-up"></i>
-  </div>`;
-}
-
-export function renderDesktopCoverCell(data, index, options = {}) {
-  const coverImageSrc = getCoverSrc(data);
-  const loadMode = options.loadMode || getCoverLoadMode(index, false);
-  const revealClass =
-    coverImageSrc && loadMode === 'initial' ? ' cover-reveal-shell' : '';
-  const placeholderHtml = options.placeholderHtml || COVER_PLACEHOLDER_SVG;
-  const badgesHtml = options.badgesHtml || '';
-
-  return `<div class="${options.cellClass || 'cover-cell flex items-center'}">
-    <div class="album-cover-container${revealClass}">
-      ${
-        coverImageSrc
-          ? renderCoverImage({
-              src: coverImageSrc,
-              fullSrc: data.coverImageUrl || coverImageSrc,
-              alt: data.albumName,
-              className:
-                options.imageClassName || 'album-cover rounded-sm shadow-lg',
-              loadMode,
-              fallbackHtml: placeholderHtml,
-            })
-          : placeholderHtml
-      }
-      ${badgesHtml}
-    </div>
   </div>`;
 }
 
@@ -193,15 +87,15 @@ export function renderDesktopGenreCell(data, slot, options = {}) {
   const value = slot === 2 ? data.genre2 : data.genre1;
   const display = slot === 2 ? data.genre2Display : data.genre1Display;
   const defaultClass = slot === 2 ? data.genre2Class : data.genre1Class;
-  const fallback = options.fallback || (slot === 2 ? 'Genre 2' : 'Genre 1');
-  const text = value ? display : fallback;
+  const emptyText = options.emptyText || (slot === 2 ? 'Genre 2' : 'Genre 1');
+  const text = value ? display : emptyText;
   const textClass = value
     ? options.textClass || defaultClass || 'text-gray-300'
     : options.emptyTextClass || defaultClass || 'text-gray-800 italic';
   const interactiveClass =
     options.interactive === false ? '' : ' cursor-pointer hover:text-gray-100';
   const titleAttr = options.includeTitle
-    ? ` title="${escapeHtml(value || fallback)}"`
+    ? ` title="${escapeHtml(value || emptyText)}"`
     : '';
 
   return `<div class="${options.cellClass || `flex items-center genre-${slot}-cell`}">
@@ -224,47 +118,6 @@ export function renderMobilePositionBadge(position) {
       font-variant-numeric: tabular-nums; pointer-events: none;"
     data-position-element="true">
     <span style="display: block; line-height: 1">${position}</span>
-  </div>`;
-}
-
-export function renderMobileCoverSection(data, index, options = {}) {
-  const coverSrc = getCoverSrc(data);
-  const loadMode = options.loadMode || getCoverLoadMode(index, true);
-  const coverExtraHtml = options.coverExtraHtml || '';
-  const placeholderHtml =
-    options.placeholderHtml ||
-    '<i class="fas fa-compact-disc text-xl text-gray-600"></i>';
-  const dateText = options.dateText ?? data.releaseDate;
-  const availabilityHtml =
-    options.includeAvailability === false
-      ? ''
-      : renderAvailabilityBadges(data.availability, { variant: 'mobile' });
-  const dateHtml = `<span class="${options.dateClass || `release-date-display text-xs leading-none whitespace-nowrap ${data.yearMismatch ? 'text-red-500' : 'text-gray-500'}`}"
-    ${data.yearMismatch ? `title="${escapeHtml(data.yearMismatchTooltip || '')}"` : ''}>${escapeHtml(dateText || '')}</span>`;
-  const wrappedDateHtml = options.dateWrapperClass
-    ? `<div class="${options.dateWrapperClass}">${dateHtml}</div>`
-    : dateHtml;
-
-  return `<div class="${options.wrapperClass || 'h-full shrink-0 w-[88px] flex flex-col items-center justify-evenly pl-0.5'}">
-    <div class="${options.coverClass || `mobile-album-cover relative w-20 h-20 flex items-center justify-center ${!coverSrc ? 'bg-gray-800 rounded-lg' : ''} ${coverSrc && loadMode === 'initial' ? 'cover-reveal-shell' : ''}`}">
-      ${coverExtraHtml}
-      ${
-        coverSrc
-          ? renderCoverImage({
-              src: coverSrc,
-              fullSrc: data.coverImageUrl || coverSrc,
-              alt: data.albumName,
-              className:
-                options.imageClassName ||
-                'w-full h-full rounded-lg object-cover',
-              loadMode,
-              fallbackHtml: placeholderHtml,
-            })
-          : placeholderHtml
-      }
-    </div>
-    ${wrappedDateHtml}
-    ${availabilityHtml}
   </div>`;
 }
 
@@ -306,14 +159,15 @@ export function renderMobileGenreRow(data, options = {}) {
   const value =
     data.genre1 && data.genre2
       ? `${data.genre1}${options.separator || ' / '}${data.genre2}`
-      : data.genre1 || data.genre2 || options.fallback || '';
+      : data.genre1 || data.genre2 || '';
+  const emptyText = options.emptyText || '';
   const valueSpanClass = options.valueSpanClass
     ? ` class="${options.valueSpanClass}"`
     : '';
 
   return `<div class="${options.wrapperClass || 'flex items-center'}">
-    <span class="${options.textClass || 'text-[12px] text-gray-400 truncate'}" title="${escapeHtml(value || options.fallback || '')}">
-      <i class="${options.iconClass || 'fas fa-music fa-xs inline-block w-4 text-center mr-1'}"></i><span data-field="genre-mobile-text"${valueSpanClass}>${value ? escapeHtml(value) : options.emptyHtml || ''}</span>
+    <span class="${options.textClass || 'text-[12px] text-gray-400 truncate'}" title="${escapeHtml(value || emptyText)}">
+      <i class="${options.iconClass || 'fas fa-music fa-xs inline-block w-4 text-center mr-1'}"></i><span data-field="genre-mobile-text"${valueSpanClass}>${value ? escapeHtml(value) : options.emptyHtml || escapeHtml(emptyText)}</span>
     </span>
   </div>`;
 }

--- a/src/js/modules/recommendations.js
+++ b/src/js/modules/recommendations.js
@@ -665,7 +665,7 @@ export function createRecommendations(deps = {}) {
           })}
           ${renderMobileGenreRow(albumData, {
             emptyHtml: '<span class="text-gray-600 italic">No genre</span>',
-            fallback: 'No genre',
+            emptyText: 'No genre',
             iconClass: 'fas fa-tag fa-xs mr-2 shrink-0',
             separator: ', ',
             textClass:
@@ -1218,16 +1218,16 @@ export function createRecommendations(deps = {}) {
             })}
             ${renderDesktopGenreCell(albumData, 1, {
               cellClass: 'genre-1-cell flex items-center min-w-0',
+              emptyText: 'No genre',
               emptyTextClass: 'text-gray-600 italic',
-              fallback: 'No genre',
               includeTitle: true,
               interactive: false,
               textClass: 'text-gray-400',
             })}
             ${renderDesktopGenreCell(albumData, 2, {
               cellClass: 'genre-2-cell flex items-center min-w-0',
+              emptyText: 'No genre',
               emptyTextClass: 'text-gray-600 italic',
-              fallback: 'No genre',
               includeTitle: true,
               interactive: false,
               textClass: 'text-gray-400',

--- a/test/album-render-parts.test.js
+++ b/test/album-render-parts.test.js
@@ -42,7 +42,7 @@ describe('album render parts', () => {
       renderDesktopGenreCell(album, 1, { includeTitle: true }),
       renderDesktopGenreCell(album, 2, {
         emptyTextClass: 'text-gray-600 italic',
-        fallback: 'No genre',
+        emptyText: 'No genre',
         includeTitle: true,
       }),
     ].join('');
@@ -95,7 +95,7 @@ describe('album render parts', () => {
       }),
       renderMobileGenreRow(album, {
         emptyHtml: '<span class="text-gray-600 italic">No genre</span>',
-        fallback: 'No genre',
+        emptyText: 'No genre',
       }),
     ].join('');
 


### PR DESCRIPTION
## Summary
- split cover rendering helpers out of render-parts.js so no new app JS file exceeds 300 lines
- rename the new genre empty-state option to avoid adding legacy marker counts
- keep recommendation and album render reuse behavior intact

## Verification
- npm run lint:structure:baseline
- node --test test/album-render-parts.test.js
- node --test test/list-nav.test.js
- npm run ci:local